### PR TITLE
NO-JIRA: improvements to export.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes export-ignore  
+.gitignore export-ignore

--- a/bin/export.sh
+++ b/bin/export.sh
@@ -28,7 +28,8 @@ SRC=$(dirname $(dirname $(readlink -f $0)))
 
 usage()
 {
-    echo "Usage: ${ME} [DIR]"
+    echo
+    echo "Usage: ${ME} [DIR] [TAG]"
     exit 1
 }
 
@@ -39,13 +40,23 @@ cleanup()
     [ ${WORKDIR} ] && [ -d ${WORKDIR} ] && rm -rf ${WORKDIR}
 }
 
-if [ $# == 1 ]; then
-    DIR=$1
-elif [ $# == 0 ]; then
-    DIR=$PWD
-else
+DIR=$PWD
+TAG=$(git describe --tags --always)
+
+##
+## Allow overrides to be passed on the cmdline
+##
+if [ $# -gt 2 ]; then
     usage
+elif [ $# -ge 1 ]; then
+    DIR=$1
+    if [ $# -eq 2 ]; then
+        TAG=$2
+    fi
 fi
+
+# verify the tag exists
+git rev-list -1 tags/${TAG} -- >/dev/null || usage
 
 WORKDIR=$(mktemp -d)
 
@@ -54,15 +65,18 @@ WORKDIR=$(mktemp -d)
 ##
 (
     cd ${SRC}
-    TAG=$(git describe --tags --always)
     MTIME=$(date -d @`git log -1 --pretty=format:%ct tags/${TAG}` '+%Y-%m-%d %H:%M:%S')
     ARCHIVE=$DIR/qpid-proton-${TAG}.tar.gz
+    VERSION=$(git show tags/${TAG}:version.txt)
+    PREFIX=qpid-proton-${VERSION}
     [ -d ${WORKDIR} ] || mkdir -p ${WORKDIR}
-    git archive --format=tar --prefix=qpid-proton-${TAG}/ tags/${TAG} \
+    git archive --format=tar --prefix=${PREFIX}/ tags/${TAG} \
         | tar -x -C ${WORKDIR}
+    ${SRC}/bin/version.sh ${WORKDIR}/${PREFIX} ${VERSION}
     cd ${WORKDIR}
     tar -c -z \
         --owner=root --group=root --numeric-owner \
         --mtime="${MTIME}" \
         -f ${ARCHIVE} .
+    echo "${ARCHIVE}"
 )


### PR DESCRIPTION
+ allow specific tag to be specified as cmdline arg
+ confirm the tag exists before proceeding
+ use the version.txt from that tag as the tar prefix folder
+ re-run the version.sh script before packaging to ensure the correct
  version is set
+ add .gitattributes to exclude .gitignore files from the exported tar

Closes #28