### PR TITLE
PROTON-811: safely handle TransportException

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameParser.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameParser.java
@@ -484,6 +484,14 @@ class FrameParser implements TransportInput
     }
 
     @Override
+    public int position() {
+        if (_tail_closed) {
+            return Transport.END_OF_STREAM;
+        }
+        return (_inputBuffer == null) ? 0 : _inputBuffer.position();
+    }
+
+    @Override
     public ByteBuffer tail()
     {
         if (_tail_closed) {

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameWriter.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameWriter.java
@@ -101,7 +101,7 @@ class FrameWriter
             try
             {
                 _buffer.position(_frameStart + 8);
-                _encoder.writeObject(frameBody);
+                if (frameBody != null) _encoder.writeObject(frameBody);
                 break;
             }
             catch (BufferOverflowException e)

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/PlainTransportWrapper.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/PlainTransportWrapper.java
@@ -43,6 +43,12 @@ public class PlainTransportWrapper implements TransportWrapper
     }
 
     @Override
+    public int position()
+    {
+        return _inputProcessor.position();
+    }
+
+    @Override
     public ByteBuffer tail()
     {
         return _inputProcessor.tail();

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslImpl.java
@@ -562,6 +562,20 @@ public class SaslImpl implements Sasl, SaslFrameBody.SaslFrameBodyHandler<Void>,
         }
 
         @Override
+        public int position()
+        {
+            if (_tail_closed) return Transport.END_OF_STREAM;
+            if (isInputInSaslMode())
+            {
+                return _inputBuffer.position();
+            }
+            else
+            {
+                return _underlyingInput.position();
+            }
+        }
+
+        @Override
         public ByteBuffer tail()
         {
             if (!isInputInSaslMode())

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -1444,7 +1444,6 @@ public class TransportImpl extends EndpointImpl
             } else if (_localIdleDeadline <= now) {
                 _localIdleDeadline = now + _localIdleTimeout;
 
-                if (_connectionEndpoint != null)
                 if (_connectionEndpoint != null &&
                     _connectionEndpoint.getLocalState() != EndpointState.CLOSED) {
                     ErrorCondition condition =
@@ -1467,8 +1466,8 @@ public class TransportImpl extends EndpointImpl
                         _isCloseSent = true;
                         writeFrame(0, close, null, null);
                     }
+                    close_tail();
                 }
-                close_tail();
             }
             timeout = _localIdleDeadline;
         }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -1373,18 +1373,11 @@ public class TransportImpl extends EndpointImpl
     {
         _processingStarted = true;
 
-
         try {
             init();
-            int beforePosition = _inputProcessor.tail().position();
+            int beforePosition = _inputProcessor.position();
             _inputProcessor.process();
-            try {
-                _bytesInput += beforePosition - _inputProcessor.tail().position();
-            } catch(TransportException e) {
-                // This is because _inputProcessor.tail() can throw an exception if
-                // the tail has been closed.  It might be better to make process()
-                // return the number of bytes that have been processed.
-            }
+            _bytesInput += beforePosition - _inputProcessor.position();
         } catch (TransportException e) {
             _head_closed = true;
             throw e;

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportInput.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportInput.java
@@ -22,7 +22,6 @@ package org.apache.qpid.proton.engine.impl;
 
 import java.nio.ByteBuffer;
 
-import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
 
 
@@ -31,7 +30,9 @@ public interface TransportInput
 
     int capacity();
 
-    ByteBuffer tail();
+    int position();
+
+    ByteBuffer tail() throws TransportException;
 
     void process() throws TransportException;
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ssl/SimpleSslTransportWrapper.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ssl/SimpleSslTransportWrapper.java
@@ -21,9 +21,7 @@
 package org.apache.qpid.proton.engine.impl.ssl;
 
 
-import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newReadableBuffer;
 import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
-import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.pourAll;
 
 import java.nio.ByteBuffer;
 import java.util.logging.Level;
@@ -328,6 +326,13 @@ public class SimpleSslTransportWrapper implements SslTransportWrapper
     {
         if (_tail_closed) return Transport.END_OF_STREAM;
         return _inputBuffer.remaining();
+    }
+
+    @Override
+    public int position()
+    {
+        if (_tail_closed) return Transport.END_OF_STREAM;
+        return _inputBuffer.position();
     }
 
     @Override

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ssl/SslHandshakeSniffingTransportWrapper.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ssl/SslHandshakeSniffingTransportWrapper.java
@@ -61,6 +61,20 @@ public class SslHandshakeSniffingTransportWrapper implements SslTransportWrapper
     }
 
     @Override
+    public int position()
+    {
+        if (isDeterminationMade())
+        {
+            return _selectedTransportWrapper.position();
+        }
+        else
+        {
+            if (_tail_closed) { return Transport.END_OF_STREAM; }
+            return _determinationBuffer.position();
+        }
+    }
+
+    @Override
     public ByteBuffer tail()
     {
         if (isDeterminationMade())

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ssl/SslImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ssl/SslImpl.java
@@ -28,10 +28,10 @@ import org.apache.qpid.proton.engine.SslDomain;
 import org.apache.qpid.proton.engine.SslPeerDetails;
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
+import org.apache.qpid.proton.engine.impl.PlainTransportWrapper;
 import org.apache.qpid.proton.engine.impl.TransportInput;
 import org.apache.qpid.proton.engine.impl.TransportOutput;
 import org.apache.qpid.proton.engine.impl.TransportWrapper;
-import org.apache.qpid.proton.engine.impl.PlainTransportWrapper;
 
 public class SslImpl implements Ssl
 {
@@ -107,6 +107,17 @@ public class SslImpl implements Ssl
             initTransportWrapperOnFirstIO();
             if (_initException == null) {
                 return _transportWrapper.capacity();
+            } else {
+                return Transport.END_OF_STREAM;
+            }
+        }
+
+        @Override
+        public int position()
+        {
+            initTransportWrapperOnFirstIO();
+            if (_initException == null) {
+                return _transportWrapper.position();
             } else {
                 return Transport.END_OF_STREAM;
             }


### PR DESCRIPTION
Previously TransportException could be thrown in the TransportImpl
beforePosition initializer that was using tail() directly without a
separate catch to ignore it. It seems cleaner to add a position()
accessor to the TransportInput interface that handles closed streams
in the same way as capacity(), without throwing the RuntimeException