### PR TITLE
PROTON-853: stop erroneous attach being sent

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -30,6 +30,7 @@ import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.UnsignedInteger;
 import org.apache.qpid.proton.amqp.UnsignedShort;
+import org.apache.qpid.proton.amqp.security.SaslCode;
 import org.apache.qpid.proton.amqp.transport.Attach;
 import org.apache.qpid.proton.amqp.transport.Begin;
 import org.apache.qpid.proton.amqp.transport.Close;
@@ -58,6 +59,7 @@ import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
 import org.apache.qpid.proton.engine.TransportResult;
 import org.apache.qpid.proton.engine.TransportResultFactory;
+import org.apache.qpid.proton.engine.Sasl.SaslOutcome;
 import org.apache.qpid.proton.engine.impl.ssl.ProtonSslEngineProvider;
 import org.apache.qpid.proton.engine.impl.ssl.SslImpl;
 import org.apache.qpid.proton.framing.TransportFrame;
@@ -409,7 +411,7 @@ public class TransportImpl extends EndpointImpl
                         UnsignedInteger localHandle = transportLink.getLocalHandle();
                         transportLink.clearLocalHandle();
                         transportSession.freeLocalHandle(localHandle);
-                        transportLink.clearSentAttach();
+
 
                         Detach detach = new Detach();
                         detach.setHandle(localHandle);
@@ -755,7 +757,6 @@ public class TransportImpl extends EndpointImpl
                             }
 
                             writeFrame(transportSession.getLocalChannel(), attach, null, null);
-                            transportLink.clearDetachReceived();
                             transportLink.sentAttach();
                         }
                     }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -22,15 +22,12 @@ import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.pourBufferToArr
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.UnsignedInteger;
 import org.apache.qpid.proton.amqp.UnsignedShort;
-import org.apache.qpid.proton.amqp.security.SaslCode;
 import org.apache.qpid.proton.amqp.transport.Attach;
 import org.apache.qpid.proton.amqp.transport.Begin;
 import org.apache.qpid.proton.amqp.transport.Close;
@@ -55,12 +52,9 @@ import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.Ssl;
 import org.apache.qpid.proton.engine.SslDomain;
 import org.apache.qpid.proton.engine.SslPeerDetails;
-import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
 import org.apache.qpid.proton.engine.TransportResult;
 import org.apache.qpid.proton.engine.TransportResultFactory;
-import org.apache.qpid.proton.engine.Sasl.SaslOutcome;
-import org.apache.qpid.proton.engine.impl.ssl.ProtonSslEngineProvider;
 import org.apache.qpid.proton.engine.impl.ssl.SslImpl;
 import org.apache.qpid.proton.framing.TransportFrame;
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportLink.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportLink.java
@@ -199,11 +199,6 @@ class TransportLink<T extends LinkImpl>
         return _detachReceived;
     }
 
-    public void clearDetachReceived()
-    {
-        _detachReceived = false;
-    }
-
     public boolean attachSent()
     {
         return _attachSent;
@@ -212,11 +207,6 @@ class TransportLink<T extends LinkImpl>
     public void sentAttach()
     {
         _attachSent = true;
-    }
-
-    public void clearSentAttach()
-    {
-        _attachSent = false;
     }
 
     public void setRemoteDeliveryCount(UnsignedInteger remoteDeliveryCount)

--- a/tests/python/proton_tests/engine.py
+++ b/tests/python/proton_tests/engine.py
@@ -430,40 +430,6 @@ class LinkTest(Test):
     assert self.snd.state == Endpoint.LOCAL_CLOSED | Endpoint.REMOTE_CLOSED
     assert self.rcv.state == Endpoint.LOCAL_CLOSED | Endpoint.REMOTE_CLOSED
 
-  def test_reopen_on_same_session(self):
-    """
-    confirm that a link is correctly opened when attaching to a previously
-    detached link on the same session
-    """
-    assert self.snd.state == Endpoint.LOCAL_UNINIT | Endpoint.REMOTE_UNINIT
-    assert self.rcv.state == Endpoint.LOCAL_UNINIT | Endpoint.REMOTE_UNINIT
-
-    self.snd.open()
-    self.rcv.open()
-    self.pump()
-
-    assert self.snd.state == Endpoint.LOCAL_ACTIVE | Endpoint.REMOTE_ACTIVE
-    assert self.rcv.state == Endpoint.LOCAL_ACTIVE | Endpoint.REMOTE_ACTIVE
-
-    self.snd.close()
-    self.rcv.close()
-    self.pump()
-
-    assert self.snd.state == Endpoint.LOCAL_CLOSED | Endpoint.REMOTE_CLOSED
-    assert self.rcv.state == Endpoint.LOCAL_CLOSED | Endpoint.REMOTE_CLOSED
-
-    self.snd, self.rcv = self.link("test-link")
-    assert self.snd.state == Endpoint.LOCAL_UNINIT | Endpoint.REMOTE_UNINIT
-    assert self.rcv.state == Endpoint.LOCAL_UNINIT | Endpoint.REMOTE_UNINIT
-
-    self.snd.open()
-    self.rcv.open()
-    self.pump()
-
-    assert self.snd.state == Endpoint.LOCAL_ACTIVE | Endpoint.REMOTE_ACTIVE
-    assert self.rcv.state == Endpoint.LOCAL_ACTIVE | Endpoint.REMOTE_ACTIVE
-
-
   def test_simultaneous_open_close(self):
     assert self.snd.state == Endpoint.LOCAL_UNINIT | Endpoint.REMOTE_UNINIT
     assert self.rcv.state == Endpoint.LOCAL_UNINIT | Endpoint.REMOTE_UNINIT


### PR DESCRIPTION
The changes for PROTON 154 commit 7d3063e7c488c97b9bad61e862d54b2b11dbc3d5 in 0.9 lead to situations where the transport will decide to send a new Attach frame out for a link that has been closed/detached.

The original change aimed to ensure that a link with the same name as one which had just been closed could be attached on the same session, by clearing the 'attach sent' and 'detach received' flags of the TransportLink. The reason that seemed necessary is that the old link object (and in turn TransportLink object) would be returned due to some caching within SessionImpl, unless you ensure to first call free() on the old link. Gordon noticed the same effect from the server side in proton-c via PROTON 850.

These changes stop the erroneous attach being sent by first reverting the change from PROTON 154, and looking to stop the earlier situation arising by returning a new Link object rather than a cached one if the states are closed (i.e similar to Gordons from PROTON 850), meaning a new TransportLink gets created rather than the old one being reused and there then being no need to play with the boolean states. It keeps a list of any 'old links' that would have been forogtten to ensure they get free'd when the session is.

The earlier test was ineffective and passed with or without the earlier changes. This was because it actually created new connections and sessions when it was aiming to be reuse the same session. I updated the test to do that, and it now catches both PROTON 154 and PROTON 850 (in proton-c too).