### PR TITLE
PROTON-936 session outgoing window handling

### DIFF
--- a/proton-c/bindings/python/proton/__init__.py
+++ b/proton-c/bindings/python/proton/__init__.py
@@ -2571,6 +2571,14 @@ class Session(Wrapper, Endpoint):
 
   incoming_capacity = property(_get_incoming_capacity, _set_incoming_capacity)
 
+  def _get_outgoing_window(self):
+    return pn_session_get_outgoing_window(self._impl)
+
+  def _set_outgoing_window(self, window):
+    pn_session_set_outgoing_window(self._impl, window)
+
+  outgoing_window = property(_get_outgoing_window, _set_outgoing_window)
+
   @property
   def outgoing_bytes(self):
     return pn_session_outgoing_bytes(self._impl)

--- a/proton-c/include/proton/session.h
+++ b/proton-c/include/proton/session.h
@@ -216,6 +216,22 @@ PN_EXTERN size_t pn_session_get_incoming_capacity(pn_session_t *session);
 PN_EXTERN void pn_session_set_incoming_capacity(pn_session_t *session, size_t capacity);
 
 /**
+ * Get the outgoing window for a session object.
+ *
+ * @param[in] session the session object
+ * @return  the outgoing window for the session
+ */
+PN_EXTERN size_t pn_session_get_outgoing_window(pn_session_t *session);
+
+/**
+ * Set the outgoing window for a session object.
+ *
+ * @param[in] session the session object
+ * @param[in] window the outgoing window for the session
+ */
+PN_EXTERN void pn_session_set_outgoing_window(pn_session_t *session, size_t window);
+
+/**
  * Get the number of outgoing bytes currently buffered by a session.
  *
  * @param[in] session a session object

--- a/proton-c/src/engine/engine-internal.h
+++ b/proton-c/src/engine/engine-internal.h
@@ -246,6 +246,7 @@ struct pn_session_t {
   pn_sequence_t outgoing_bytes;
   pn_sequence_t incoming_deliveries;
   pn_sequence_t outgoing_deliveries;
+  pn_sequence_t outgoing_window;
   pn_session_state_t state;
 };
 

--- a/proton-c/src/engine/engine.c
+++ b/proton-c/src/engine/engine.c
@@ -991,6 +991,7 @@ pn_session_t *pn_session(pn_connection_t *conn)
   ssn->outgoing_bytes = 0;
   ssn->incoming_deliveries = 0;
   ssn->outgoing_deliveries = 0;
+  ssn->outgoing_window = 2147483647;
 
   // begin transport state
   memset(&ssn->state, 0, sizeof(ssn->state));
@@ -1041,6 +1042,18 @@ void pn_session_set_incoming_capacity(pn_session_t *ssn, size_t capacity)
   assert(ssn);
   // XXX: should this trigger a flow?
   ssn->incoming_capacity = capacity;
+}
+
+size_t pn_session_get_outgoing_window(pn_session_t *ssn)
+{
+  assert(ssn);
+  return ssn->outgoing_window;
+}
+
+void pn_session_set_outgoing_window(pn_session_t *ssn, size_t window)
+{
+  assert(ssn);
+  ssn->outgoing_window = window;
 }
 
 size_t pn_session_outgoing_bytes(pn_session_t *ssn)

--- a/proton-c/src/transport/transport.c
+++ b/proton-c/src/transport/transport.c
@@ -1909,16 +1909,7 @@ static uint16_t allocate_alias(pn_hash_t *aliases, uint32_t max_index, int * val
 
 static size_t pni_session_outgoing_window(pn_session_t *ssn)
 {
-  uint32_t size = ssn->connection->transport->remote_max_frame;
-  if (!size) {
-    return ssn->outgoing_deliveries;
-  } else {
-    pn_sequence_t frames = ssn->outgoing_bytes/size;
-    if (ssn->outgoing_bytes % size) {
-      frames++;
-    }
-    return pn_max(frames, ssn->outgoing_deliveries);
-  }
+  return ssn->outgoing_window;
 }
 
 static size_t pni_session_incoming_window(pn_session_t *ssn)

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/Session.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/Session.java
@@ -52,4 +52,12 @@ public interface Session extends Endpoint
 
     public int getOutgoingBytes();
 
+    public long getOutgoingWindow();
+
+    /**
+     * Sets the outgoing window size.
+     *
+     * @param outgoingWindowSize the outgoing window size
+     */
+    public void setOutgoingWindow(long outgoingWindowSize);
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SessionImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SessionImpl.java
@@ -44,6 +44,7 @@ public class SessionImpl extends EndpointImpl implements ProtonJSession
     private int _outgoingBytes = 0;
     private int _incomingDeliveries = 0;
     private int _outgoingDeliveries = 0;
+    private long _outgoingWindow = Integer.MAX_VALUE;
 
     private LinkNode<SessionImpl> _node;
 
@@ -269,5 +270,22 @@ public class SessionImpl extends EndpointImpl implements ProtonJSession
     void localClose()
     {
         getConnectionImpl().put(Event.Type.SESSION_LOCAL_CLOSE, this);
+    }
+
+    @Override
+    public void setOutgoingWindow(long outgoingWindow) {
+        if(outgoingWindow < 0 || outgoingWindow > 0xFFFFFFFFL)
+        {
+            throw new IllegalArgumentException("Value '" + outgoingWindow + "' must be in the"
+                    + " range [0 - 2^32-1]");
+        }
+
+        _outgoingWindow = outgoingWindow;
+    }
+
+    @Override
+    public long getOutgoingWindow()
+    {
+        return _outgoingWindow;
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -448,7 +448,7 @@ public class TransportImpl extends EndpointImpl
         Flow flow = new Flow();
         flow.setNextIncomingId(ssn.getNextIncomingId());
         flow.setNextOutgoingId(ssn.getNextOutgoingId());
-        ssn.updateWindows();
+        ssn.updateIncomingWindow();
         flow.setIncomingWindow(ssn.getIncomingWindowSize());
         flow.setOutgoingWindow(ssn.getOutgoingWindowSize());
         if (link != null) {

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportSession.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportSession.java
@@ -70,6 +70,7 @@ class TransportSession
     {
         _transport = transport;
         _session = session;
+        _outgoingWindowSize = UnsignedInteger.valueOf(session.getOutgoingWindow());
     }
 
     void unbind()
@@ -175,31 +176,13 @@ class TransportSession
         return _incomingWindowSize;
     }
 
-    public void updateWindows()
+    void updateIncomingWindow()
     {
-        // incoming window
         int size = _transport.getMaxFrameSize();
         if (size <= 0) {
             _incomingWindowSize = UnsignedInteger.valueOf(2147483647); // biggest legal value
         } else {
             _incomingWindowSize = UnsignedInteger.valueOf((_session.getIncomingCapacity() - _session.getIncomingBytes())/size);
-        }
-
-        // outgoing window
-        int outgoingDeliveries = _session.getOutgoingDeliveries();
-        if (size <= 0) {
-            _outgoingWindowSize = UnsignedInteger.valueOf(outgoingDeliveries);
-        } else {
-            int outgoingBytes = _session.getOutgoingBytes();
-            int frames = outgoingBytes/size;
-            if (outgoingBytes % size > 0) {
-                frames++;
-            }
-            if (frames > outgoingDeliveries) {
-                _outgoingWindowSize = UnsignedInteger.valueOf(frames);
-            } else {
-                _outgoingWindowSize = UnsignedInteger.valueOf(outgoingDeliveries);
-            }
         }
     }
 

--- a/proton-j/src/main/resources/cengine.py
+++ b/proton-j/src/main/resources/cengine.py
@@ -280,6 +280,12 @@ def pn_session_incoming_bytes(ssn):
 def pn_session_outgoing_bytes(ssn):
   return ssn.impl.getOutgoingBytes()
 
+def pn_session_get_outgoing_window(ssn):
+  return ssn.impl.getOutgoingWindow()
+
+def pn_session_set_outgoing_window(ssn, window):
+  ssn.impl.setOutgoingWindow(window)
+
 def pn_session_condition(ssn):
   return ssn.condition
 

--- a/tests/python/proton_tests/engine.py
+++ b/tests/python/proton_tests/engine.py
@@ -506,6 +506,12 @@ class SessionTest(Test):
     assert snd.state == Endpoint.LOCAL_ACTIVE | Endpoint.REMOTE_ACTIVE
     assert rcv.state == Endpoint.LOCAL_ACTIVE | Endpoint.REMOTE_ACTIVE
 
+  def test_set_get_outgoing_window(self):
+    assert self.ssn.outgoing_window == 2147483647
+
+    self.ssn.outgoing_window = 1024
+    assert self.ssn.outgoing_window == 1024
+
 
 class LinkTest(Test):
 


### PR DESCRIPTION
As discussed on the mailing lists [1], proton currently sets the outgoing window to 0 in most cases (except when using Messenger), but then sends messages anyway if allowed by the current remote-outgoing-window. This means it is typically violating the advertised window. Additionally, Service Bus uses the outgoing window to initialise its incoming window, which means it is set to 0 and we can never send it any messages.

This is an initial attempt at an update based on the discussions. It sets the outgoing window to a fixed default value of max int, and adds a setter to allow users of the engine to adjust it. Mainly looking for feedback on the approach and whether I have committed any atrocities on the C/python side, as I basically cut and paste all of those changes after grep'ing use of other fields/methods.

There is a basic test that the default exists and the getter+setter work, but that is all as we dont actually use the [remote] outgoing window for anything in proton currently so seems to be no way to inspect things.

[1] http://mail-archives.apache.org/mod_mbox/qpid-users/201507.mbox/%3CCAFitrpQoK8SFgd1xXPtc9PeNWwWcEqtJgN8ZN88RBj3u6fwdag%40mail.gmail.com%3E
