### PR TITLE
PROTON-848-and-849: stop leaking the transport state

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -96,10 +96,6 @@ public class TransportImpl extends EndpointImpl
     private TransportInput _inputProcessor;
     private TransportOutput _outputProcessor;
 
-    private Map<SessionImpl, TransportSession> _transportSessionState = new HashMap<SessionImpl, TransportSession>();
-    private Map<LinkImpl, TransportLink<?>> _transportLinkState = new HashMap<LinkImpl, TransportLink<?>>();
-
-
     private DecoderImpl _decoder = new DecoderImpl();
     private EncoderImpl _encoder = new EncoderImpl(_decoder);
 
@@ -252,12 +248,11 @@ public class TransportImpl extends EndpointImpl
     @Override
     public void unbind()
     {
-        for (TransportSession ts: _transportSessionState.values()) {
+        for (TransportSession ts: _localSessions.values()) {
             ts.unbind();
         }
-
-        for (TransportLink tl: _transportLinkState.values()) {
-            tl.unbind();
+        for (TransportSession ts: _remoteSessions.values()) {
+            ts.unbind();
         }
 
         put(Event.Type.CONNECTION_UNBOUND, _connectionEndpoint);
@@ -846,23 +841,21 @@ public class TransportImpl extends EndpointImpl
 
     private TransportSession getTransportState(SessionImpl session)
     {
-        TransportSession transportSession = _transportSessionState.get(session);
+        TransportSession transportSession = session.getTransportSession();
         if(transportSession == null)
         {
             transportSession = new TransportSession(this, session);
             session.setTransportSession(transportSession);
-            _transportSessionState.put(session, transportSession);
         }
         return transportSession;
     }
 
     private TransportLink<?> getTransportState(LinkImpl link)
     {
-        TransportLink<?> transportLink = _transportLinkState.get(link);
+        TransportLink<?> transportLink = link.getTransportLink();
         if(transportLink == null)
         {
             transportLink = TransportLink.createTransportLink(link);
-            _transportLinkState.put(link, transportLink);
         }
         return transportLink;
     }
@@ -1248,6 +1241,7 @@ public class TransportImpl extends EndpointImpl
         {
             _remoteSessions.remove(channel);
             transportSession.receivedEnd();
+            transportSession.unsetRemoteChannel();
             SessionImpl session = transportSession.getSession();
             session.setRemoteState(EndpointState.CLOSED);
             ErrorCondition errorCondition = end.getError();

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportLink.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportLink.java
@@ -46,9 +46,22 @@ class TransportLink<T extends LinkImpl>
 
     static <L extends LinkImpl> TransportLink<L> createTransportLink(L link)
     {
-        return (TransportLink<L>) (link instanceof ReceiverImpl
-                       ? new TransportReceiver((ReceiverImpl)link)
-                       : new TransportSender((SenderImpl)link));
+        if (link instanceof ReceiverImpl)
+        {
+            ReceiverImpl r = (ReceiverImpl) link;
+            TransportReceiver tr = new TransportReceiver(r);
+            r.setTransportLink(tr);
+
+            return (TransportLink<L>) tr;
+        }
+        else
+        {
+            SenderImpl s = (SenderImpl) link;
+            TransportSender ts = new TransportSender(s);
+            s.setTransportLink(ts);
+
+            return (TransportLink<L>) ts;
+        }
     }
 
     void unbind()

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportSession.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportSession.java
@@ -130,19 +130,46 @@ class TransportSession
     public void unsetLocalChannel()
     {
         if (isLocalChannelSet()) {
+            unsetLocalHandles();
             _session.decref();
         }
         _localChannel = -1;
     }
 
+    private void unsetLocalHandles()
+    {
+        for(int i = 0; i < _localHandleMap.length; i++)
+        {
+            TransportLink<?> tl = _localHandleMap[i];
+            if(tl != null)
+            {
+                _localHandleMap[i] = null;
+                tl.clearLocalHandle();
+            }
+        }
+    }
+
     public void unsetRemoteChannel()
     {
         if (isRemoteChannelSet()) {
+            unsetRemoteHandles();
             _session.decref();
         }
         _remoteChannel = -1;
     }
 
+    private void unsetRemoteHandles()
+    {
+        for(int i = 0; i < _remoteHandleMap.length; i++)
+        {
+            TransportLink<?> tl = _remoteHandleMap[i];
+            if(tl != null)
+            {
+                _remoteHandleMap[i] = null;
+                tl.clearRemoteHandle();
+            }
+        }
+    }
 
     public UnsignedInteger getHandleMax()
     {
@@ -332,6 +359,11 @@ class TransportSession
     public void freeLocalChannel()
     {
         unsetLocalChannel();
+    }
+
+    public void freeRemoteChannel()
+    {
+        unsetRemoteChannel();
     }
 
     private void setRemoteIncomingWindow(UnsignedInteger incomingWindow)

--- a/tests/python/proton_tests/engine.py
+++ b/tests/python/proton_tests/engine.py
@@ -2399,9 +2399,10 @@ class TeardownLeakTest(PeerTest):
                   Event.TRANSPORT_CLOSED)
 
     self.connection.free()
+    self.expect(Event.LINK_FINAL, Event.SESSION_FINAL)
     self.transport.unbind()
 
-    self.expect(Event.LINK_FINAL, Event.SESSION_FINAL, Event.CONNECTION_UNBOUND, Event.CONNECTION_FINAL)
+    self.expect(Event.CONNECTION_UNBOUND, Event.CONNECTION_FINAL)
 
   def testLocalRemoteLeak(self):
     self.doLeak(True, True)


### PR DESCRIPTION
Stops leaking the transport state by removing the maps storing the TransportSession or TransportLink objects, instead using the references set on the associated Session and Link objects at the time they would have been entered into the maps. Not much to that bit.

The bulk of the annoyance came from some tests failing after those changes due to alteration of the events being emitted when calling free+unbind on the connection+transport. Much debugging suggested this was possibly as result of existing differences in behaviour (mainly that things were not showing FINAL events until the unbind step in proton-j, unlike proton-c) which just happened to become more visible following my modifications. After looking at some of the differences between proton-c and proton-j's session+link reference handling I made some alterations to have it act more like proton-c, which fixed the earlier test failures, however I'd like a second opinion from someone who actually understands what this stuff is meant to do :)