### PR TITLE
PROTON-838: proton-hawtdispatch cannot connect with SSL

### DIFF
--- a/contrib/proton-hawtdispatch/src/main/java/org/apache/qpid/proton/hawtdispatch/impl/AmqpTransport.java
+++ b/contrib/proton-hawtdispatch/src/main/java/org/apache/qpid/proton/hawtdispatch/impl/AmqpTransport.java
@@ -167,7 +167,6 @@ public class AmqpTransport extends WatchBase {
         transport.setSendBufferSize(options.getSendBufferSize());
         transport.setTrafficClass(options.getTrafficClass());
         transport.setUseLocalHost(options.isUseLocalHost());
-        transport.connecting(host, options.getLocalAddress());
 
         transport.setTransportListener(new DefaultTransportListener(){
             public void onTransportConnected() {


### PR DESCRIPTION
Remove one of calls to transport.connecting() as this causes
an assert with SslTransport