### PR TITLE
PROTON-931: proton-j expose detached state of Link

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/Link.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/Link.java
@@ -186,5 +186,6 @@ public interface Link extends Endpoint
     public boolean getDrain();
 
     public void detach();
+    public boolean detached();
 
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/LinkImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/LinkImpl.java
@@ -413,7 +413,7 @@ public abstract class LinkImpl extends EndpointImpl implements Link
         modified();
     }
 
-    boolean detached()
+    public boolean detached()
     {
         return _detached;
     }


### PR DESCRIPTION
The Link detached state is required to assess when a
LINK_REMOTE_DETACHED event is received as to whether or not it was as a
result of a local detach or the remote end detaching or closing the
link.