### PR TITLE
PROTON-697: part 1, server support and documentation changes for certificate stores/dbs

### DIFF
--- a/proton-c/include/proton/ssl.h
+++ b/proton-c/include/proton/ssl.h
@@ -121,17 +121,18 @@ PN_EXTERN void pn_ssl_domain_free( pn_ssl_domain_t *domain );
  * previous setting.
  *
  * @param[in] domain the ssl domain that will use this certificate.
- * @param[in] certificate_file path to file/database containing the identifying
+ * @param[in] certificate_file_or_db path to file/database containing the identifying
  * certificate.
- * @param[in] private_key_file path to file/database containing the private key used to
- * sign the certificate
- * @param[in] password the password used to sign the key, else NULL if key is not
- * protected.
+ * @param[in] private_key_file_or_certname path to file/database containing the
+ * certificate's private key or the name of the certificate in the database, or NULL if
+ * the certificate database contains a single certificate including its private key
+ * @param[in] password the password used to access the certificate key information, else
+ * NULL if key is not protected.
  * @return 0 on success
  */
 PN_EXTERN int pn_ssl_domain_set_credentials( pn_ssl_domain_t *domain,
-                                             const char *certificate_file,
-                                             const char *private_key_file,
+                                             const char *certificate_file_or_db,
+                                             const char *private_key_file_or_certname,
                                              const char *password);
 
 /** Configure the set of trusted CA certificates used by this domain to verify peers.


### PR DESCRIPTION
This patch provides server-side support, and PN_SSL_ANONYMOUS_PEER
connections.

The most important changes for review are the documentation changes to
ssl.h regarding certificates.  Windows first class citizens are
registry stores and pkcs#12 files, both which resemble NSS databases
and Java keystores.

Re-purposing the "private_key_file" parameter to alternatively denote a
certificate name in a database/store works in this case for Windows
and presumably for Java keystores and NSS databases.  Hopefully for
any other SSL/TLS implementations we may encounter too.

I am unable to find a convention for identifying Windows system (or
registry) certificate stores.  The command line option for the common
case is "-ss name_of_store_or_its_alias", and I have adopted "foo" or
"c:\path\to\foo" to mean a file based store and "ss:bar" to mean a
user system store named "bar" and "lmss:bar" for the less common Local
Machine system store designation.  I'm not sure of the best place to
document the platform specific naming conventions.

At the moment you may have any system store you like as long as it is
"ss:root".  That limitation should be lifted in a few days.
