### PR TITLE
-Fix 2 Code Analysis warnings and a realloc failure

### DIFF
--- a/proton-c/include/proton/error.h
+++ b/proton-c/include/proton/error.h
@@ -40,6 +40,7 @@ typedef struct pn_error_t pn_error_t;
 #define PN_TIMEOUT (-7)
 #define PN_INTR (-8)
 #define PN_INPROGRESS (-9)
+#define PN_OUT_OF_MEMORY (-10)
 
 PN_EXTERN const char *pn_code(int code);
 

--- a/proton-c/src/codec/codec.c
+++ b/proton-c/src/codec/codec.c
@@ -1116,15 +1116,11 @@ static size_t pni_data_id(pn_data_t *data, pni_node_t *node)
 static pni_node_t *pni_data_new(pn_data_t *data)
 {
   pni_node_t *node;
-  if ((data->capacity <= data->size) && (pni_data_grow(data) != 0)) {
-    node = NULL;
-  }
-  else {
-    node = pn_data_node(data, ++(data->size));
-    node->next = 0;
-    node->down = 0;
-    node->children = 0;
-  }
+  if ((data->capacity <= data->size) && (pni_data_grow(data) != 0)) return NULL;
+  node = pn_data_node(data, ++(data->size));
+  node->next = 0;
+  node->down = 0;
+  node->children = 0;
   return node;
 }
 
@@ -1644,45 +1640,37 @@ int pn_data_put_uuid(pn_data_t *data, pn_uuid_t u)
 
 int pn_data_put_binary(pn_data_t *data, pn_bytes_t bytes)
 {
-  int result;
   pni_node_t *node = pni_data_add(data);
   if (node == NULL) return PN_ERR;
   node->atom.type = PN_BINARY;
   node->atom.u.as_bytes = bytes;
-  result = pni_data_intern_node(data, node);
-  return result;
+  return pni_data_intern_node(data, node);
 }
 
 int pn_data_put_string(pn_data_t *data, pn_bytes_t string)
 {
-  int result;
   pni_node_t *node = pni_data_add(data);
   if (node == NULL) return PN_ERR;
   node->atom.type = PN_STRING;
   node->atom.u.as_bytes = string;
-  result = pni_data_intern_node(data, node);
-  return result;
+  return pni_data_intern_node(data, node);
 }
 
 int pn_data_put_symbol(pn_data_t *data, pn_bytes_t symbol)
 {
-  int result;
   pni_node_t *node = pni_data_add(data);
   if (node == NULL) return PN_ERR;
   node->atom.type = PN_SYMBOL;
   node->atom.u.as_bytes = symbol;
-  result = pni_data_intern_node(data, node);
-  return result;
+  return pni_data_intern_node(data, node);
 }
 
 int pn_data_put_atom(pn_data_t *data, pn_atom_t atom)
 {
-  int result;
   pni_node_t *node = pni_data_add(data);
   if (node == NULL) return PN_ERR;
   node->atom = atom;
-  result = pni_data_intern_node(data, node);
-  return result;
+  return pni_data_intern_node(data, node);
 }
 
 size_t pn_data_get_list(pn_data_t *data)

--- a/proton-c/src/codec/codec.c
+++ b/proton-c/src/codec/codec.c
@@ -417,8 +417,12 @@ void pn_data_clear(pn_data_t *data)
 
 static int pni_data_grow(pn_data_t *data)
 {
-  data->capacity = 2*(data->capacity ? data->capacity : 2);
-  data->nodes = (pni_node_t *) realloc(data->nodes, data->capacity * sizeof(pni_node_t));
+  pni_node_t * new_nodes;
+  pni_nid_t new_capacity = 2 * (data->capacity ? data->capacity : 2);
+  new_nodes = (pni_node_t *)realloc(data->nodes, new_capacity * sizeof(pni_node_t));
+  if (new_nodes == NULL) return PN_OUT_OF_MEMORY;
+  data->capacity = new_capacity;
+  data->nodes = new_nodes;
   return 0;
 }
 
@@ -1111,13 +1115,16 @@ static size_t pni_data_id(pn_data_t *data, pni_node_t *node)
 
 static pni_node_t *pni_data_new(pn_data_t *data)
 {
-  if (data->capacity <= data->size) {
-    pni_data_grow(data);
+  pni_node_t *node;
+  if ((data->capacity <= data->size) && (pni_data_grow(data) != 0)) {
+    node = NULL;
   }
-  pni_node_t *node = pn_data_node(data, ++(data->size));
-  node->next = 0;
-  node->down = 0;
-  node->children = 0;
+  else {
+    node = pn_data_node(data, ++(data->size));
+    node->next = 0;
+    node->down = 0;
+    node->children = 0;
+  }
   return node;
 }
 
@@ -1369,17 +1376,19 @@ static pni_node_t *pni_data_add(pn_data_t *data)
       node = pn_data_node(data, current->next);
     } else {
       node = pni_data_new(data);
-      // refresh the pointers in case we grew
-      current = pni_data_current(data);
-      parent = pn_data_node(data, data->parent);
-      node->prev = data->current;
-      current->next = pni_data_id(data, node);
-      node->parent = data->parent;
-      if (parent) {
-        if (!parent->down) {
-          parent->down = pni_data_id(data, node);
+      if (node != NULL) {
+        // refresh the pointers in case we grew
+        current = pni_data_current(data);
+        parent = pn_data_node(data, data->parent);
+        node->prev = data->current;
+        current->next = pni_data_id(data, node);
+        node->parent = data->parent;
+        if (parent) {
+          if (!parent->down) {
+            parent->down = pni_data_id(data, node);
+          }
+          parent->children++;
         }
-        parent->children++;
       }
     }
   } else if (parent) {
@@ -1387,27 +1396,33 @@ static pni_node_t *pni_data_add(pn_data_t *data)
       node = pn_data_node(data, parent->down);
     } else {
       node = pni_data_new(data);
-      // refresh the pointers in case we grew
-      parent = pn_data_node(data, data->parent);
-      node->prev = 0;
-      node->parent = data->parent;
-      parent->down = pni_data_id(data, node);
-      parent->children++;
+      if (node != NULL) {
+        // refresh the pointers in case we grew
+        parent = pn_data_node(data, data->parent);
+        node->prev = 0;
+        node->parent = data->parent;
+        parent->down = pni_data_id(data, node);
+        parent->children++;
+      }
     }
   } else if (data->size) {
     node = pn_data_node(data, 1);
   } else {
     node = pni_data_new(data);
-    node->prev = 0;
-    node->parent = 0;
+    if (node != NULL) {
+      node->prev = 0;
+      node->parent = 0;
+    }
   }
 
-  node->down = 0;
-  node->children = 0;
-  node->data = false;
-  node->data_offset = 0;
-  node->data_size = 0;
-  data->current = pni_data_id(data, node);
+  if (node != NULL) {
+    node->down = 0;
+    node->children = 0;
+    node->data = false;
+    node->data_offset = 0;
+    node->data_size = 0;
+    data->current = pni_data_id(data, node);
+  }
   return node;
 }
 
@@ -1429,6 +1444,7 @@ ssize_t pn_data_decode(pn_data_t *data, const char *bytes, size_t size)
 int pn_data_put_list(pn_data_t *data)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_LIST;
   return 0;
 }
@@ -1436,6 +1452,7 @@ int pn_data_put_list(pn_data_t *data)
 int pn_data_put_map(pn_data_t *data)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_MAP;
   return 0;
 }
@@ -1443,6 +1460,7 @@ int pn_data_put_map(pn_data_t *data)
 int pn_data_put_array(pn_data_t *data, bool described, pn_type_t type)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_ARRAY;
   node->described = described;
   node->type = type;
@@ -1458,6 +1476,7 @@ void pni_data_set_array_type(pn_data_t *data, pn_type_t type)
 int pn_data_put_described(pn_data_t *data)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_DESCRIBED;
   return 0;
 }
@@ -1465,6 +1484,7 @@ int pn_data_put_described(pn_data_t *data)
 int pn_data_put_null(pn_data_t *data)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   pni_atom_init(&node->atom, PN_NULL);
   return 0;
 }
@@ -1472,6 +1492,7 @@ int pn_data_put_null(pn_data_t *data)
 int pn_data_put_bool(pn_data_t *data, bool b)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_BOOL;
   node->atom.u.as_bool = b;
   return 0;
@@ -1480,6 +1501,7 @@ int pn_data_put_bool(pn_data_t *data, bool b)
 int pn_data_put_ubyte(pn_data_t *data, uint8_t ub)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_UBYTE;
   node->atom.u.as_ubyte = ub;
   return 0;
@@ -1488,6 +1510,7 @@ int pn_data_put_ubyte(pn_data_t *data, uint8_t ub)
 int pn_data_put_byte(pn_data_t *data, int8_t b)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_BYTE;
   node->atom.u.as_byte = b;
   return 0;
@@ -1496,6 +1519,7 @@ int pn_data_put_byte(pn_data_t *data, int8_t b)
 int pn_data_put_ushort(pn_data_t *data, uint16_t us)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_USHORT;
   node->atom.u.as_ushort = us;
   return 0;
@@ -1504,6 +1528,7 @@ int pn_data_put_ushort(pn_data_t *data, uint16_t us)
 int pn_data_put_short(pn_data_t *data, int16_t s)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_SHORT;
   node->atom.u.as_short = s;
   return 0;
@@ -1512,6 +1537,7 @@ int pn_data_put_short(pn_data_t *data, int16_t s)
 int pn_data_put_uint(pn_data_t *data, uint32_t ui)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_UINT;
   node->atom.u.as_uint = ui;
   return 0;
@@ -1520,6 +1546,7 @@ int pn_data_put_uint(pn_data_t *data, uint32_t ui)
 int pn_data_put_int(pn_data_t *data, int32_t i)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_INT;
   node->atom.u.as_int = i;
   return 0;
@@ -1528,6 +1555,7 @@ int pn_data_put_int(pn_data_t *data, int32_t i)
 int pn_data_put_char(pn_data_t *data, pn_char_t c)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_CHAR;
   node->atom.u.as_char = c;
   return 0;
@@ -1536,6 +1564,7 @@ int pn_data_put_char(pn_data_t *data, pn_char_t c)
 int pn_data_put_ulong(pn_data_t *data, uint64_t ul)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_ULONG;
   node->atom.u.as_ulong = ul;
   return 0;
@@ -1544,6 +1573,7 @@ int pn_data_put_ulong(pn_data_t *data, uint64_t ul)
 int pn_data_put_long(pn_data_t *data, int64_t l)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_LONG;
   node->atom.u.as_long = l;
   return 0;
@@ -1552,6 +1582,7 @@ int pn_data_put_long(pn_data_t *data, int64_t l)
 int pn_data_put_timestamp(pn_data_t *data, pn_timestamp_t t)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_TIMESTAMP;
   node->atom.u.as_timestamp = t;
   return 0;
@@ -1560,6 +1591,7 @@ int pn_data_put_timestamp(pn_data_t *data, pn_timestamp_t t)
 int pn_data_put_float(pn_data_t *data, float f)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_FLOAT;
   node->atom.u.as_float = f;
   return 0;
@@ -1568,6 +1600,7 @@ int pn_data_put_float(pn_data_t *data, float f)
 int pn_data_put_double(pn_data_t *data, double d)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_DOUBLE;
   node->atom.u.as_double = d;
   return 0;
@@ -1576,6 +1609,7 @@ int pn_data_put_double(pn_data_t *data, double d)
 int pn_data_put_decimal32(pn_data_t *data, pn_decimal32_t d)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_DECIMAL32;
   node->atom.u.as_decimal32 = d;
   return 0;
@@ -1584,6 +1618,7 @@ int pn_data_put_decimal32(pn_data_t *data, pn_decimal32_t d)
 int pn_data_put_decimal64(pn_data_t *data, pn_decimal64_t d)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_DECIMAL64;
   node->atom.u.as_decimal64 = d;
   return 0;
@@ -1592,48 +1627,62 @@ int pn_data_put_decimal64(pn_data_t *data, pn_decimal64_t d)
 int pn_data_put_decimal128(pn_data_t *data, pn_decimal128_t d)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_DECIMAL128;
-  memmove(node->atom.u.as_decimal128.bytes, d.bytes, 16);
+  (void)memmove(node->atom.u.as_decimal128.bytes, d.bytes, 16);
   return 0;
 }
 
 int pn_data_put_uuid(pn_data_t *data, pn_uuid_t u)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_UUID;
-  memmove(node->atom.u.as_uuid.bytes, u.bytes, 16);
+  (void)memmove(node->atom.u.as_uuid.bytes, u.bytes, 16);
   return 0;
 }
 
 int pn_data_put_binary(pn_data_t *data, pn_bytes_t bytes)
 {
+  int result;
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_BINARY;
   node->atom.u.as_bytes = bytes;
-  return pni_data_intern_node(data, node);
+  result = pni_data_intern_node(data, node);
+  return result;
 }
 
 int pn_data_put_string(pn_data_t *data, pn_bytes_t string)
 {
+  int result;
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_STRING;
   node->atom.u.as_bytes = string;
-  return pni_data_intern_node(data, node);
+  result = pni_data_intern_node(data, node);
+  return result;
 }
 
 int pn_data_put_symbol(pn_data_t *data, pn_bytes_t symbol)
 {
+  int result;
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom.type = PN_SYMBOL;
   node->atom.u.as_bytes = symbol;
-  return pni_data_intern_node(data, node);
+  result = pni_data_intern_node(data, node);
+  return result;
 }
 
 int pn_data_put_atom(pn_data_t *data, pn_atom_t atom)
 {
+  int result;
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_ERR;
   node->atom = atom;
-  return pni_data_intern_node(data, node);
+  result = pni_data_intern_node(data, node);
+  return result;
 }
 
 size_t pn_data_get_list(pn_data_t *data)

--- a/proton-c/src/error.c
+++ b/proton-c/src/error.c
@@ -129,6 +129,7 @@ const char *pn_code(int code)
   case PN_ARG_ERR: return "PN_ARG_ERR";
   case PN_TIMEOUT: return "PN_TIMEOUT";
   case PN_INTR: return "PN_INTR";
+  case PN_OUT_OF_MEMORY: return "PN_OUT_OF_MEMORY";
   default: return "<unknown>";
   }
 }

--- a/proton-c/src/windows/iocp.c
+++ b/proton-c/src/windows/iocp.c
@@ -304,7 +304,7 @@ pn_socket_t pni_iocp_end_accept(iocpdesc_t *ld, sockaddr *addr, socklen_t *addrl
     pni_events_update(ld, ld->events & ~PN_READABLE);  // No pending accepts
 
   pn_socket_t accept_sock;
-  if (result->base.status) {
+  if (FAILED(result->base.status)) {
     accept_sock = INVALID_SOCKET;
     pni_win32_error(ld->error, "accept failure", result->base.status);
     if (ld->iocp->iocp_trace)
@@ -424,7 +424,7 @@ static void complete_connect(connect_result_t *result, HRESULT status)
     return;
   }
 
-  if (status) {
+  if (FAILED(status)) {
     iocpdesc_fail(iocpd, status, "Connect failure");
   } else {
     release_sys_sendbuf(iocpd->socket);


### PR DESCRIPTION
-Fix 2 Code Analysis warnings in iocp.c
-Fix one realloc leak and the fact that the realloc result was not checked. This rippled through codec.c as more functions needed to have error checking. Also, more fixes regarding return values being checked need to be done throughout message.c, transport.c, etc., but the amount of changes is significant, so it needs to be done in several chunks.