### PR TITLE
Initial transport frame size 256 bytes

### DIFF
--- a/proton-c/CMakeLists.txt
+++ b/proton-c/CMakeLists.txt
@@ -342,6 +342,8 @@ set (qpid-proton-core
   src/messenger/transform.c
   src/selectable.c
 
+  src/config.h
+
   ${CMAKE_CURRENT_BINARY_DIR}/src/encodings.h
   ${CMAKE_CURRENT_BINARY_DIR}/src/protocol.h
   )

--- a/proton-c/src/config.h
+++ b/proton-c/src/config.h
@@ -1,0 +1,26 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*/
+
+#ifndef  _PROTON_SRC_CONFIG_H 
+#define  _PROTON_SRC_CONFIG_H 
+
+#define TRANSPORT_INITIAL_FRAME_SIZE    (512) /* bytes */
+
+#endif /*  _PROTON_SRC_CONFIG_H */

--- a/proton-c/src/transport/transport.c
+++ b/proton-c/src/transport/transport.c
@@ -30,6 +30,7 @@
 #include "proton/event.h"
 #include "platform.h"
 #include "platform_fmt.h"
+#include "config.h"
 #include "../log_private.h"
 
 #include <stdlib.h>
@@ -349,7 +350,7 @@ static void pn_transport_initialize(void *object)
   transport->scratch = pn_string(NULL);
   transport->args = pn_data(16);
   transport->output_args = pn_data(16);
-  transport->frame = pn_buffer(4*1024);
+  transport->frame = pn_buffer(TRANSPORT_INITIAL_FRAME_SIZE);
   transport->input_frames_ct = 0;
   transport->output_frames_ct = 0;
 


### PR DESCRIPTION
In order to reduce RAM footprint on rather simple scenarios on small devices the initial transport frame size could be lowered to 256, since the buffer is anyhow automatically enlarged if needed.

Per earlier suggestions I created a config.h where parameters like this can go (the next candidate is the initial size for pn_data). If the need arises these parameters should be easily changeable in this case to match the platform need.