### PR TITLE
PROTON-881: Graceful handling of runtime exceptions thrown within han…

### DIFF
--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Cat.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Cat.java
@@ -30,6 +30,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 import org.apache.qpid.proton.reactor.Selectable;
 
 public class Cat extends BaseHandler {
@@ -82,7 +83,7 @@ public class Cat extends BaseHandler {
         reactor.update(selectable);
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         if (args.length != 1) {
             System.err.println("Specify a file name as an argument.");
             System.exit(1);

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/CountRandomly.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/CountRandomly.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 // Let's try to modify our counter example. In addition to counting to
 // 10 in quarter second intervals, let's also print out a random number
@@ -91,7 +92,7 @@ public class CountRandomly extends BaseHandler {
         System.out.println("Goodbye, World! (after " + elapsedTime + " long milliseconds)");
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         // In HelloWorld.java we said the reactor exits when there are no more
         // events to process. While this is true, it's not actually complete.
         // The reactor exits when there are no more events to process and no

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Counter.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Counter.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 public class Counter extends BaseHandler {
 
@@ -68,7 +69,7 @@ public class Counter extends BaseHandler {
         System.out.println("Goodbye, World! (after " + elapsedTime + " long milliseconds)");
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         // In HelloWorld.java we said the reactor exits when there are no more
         // events to process. While this is true, it's not actually complete.
         // The reactor exits when there are no more events to process and no

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Delegates.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Delegates.java
@@ -28,6 +28,7 @@ import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.engine.Handler;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 // Events know how to dispatch themselves to handlers. By combining
 // this with on_unhandled, you can provide a kind of inheritance
@@ -61,7 +62,7 @@ public class Delegates extends BaseHandler {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         Reactor reactor = Proton.reactor(new Delegates(new Hello(), new Goodbye()));
         reactor.run();
     }

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Echo.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Echo.java
@@ -29,6 +29,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 import org.apache.qpid.proton.reactor.Selectable;
 
 public class Echo extends BaseHandler {
@@ -82,7 +83,7 @@ public class Echo extends BaseHandler {
         reactor.update(selectable);
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         SourceChannel inChannel = EchoInputStreamWrapper.wrap(System.in);
         Reactor reactor = Proton.reactor(new Echo(inChannel));
         reactor.run();

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/GlobalLogger.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/GlobalLogger.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 /*
 # Not every event goes to the reactor's event handler. If we have a
@@ -99,7 +100,7 @@ public class GlobalLogger extends BaseHandler {
         System.out.println("Goodbye, World!");
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         Reactor reactor = Proton.reactor(new GlobalLogger());
 
         // In addition to having a regular handler, the reactor also has a

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/GoodbyeWorld.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/GoodbyeWorld.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 // TODO: sort out docs!
 // So far the reactive hello-world doesn't look too different from a
@@ -55,7 +56,7 @@ public class GoodbyeWorld extends BaseHandler {
         System.out.println("Goodbye, World!");;
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         Reactor reactor = Proton.reactor(new GoodbyeWorld());
         reactor.run();
     }

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/HelloWorld.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/HelloWorld.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 // TODO: sort out docs!
 /*
@@ -46,7 +47,7 @@ public class HelloWorld extends BaseHandler {
         System.out.println("Hello, World!");
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
 
         // When you construct a reactor, you can give it a handler that
         // is used, by default.

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/ReactorLogger.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/ReactorLogger.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 /*
 class Logger:
@@ -83,7 +84,7 @@ public class ReactorLogger extends BaseHandler {
 
     private static boolean loggingEnabled = false;
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
 
         // You can pass multiple handlers to a reactor when you construct it.
         // Each of these handlers will see every event the reactor sees. By

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Recv.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Recv.java
@@ -33,6 +33,7 @@ import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.reactor.FlowController;
 import org.apache.qpid.proton.reactor.Handshaker;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 public class Recv extends BaseHandler {
 
@@ -72,7 +73,7 @@ public class Recv extends BaseHandler {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         Reactor r = Proton.reactor(new Recv());
         r.run();
     }

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Scheduling.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Scheduling.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 import org.apache.qpid.proton.reactor.Task;
 
 public class Scheduling extends BaseHandler {
@@ -53,7 +54,7 @@ public class Scheduling extends BaseHandler {
         System.out.println("Goodbye, World! (after " + elapsedTime + " long milliseconds)");
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         Reactor reactor = Proton.reactor(new Scheduling());
         reactor.run();
     }

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Send.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Send.java
@@ -36,6 +36,7 @@ import org.apache.qpid.proton.engine.Session;
 import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.reactor.Handshaker;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 // This is a send in terms of low level AMQP events.
 public class Send extends BaseHandler {
@@ -131,7 +132,7 @@ public class Send extends BaseHandler {
         event.getReactor().connection(new SendHandler(hostname, message));
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         String hostname = args.length > 0 ? args[0] : "localhost";
         String content = args.length > 1 ? args[1] : "Hello World!";
 

--- a/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Unhandled.java
+++ b/examples/java/reactor/src/main/java/org/apache/qpid/proton/example/reactor/Unhandled.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.HandlerException;
 
 public class Unhandled extends BaseHandler {
 
@@ -39,7 +40,7 @@ public class Unhandled extends BaseHandler {
         System.out.println(event);
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         Reactor reactor = Proton.reactor(new Unhandled());
         reactor.run();
     }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/EventImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/EventImpl.java
@@ -38,12 +38,13 @@ import org.apache.qpid.proton.reactor.Task;
  *
  */
 
-class EventImpl implements Event
+public class EventImpl implements Event
 {
 
     Type type;
     Object context;
     EventImpl next;
+    Handler lastHandler;
 
     EventImpl()
     {
@@ -77,6 +78,7 @@ class EventImpl implements Event
     @Override
     public void dispatch(Handler handler)
     {
+        lastHandler = handler;
         switch (type) {
         case CONNECTION_INIT:
             handler.onConnectionInit(this);
@@ -207,6 +209,8 @@ class EventImpl implements Event
         while(children.hasNext()) {
             dispatch(children.next());
         }
+
+        lastHandler = null;
     }
 
     @Override
@@ -323,6 +327,10 @@ class EventImpl implements Event
        EventImpl newEvent = new EventImpl();
        newEvent.init(type, context);
        return newEvent;
+    }
+
+    public Handler getLastHandler() {
+        return lastHandler;
     }
 
     @Override

--- a/proton-j/src/main/java/org/apache/qpid/proton/reactor/HandlerException.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/reactor/HandlerException.java
@@ -1,0 +1,40 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.proton.reactor;
+
+import org.apache.qpid.proton.engine.Handler;
+
+public class HandlerException extends Exception {
+
+    private static final long serialVersionUID = 5300211824119834005L;
+
+    private final Handler handler;
+
+    public HandlerException(Handler handler, Throwable cause) {
+        super(cause);
+        this.handler = handler;
+    }
+
+    public Handler getHandler() {
+        return handler;
+    }
+}

--- a/proton-j/src/main/java/org/apache/qpid/proton/reactor/Reactor.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/reactor/Reactor.java
@@ -72,15 +72,15 @@ public interface Reactor {
 
     public boolean quiesced();
 
-    public boolean process();
+    public boolean process() throws HandlerException;
 
     public void wakeup() throws IOException;
 
     public void start() ;
 
-    public void stop() ;
+    public void stop() throws HandlerException;
 
-    public void run();
+    public void run() throws HandlerException;
 
     // pn_reactor_schedule from reactor.c
     public Task schedule(int delay, Handler handler);

--- a/tests/java/org/apache/qpid/proton/ProtonJInterop.java
+++ b/tests/java/org/apache/qpid/proton/ProtonJInterop.java
@@ -37,6 +37,7 @@ import org.apache.qpid.proton.engine.Session;
 import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.reactor.Acceptor;
 import org.apache.qpid.proton.reactor.FlowController;
+import org.apache.qpid.proton.reactor.HandlerException;
 import org.apache.qpid.proton.reactor.Handshaker;
 import org.apache.qpid.proton.reactor.Reactor;
 
@@ -178,7 +179,7 @@ public class ProtonJInterop {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, HandlerException {
         try {
             int port = Integer.valueOf(args[1]);
             int numMsgs = Integer.valueOf(args[2]);


### PR DESCRIPTION
Adds support for more gracefully handling runtime exceptions thrown from within a handler.

When a runtime (unchecked) exceptions is thrown within a handler, the reactor now catches it and throws a HandlerException (which is a checked exception).  The HandlerException references the Handler that threw the original exception and also chains the original exception as its "cause".

One facet of this PR that I'm not 100% happy with is the changes to EventImpl.  Really EventImpl.dispatch() should throw HandlerException - but this would be a pretty disruptive change, so instead I've added a 'lastHandler' attribute to the class which remembers the last handler to be dispatched.  This means that if a handler throws an exception inside the dispatch() method the calling class can discover which handler was responsible (even if dispatch() has recursed  into one, or more, level of child handler).

If there's a better way to do this (I'm sure it'll be really obvious in hindsight...), please let me know and I'll resubmit the PR with the changes.