### PR TITLE
PROTON-843: Java should match C for idle timeout

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -798,8 +798,11 @@ public class TransportImpl extends EndpointImpl
             if (_channelMax > 0) {
                 open.setChannelMax(UnsignedShort.valueOf((short) _channelMax));
             }
+
+            // as per the recommendation in the spec, advertise half our
+            // actual timeout to the remote
             if (_localIdleTimeout > 0) {
-                open.setIdleTimeOut(new UnsignedInteger(_localIdleTimeout));
+                open.setIdleTimeOut(new UnsignedInteger(_localIdleTimeout / 2));
             }
             _isOpenSent = true;
 


### PR DESCRIPTION
As discussed on the mailing list. Currently proton-j advertises a
provided local idle timeout value as-is, whereas proton-c will halve it
before sending it to the remote side. The two implementations should
match in behaviour.