### PR TITLE
NO-JIRA: Measure size of encoded data.

### DIFF
--- a/proton-c/include/proton/codec.h
+++ b/proton-c/include/proton/codec.h
@@ -512,6 +512,21 @@ PN_EXTERN int pn_data_format(pn_data_t *data, char *bytes, size_t *size);
 PN_EXTERN ssize_t pn_data_encode(pn_data_t *data, char *bytes, size_t size);
 
 /**
+ * Writes the contents of a data object to the given buffer as an AMQP data
+ * stream. If the entire contents cannot be written, returns the number of bytes
+ * that would be needed to write it all.
+ *
+ * @param data the data object to encode
+ * @param bytes the buffer for encoded data (0 if you just want to calculate the size needed)
+ * @param size the size of the buffer (0 if you just want to calculate the size needed)
+ *
+ * @param size_t returns the size needed to encode all the data. If the returned
+ *     size <= size parameter then all the data was encoded successfully. If not,
+ *     a buffer of the returned size is required to encode it all.
+ */
+PN_EXTERN size_t pn_data_encode2(pn_data_t *data, char *bytes, size_t size);
+
+/**
  * Decodes a single value from the contents of the AMQP data stream
  * into the current data object. Note that if the pn_data_t object is
  * pointing to a current node, the decoded value will overwrite the

--- a/proton-c/src/codec/codec.c
+++ b/proton-c/src/codec/codec.c
@@ -1424,6 +1424,11 @@ ssize_t pn_data_encode(pn_data_t *data, char *bytes, size_t size)
   return pn_encoder_encode(data->encoder, data, bytes, size);
 }
 
+size_t pn_data_encode2(pn_data_t *data, char *bytes, size_t size)
+{
+  return pn_encoder_encode2(data->encoder, data, bytes, size);
+}
+
 ssize_t pn_data_decode(pn_data_t *data, const char *bytes, size_t size)
 {
   return pn_decoder_decode(data->decoder, bytes, size, data);

--- a/proton-c/src/codec/encoder.c
+++ b/proton-c/src/codec/encoder.c
@@ -30,6 +30,7 @@
 #include "data.h"
 
 struct pn_encoder_t {
+  bool counting;   /* Count the total size of the data even if there is not enough buffer */
   char *output;
   size_t size;
   char *position;
@@ -39,6 +40,7 @@ struct pn_encoder_t {
 static void pn_encoder_initialize(void *obj)
 {
   pn_encoder_t *encoder = (pn_encoder_t *) obj;
+  encoder->counting = false;
   encoder->output = NULL;
   encoder->size = 0;
   encoder->position = NULL;
@@ -155,6 +157,14 @@ static size_t pn_encoder_remaining(pn_encoder_t *encoder)
   return encoder->output + encoder->size - encoder->position;
 }
 
+static int overflow(pn_encoder_t *encoder, int size) {
+    if (encoder->counting) {
+        encoder->position += size; /* Count even if overflowing */
+        return 0;
+    }
+    return PN_OVERFLOW;
+}
+
 static inline int pn_encoder_writef8(pn_encoder_t *encoder, uint8_t value)
 {
   if (pn_encoder_remaining(encoder)) {
@@ -162,14 +172,14 @@ static inline int pn_encoder_writef8(pn_encoder_t *encoder, uint8_t value)
     encoder->position++;
     return 0;
   } else {
-    return PN_OVERFLOW;
+    return overflow(encoder, 1);
   }
 }
 
 static inline int pn_encoder_writef16(pn_encoder_t *encoder, uint16_t value)
 {
   if (pn_encoder_remaining(encoder) < 2) {
-    return PN_OVERFLOW;
+    return overflow(encoder, 2);
   } else {
     encoder->position[0] = 0xFF & (value >> 8);
     encoder->position[1] = 0xFF & (value     );
@@ -181,7 +191,7 @@ static inline int pn_encoder_writef16(pn_encoder_t *encoder, uint16_t value)
 static inline int pn_encoder_writef32(pn_encoder_t *encoder, uint32_t value)
 {
   if (pn_encoder_remaining(encoder) < 4) {
-    return PN_OVERFLOW;
+    return overflow(encoder, 4);
   } else {
     encoder->position[0] = 0xFF & (value >> 24);
     encoder->position[1] = 0xFF & (value >> 16);
@@ -194,7 +204,7 @@ static inline int pn_encoder_writef32(pn_encoder_t *encoder, uint32_t value)
 
 static inline int pn_encoder_writef64(pn_encoder_t *encoder, uint64_t value) {
   if (pn_encoder_remaining(encoder) < 8) {
-    return PN_OVERFLOW;
+    return overflow(encoder, 8);
   } else {
     encoder->position[0] = 0xFF & (value >> 56);
     encoder->position[1] = 0xFF & (value >> 48);
@@ -211,7 +221,7 @@ static inline int pn_encoder_writef64(pn_encoder_t *encoder, uint64_t value) {
 
 static inline int pn_encoder_writef128(pn_encoder_t *encoder, char *value) {
   if (pn_encoder_remaining(encoder) < 16) {
-    return PN_OVERFLOW;
+    return overflow(encoder, 16);
   } else {
     memmove(encoder->position, value, 16);
     encoder->position += 16;
@@ -222,7 +232,7 @@ static inline int pn_encoder_writef128(pn_encoder_t *encoder, char *value) {
 static inline int pn_encoder_writev8(pn_encoder_t *encoder, const pn_bytes_t *value)
 {
   if (pn_encoder_remaining(encoder) < 1 + value->size) {
-    return PN_OVERFLOW;
+    return overflow(encoder, 1 + value->size);
   } else {
     int e = pn_encoder_writef8(encoder, value->size);
     if (e) return e;
@@ -235,7 +245,7 @@ static inline int pn_encoder_writev8(pn_encoder_t *encoder, const pn_bytes_t *va
 static inline int pn_encoder_writev32(pn_encoder_t *encoder, const pn_bytes_t *value)
 {
   if (pn_encoder_remaining(encoder) < 4 + value->size) {
-    return PN_OVERFLOW;
+    return overflow(encoder, 4 + value->size);
   } else {
     int e = pn_encoder_writef32(encoder, value->size);
     if (e) return e;
@@ -326,7 +336,7 @@ static int pni_encoder_enter(void *ctx, pn_data_t *data, pni_node_t *node)
     node->start = encoder->position;
     node->small = false;
     // we'll backfill the size on exit
-    if (pn_encoder_remaining(encoder) < 4) return PN_OVERFLOW;
+    if (pn_encoder_remaining(encoder) < 4) return overflow(encoder, 4);
     encoder->position += 4;
 
     err = pn_encoder_writef32(encoder, node->described ? node->children - 1 : node->children);
@@ -342,7 +352,7 @@ static int pni_encoder_enter(void *ctx, pn_data_t *data, pni_node_t *node)
     node->start = encoder->position;
     node->small = false;
     // we'll backfill the size later
-    if (pn_encoder_remaining(encoder) < 4) return PN_OVERFLOW;
+    if (pn_encoder_remaining(encoder) < 4) return overflow(encoder, 4);
     encoder->position += 4;
     return pn_encoder_writef32(encoder, node->children);
   default:
@@ -387,6 +397,7 @@ static int pni_encoder_exit(void *ctx, pn_data_t *data, pni_node_t *node)
 
 ssize_t pn_encoder_encode(pn_encoder_t *encoder, pn_data_t *src, char *dst, size_t size)
 {
+  encoder->counting = false;
   encoder->output = dst;
   encoder->position = dst;
   encoder->size = size;
@@ -394,5 +405,17 @@ ssize_t pn_encoder_encode(pn_encoder_t *encoder, pn_data_t *src, char *dst, size
   int err = pni_data_traverse(src, pni_encoder_enter, pni_encoder_exit, encoder);
   if (err) return err;
 
-  return size - pn_encoder_remaining(encoder);
+  return encoder->position - encoder->output;
 }
+
+size_t pn_encoder_encode2(pn_encoder_t *encoder, pn_data_t *src, char *dst, size_t size)
+{
+  encoder->counting = true;
+  encoder->output = dst;
+  encoder->position = dst;
+  encoder->size = size;
+
+  pni_data_traverse(src, pni_encoder_enter, pni_encoder_exit, encoder);
+  return encoder->position - encoder->output;
+}
+

--- a/proton-c/src/codec/encoder.h
+++ b/proton-c/src/codec/encoder.h
@@ -26,5 +26,6 @@ typedef struct pn_encoder_t pn_encoder_t;
 
 pn_encoder_t *pn_encoder(void);
 ssize_t pn_encoder_encode(pn_encoder_t *encoder, pn_data_t *src, char *dst, size_t size);
+size_t pn_encoder_encode2(pn_encoder_t *encoder, pn_data_t *src, char *dst, size_t size);
 
 #endif /* encoder.h */


### PR DESCRIPTION
Introduce pn_data_encode2 which allows you to both encode data and, if you don't have enough
space, find out how much space you need. You can also use this to simply find out how
much space is required to  the data.

This supports two patterns of use:

1. Check how much space you need, allocate the space and encode.

2. Try to encode into a buffer you already have. If that doesn't work, re-allocate
   to the correct size and encode.

Eliminates the need for guessing and buffer doubling strategies, which are
inefficient given that we know exactly what is in the data.

The original pn_data_encode is unmodified for compatibility.