### PR TITLE
PROTON-844: police handle-max in proton-j

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -1092,7 +1092,27 @@ public class TransportImpl extends EndpointImpl
         else
         {
             SessionImpl session = transportSession.getSession();
-            TransportLink<?> transportLink = transportSession.getLinkFromRemoteHandle(attach.getHandle());
+            final UnsignedInteger handle = attach.getHandle();
+            if (handle.compareTo(transportSession.getHandleMax()) > 0) {
+                // The handle-max value is the highest handle value that can be used on the session. A peer MUST
+                // NOT attempt to attach a link using a handle value outside the range that its partner can handle.
+                // A peer that receives a handle outside the supported range MUST close the connection with the
+                // framing-error error-code.
+                ErrorCondition condition =
+                        new ErrorCondition(ConnectionError.FRAMING_ERROR,
+                                                            "handle-max exceeded");
+                _connectionEndpoint.setCondition(condition);
+                _connectionEndpoint.setLocalState(EndpointState.CLOSED);
+                if (!_isCloseSent) {
+                    Close close = new Close();
+                    close.setError(condition);
+                    _isCloseSent = true;
+                    writeFrame(0, close, null, null);
+                }
+                close_tail();
+                return;
+            }
+            TransportLink<?> transportLink = transportSession.getLinkFromRemoteHandle(handle);
             LinkImpl link = null;
 
             if(transportLink != null)
@@ -1127,8 +1147,8 @@ public class TransportImpl extends EndpointImpl
                 link.setRemoteSenderSettleMode(attach.getSndSettleMode());
 
                 transportLink.setName(attach.getName());
-                transportLink.setRemoteHandle(attach.getHandle());
-                transportSession.addLinkRemoteHandle(transportLink, attach.getHandle());
+                transportLink.setRemoteHandle(handle);
+                transportSession.addLinkRemoteHandle(transportLink, handle);
 
             }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportSession.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportSession.java
@@ -23,6 +23,7 @@ package org.apache.qpid.proton.engine.impl;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.UnsignedInteger;
 import org.apache.qpid.proton.amqp.transport.Disposition;
@@ -38,16 +39,16 @@ class TransportSession
     private int _localChannel = -1;
     private int _remoteChannel = -1;
     private boolean _openSent;
-    private UnsignedInteger _handleMax = UnsignedInteger.valueOf(1024);
+    private final UnsignedInteger _handleMax = UnsignedInteger.valueOf(65536);
     private UnsignedInteger _outgoingDeliveryId = UnsignedInteger.ZERO;
     private UnsignedInteger _incomingWindowSize = UnsignedInteger.ZERO;
     private UnsignedInteger _outgoingWindowSize = UnsignedInteger.ZERO;
     private UnsignedInteger _nextOutgoingId = UnsignedInteger.ONE;
     private UnsignedInteger _nextIncomingId = null;
 
-    private TransportLink[] _remoteHandleMap = new TransportLink[1024];
-    private TransportLink[] _localHandleMap = new TransportLink[1024];
-    private Map<String, TransportLink> _halfOpenLinks = new HashMap<String, TransportLink>();
+    private final TransportLink[] _remoteHandleMap = new TransportLink[_handleMax.intValue() + 1];
+    private final TransportLink[] _localHandleMap = new TransportLink[_handleMax.intValue() + 1];
+    private final Map<String, TransportLink> _halfOpenLinks = new HashMap<String, TransportLink>();
 
 
     private UnsignedInteger _incomingDeliveryId = null;
@@ -55,9 +56,9 @@ class TransportSession
     private UnsignedInteger _remoteOutgoingWindow;
     private UnsignedInteger _remoteNextIncomingId = _nextOutgoingId;
     private UnsignedInteger _remoteNextOutgoingId;
-    private Map<UnsignedInteger, DeliveryImpl>
+    private final Map<UnsignedInteger, DeliveryImpl>
             _unsettledIncomingDeliveriesById = new HashMap<UnsignedInteger, DeliveryImpl>();
-    private Map<UnsignedInteger, DeliveryImpl>
+    private final Map<UnsignedInteger, DeliveryImpl>
             _unsettledOutgoingDeliveriesById = new HashMap<UnsignedInteger, DeliveryImpl>();
     private int _unsettledIncomingSize;
     private boolean _endReceived;
@@ -218,8 +219,7 @@ class TransportSession
                 return rc;
             }
         }
-        // TODO - error
-        return UnsignedInteger.MAX_VALUE;
+        throw new IllegalStateException("no local handle available for allocation");
     }
 
     public void addLinkRemoteHandle(TransportLink link, UnsignedInteger remoteHandle)


### PR DESCRIPTION
* when receiving an attach with a handle > handle-max, the connection
  should be closed
* when attempting to allocate a new local handle when handle-max are
  already in-use should throw an Exception
* the default of 1024 handle-max is quite small when proton-c appears to
  default to 4294967295 - increase it more modestly to 65536

Closes #16