### PR TITLE
proton-c: minor code fixes

### DIFF
--- a/proton-c/src/codec/codec.c
+++ b/proton-c/src/codec/codec.c
@@ -477,6 +477,7 @@ int pn_data_intern_node(pn_data_t *data, pni_node_t *node)
 int pn_data_vfill(pn_data_t *data, const char *fmt, va_list ap)
 {
   int err = 0;
+  const char *begin = fmt;
   while (*fmt) {
     char code = *(fmt++);
     if (!code) return 0;
@@ -578,7 +579,7 @@ int pn_data_vfill(pn_data_t *data, const char *fmt, va_list ap)
       }
       break;
     case '[':
-      if (*(fmt - 2) != 'T') {
+      if (fmt < (begin + 2) || *(fmt - 2) != 'T') {
         err = pn_data_put_list(data);
         if (err) return err;
         pn_data_enter(data);

--- a/proton-c/src/codec/codec.c
+++ b/proton-c/src/codec/codec.c
@@ -1934,7 +1934,7 @@ pn_atom_t pn_data_get_atom(pn_data_t *data)
   if (node) {
     return *((pn_atom_t *) &node->atom);
   } else {
-    pn_atom_t t = {PN_NULL};
+    pn_atom_t t = {PN_NULL, {0,}};
     return t;
   }
 }

--- a/proton-c/src/posix/io.c
+++ b/proton-c/src/posix/io.c
@@ -64,7 +64,7 @@ void pn_io_finalize(void *obj)
 
 #define pn_io_hashcode NULL
 #define pn_io_compare NULL
-#define pn_io_inspect
+#define pn_io_inspect NULL
 
 pn_io_t *pn_io(void)
 {

--- a/proton-c/src/scanner.c
+++ b/proton-c/src/scanner.c
@@ -94,7 +94,7 @@ pn_token_t pn_scanner_token(pn_scanner_t *scanner)
   if (scanner) {
     return scanner->token;
   } else {
-    pn_token_t tok = {PN_TOK_ERR};
+    pn_token_t tok = {PN_TOK_ERR, 0, (size_t)0};
     return tok;
   }
 }

--- a/proton-c/src/transport/transport.c
+++ b/proton-c/src/transport/transport.c
@@ -843,7 +843,8 @@ int pn_post_frame(pn_transport_t *transport, uint8_t type, uint16_t ch, const ch
     return PN_ERR;
   }
 
-  pn_frame_t frame = {type};
+  pn_frame_t frame = {0,};
+  frame.type = type;
   frame.channel = ch;
   frame.payload = buf.start;
   frame.size = wr;


### PR DESCRIPTION
Prevent pn_data_vfill from peeking at memory outside the intended bounds and fix a few minor -Wextra warnings about incomplete struct initialisation