### PR TITLE
Fixes for Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ if (MSVC)
 endif (MSVC)
 option(BUILD_WITH_CXX "Compile Proton using C++" ${DEFAULT_BUILD_WITH_CXX})
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # Default to universal binary on Mac OS X unless user has overriden
+  if (NOT DEFINED CMAKE_OSX_ARCHITECTURES OR "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "")
+    set(CMAKE_OSX_ARCHITECTURES "i386;x86_64")
+  endif ()
+endif ()
+
 if (BUILD_WITH_CXX)
   project (Proton C CXX)
 endif (BUILD_WITH_CXX)

--- a/tests/python/proton_tests/messenger.py
+++ b/tests/python/proton_tests/messenger.py
@@ -1013,16 +1013,17 @@ class SelectableMessengerTest(common.Test):
     mc = Message()
 
     for i in range(count):
-      if mrcv.incoming == 0:
+      while mrcv.incoming == 0:
         p.pump()
       assert mrcv.incoming > 0
       mrcv.get(mc)
       assert mc.body == u"Hello World! %s" % i, (i, mc.body)
 
     mrcv.stop()
-    assert not mrcv.stopped
+    msnd.stop()
     p.pump()
     assert mrcv.stopped
+    assert msnd.stopped
 
   def testSelectable16(self):
     self.testSelectable(count=16)


### PR DESCRIPTION
1. default to building universal binaries so the various language bindings can link against the system libraries out of the box

2. small fix to SelectableMessengerTest as it was regularly failing on Mac builds.