### PR TITLE
Fix none_sasl.c to use pn_strdup instead of strdup

### DIFF
--- a/proton-c/src/sasl/none_sasl.c
+++ b/proton-c/src/sasl/none_sasl.c
@@ -25,6 +25,7 @@
 #include "buffer.h"
 #include "protocol.h"
 #include "dispatch_actions.h"
+#include "util.h"
 #include "engine/engine-internal.h"
 
 struct pni_sasl_t {
@@ -93,7 +94,7 @@ void pn_sasl_allowed_mechs(pn_sasl_t *sasl0, const char *mechs)
   pni_sasl_t *sasl = get_sasl_internal(sasl0);
   if (!sasl) return;
   free(sasl->included_mechanisms);
-  sasl->included_mechanisms = mechs ? strdup(mechs) : NULL;
+  sasl->included_mechanisms = mechs ? pn_strdup(mechs) : NULL;
   if (strcmp(mechs, "ANONYMOUS")==0 ) {
     // If we do this on the client it is a hack to tell us that
     // no actual negatiation is going to happen and we can go
@@ -165,7 +166,7 @@ void pni_sasl_set_user_password(pn_transport_t *transport, const char *user, con
 {
   pni_sasl_t *sasl = transport->sasl;
   sasl->username = user;
-  sasl->password = password ? strdup(password) : NULL;
+  sasl->password = password ? pn_strdup(password) : NULL;
 }
 
 const char *pn_sasl_get_user(pn_sasl_t *sasl0)


### PR DESCRIPTION
(PROTON-870) none_sasl.c should use pn_strdup.

none_sasl.c uses strdup, but strdup is not part of C99 and subsequently does not exist on some platforms. Instead pn_strdup should be used.

Thanks,
/Dan