### PR TITLE
-Fix 2 Code Analysis warnings in iocp.c and a realloc leak

### DIFF
--- a/proton-c/include/proton/error.h
+++ b/proton-c/include/proton/error.h
@@ -40,6 +40,7 @@ typedef struct pn_error_t pn_error_t;
 #define PN_TIMEOUT (-7)
 #define PN_INTR (-8)
 #define PN_INPROGRESS (-9)
+#define PN_OUT_OF_MEMORY (-10)
 
 PN_EXTERN const char *pn_code(int code);
 
@@ -52,6 +53,12 @@ PN_EXTERN int pn_error_format(pn_error_t *error, int code, const char *fmt, ...)
 PN_EXTERN int pn_error_code(pn_error_t *error);
 PN_EXTERN const char *pn_error_text(pn_error_t *error);
 PN_EXTERN int pn_error_copy(pn_error_t *error, pn_error_t *src);
+
+#define PN_RETURN_IF_ERROR(x) \
+do {\
+int r = (x);\
+if (r != 0) return r; \
+} while (0)
 
 #ifdef __cplusplus
 }

--- a/proton-c/src/codec/codec.c
+++ b/proton-c/src/codec/codec.c
@@ -417,8 +417,12 @@ void pn_data_clear(pn_data_t *data)
 
 static int pni_data_grow(pn_data_t *data)
 {
-  data->capacity = 2*(data->capacity ? data->capacity : 2);
-  data->nodes = (pni_node_t *) realloc(data->nodes, data->capacity * sizeof(pni_node_t));
+  pni_node_t * new_nodes;
+  pni_nid_t new_capacity = 2 * (data->capacity ? data->capacity : 2);
+  new_nodes = (pni_node_t *)realloc(data->nodes, new_capacity * sizeof(pni_node_t));
+  if (new_nodes == NULL) return PN_OUT_OF_MEMORY;
+  data->capacity = new_capacity;
+  data->nodes = new_nodes;
   return 0;
 }
 
@@ -1111,10 +1115,9 @@ static size_t pni_data_id(pn_data_t *data, pni_node_t *node)
 
 static pni_node_t *pni_data_new(pn_data_t *data)
 {
-  if (data->capacity <= data->size) {
-    pni_data_grow(data);
-  }
-  pni_node_t *node = pn_data_node(data, ++(data->size));
+  pni_node_t *node;
+  if ((data->capacity <= data->size) && (pni_data_grow(data) != 0)) return NULL;
+  node = pn_data_node(data, ++(data->size));
   node->next = 0;
   node->down = 0;
   node->children = 0;
@@ -1369,17 +1372,19 @@ static pni_node_t *pni_data_add(pn_data_t *data)
       node = pn_data_node(data, current->next);
     } else {
       node = pni_data_new(data);
-      // refresh the pointers in case we grew
-      current = pni_data_current(data);
-      parent = pn_data_node(data, data->parent);
-      node->prev = data->current;
-      current->next = pni_data_id(data, node);
-      node->parent = data->parent;
-      if (parent) {
-        if (!parent->down) {
-          parent->down = pni_data_id(data, node);
+      if (node != NULL) {
+        // refresh the pointers in case we grew
+        current = pni_data_current(data);
+        parent = pn_data_node(data, data->parent);
+        node->prev = data->current;
+        current->next = pni_data_id(data, node);
+        node->parent = data->parent;
+        if (parent) {
+          if (!parent->down) {
+            parent->down = pni_data_id(data, node);
+          }
+          parent->children++;
         }
-        parent->children++;
       }
     }
   } else if (parent) {
@@ -1387,27 +1392,33 @@ static pni_node_t *pni_data_add(pn_data_t *data)
       node = pn_data_node(data, parent->down);
     } else {
       node = pni_data_new(data);
-      // refresh the pointers in case we grew
-      parent = pn_data_node(data, data->parent);
-      node->prev = 0;
-      node->parent = data->parent;
-      parent->down = pni_data_id(data, node);
-      parent->children++;
+      if (node != NULL) {
+        // refresh the pointers in case we grew
+        parent = pn_data_node(data, data->parent);
+        node->prev = 0;
+        node->parent = data->parent;
+        parent->down = pni_data_id(data, node);
+        parent->children++;
+      }
     }
   } else if (data->size) {
     node = pn_data_node(data, 1);
   } else {
     node = pni_data_new(data);
-    node->prev = 0;
-    node->parent = 0;
+    if (node != NULL) {
+      node->prev = 0;
+      node->parent = 0;
+    }
   }
 
-  node->down = 0;
-  node->children = 0;
-  node->data = false;
-  node->data_offset = 0;
-  node->data_size = 0;
-  data->current = pni_data_id(data, node);
+  if (node != NULL) {
+    node->down = 0;
+    node->children = 0;
+    node->data = false;
+    node->data_offset = 0;
+    node->data_size = 0;
+    data->current = pni_data_id(data, node);
+  }
   return node;
 }
 
@@ -1429,6 +1440,7 @@ ssize_t pn_data_decode(pn_data_t *data, const char *bytes, size_t size)
 int pn_data_put_list(pn_data_t *data)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_LIST;
   return 0;
 }
@@ -1436,6 +1448,7 @@ int pn_data_put_list(pn_data_t *data)
 int pn_data_put_map(pn_data_t *data)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_MAP;
   return 0;
 }
@@ -1443,6 +1456,7 @@ int pn_data_put_map(pn_data_t *data)
 int pn_data_put_array(pn_data_t *data, bool described, pn_type_t type)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_ARRAY;
   node->described = described;
   node->type = type;
@@ -1458,6 +1472,7 @@ void pni_data_set_array_type(pn_data_t *data, pn_type_t type)
 int pn_data_put_described(pn_data_t *data)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_DESCRIBED;
   return 0;
 }
@@ -1465,6 +1480,7 @@ int pn_data_put_described(pn_data_t *data)
 int pn_data_put_null(pn_data_t *data)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   pni_atom_init(&node->atom, PN_NULL);
   return 0;
 }
@@ -1472,6 +1488,7 @@ int pn_data_put_null(pn_data_t *data)
 int pn_data_put_bool(pn_data_t *data, bool b)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_BOOL;
   node->atom.u.as_bool = b;
   return 0;
@@ -1480,6 +1497,7 @@ int pn_data_put_bool(pn_data_t *data, bool b)
 int pn_data_put_ubyte(pn_data_t *data, uint8_t ub)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_UBYTE;
   node->atom.u.as_ubyte = ub;
   return 0;
@@ -1488,6 +1506,7 @@ int pn_data_put_ubyte(pn_data_t *data, uint8_t ub)
 int pn_data_put_byte(pn_data_t *data, int8_t b)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_BYTE;
   node->atom.u.as_byte = b;
   return 0;
@@ -1496,6 +1515,7 @@ int pn_data_put_byte(pn_data_t *data, int8_t b)
 int pn_data_put_ushort(pn_data_t *data, uint16_t us)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_USHORT;
   node->atom.u.as_ushort = us;
   return 0;
@@ -1504,6 +1524,7 @@ int pn_data_put_ushort(pn_data_t *data, uint16_t us)
 int pn_data_put_short(pn_data_t *data, int16_t s)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_SHORT;
   node->atom.u.as_short = s;
   return 0;
@@ -1512,6 +1533,7 @@ int pn_data_put_short(pn_data_t *data, int16_t s)
 int pn_data_put_uint(pn_data_t *data, uint32_t ui)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_UINT;
   node->atom.u.as_uint = ui;
   return 0;
@@ -1520,6 +1542,7 @@ int pn_data_put_uint(pn_data_t *data, uint32_t ui)
 int pn_data_put_int(pn_data_t *data, int32_t i)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_INT;
   node->atom.u.as_int = i;
   return 0;
@@ -1528,6 +1551,7 @@ int pn_data_put_int(pn_data_t *data, int32_t i)
 int pn_data_put_char(pn_data_t *data, pn_char_t c)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_CHAR;
   node->atom.u.as_char = c;
   return 0;
@@ -1536,6 +1560,7 @@ int pn_data_put_char(pn_data_t *data, pn_char_t c)
 int pn_data_put_ulong(pn_data_t *data, uint64_t ul)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_ULONG;
   node->atom.u.as_ulong = ul;
   return 0;
@@ -1544,6 +1569,7 @@ int pn_data_put_ulong(pn_data_t *data, uint64_t ul)
 int pn_data_put_long(pn_data_t *data, int64_t l)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_LONG;
   node->atom.u.as_long = l;
   return 0;
@@ -1552,6 +1578,7 @@ int pn_data_put_long(pn_data_t *data, int64_t l)
 int pn_data_put_timestamp(pn_data_t *data, pn_timestamp_t t)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_TIMESTAMP;
   node->atom.u.as_timestamp = t;
   return 0;
@@ -1560,6 +1587,7 @@ int pn_data_put_timestamp(pn_data_t *data, pn_timestamp_t t)
 int pn_data_put_float(pn_data_t *data, float f)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_FLOAT;
   node->atom.u.as_float = f;
   return 0;
@@ -1568,6 +1596,7 @@ int pn_data_put_float(pn_data_t *data, float f)
 int pn_data_put_double(pn_data_t *data, double d)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_DOUBLE;
   node->atom.u.as_double = d;
   return 0;
@@ -1576,6 +1605,7 @@ int pn_data_put_double(pn_data_t *data, double d)
 int pn_data_put_decimal32(pn_data_t *data, pn_decimal32_t d)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_DECIMAL32;
   node->atom.u.as_decimal32 = d;
   return 0;
@@ -1584,6 +1614,7 @@ int pn_data_put_decimal32(pn_data_t *data, pn_decimal32_t d)
 int pn_data_put_decimal64(pn_data_t *data, pn_decimal64_t d)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_DECIMAL64;
   node->atom.u.as_decimal64 = d;
   return 0;
@@ -1592,6 +1623,7 @@ int pn_data_put_decimal64(pn_data_t *data, pn_decimal64_t d)
 int pn_data_put_decimal128(pn_data_t *data, pn_decimal128_t d)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_DECIMAL128;
   memmove(node->atom.u.as_decimal128.bytes, d.bytes, 16);
   return 0;
@@ -1600,6 +1632,7 @@ int pn_data_put_decimal128(pn_data_t *data, pn_decimal128_t d)
 int pn_data_put_uuid(pn_data_t *data, pn_uuid_t u)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_UUID;
   memmove(node->atom.u.as_uuid.bytes, u.bytes, 16);
   return 0;
@@ -1608,6 +1641,7 @@ int pn_data_put_uuid(pn_data_t *data, pn_uuid_t u)
 int pn_data_put_binary(pn_data_t *data, pn_bytes_t bytes)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_BINARY;
   node->atom.u.as_bytes = bytes;
   return pni_data_intern_node(data, node);
@@ -1616,6 +1650,7 @@ int pn_data_put_binary(pn_data_t *data, pn_bytes_t bytes)
 int pn_data_put_string(pn_data_t *data, pn_bytes_t string)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_STRING;
   node->atom.u.as_bytes = string;
   return pni_data_intern_node(data, node);
@@ -1624,6 +1659,7 @@ int pn_data_put_string(pn_data_t *data, pn_bytes_t string)
 int pn_data_put_symbol(pn_data_t *data, pn_bytes_t symbol)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom.type = PN_SYMBOL;
   node->atom.u.as_bytes = symbol;
   return pni_data_intern_node(data, node);
@@ -1632,6 +1668,7 @@ int pn_data_put_symbol(pn_data_t *data, pn_bytes_t symbol)
 int pn_data_put_atom(pn_data_t *data, pn_atom_t atom)
 {
   pni_node_t *node = pni_data_add(data);
+  if (node == NULL) return PN_OUT_OF_MEMORY;
   node->atom = atom;
   return pni_data_intern_node(data, node);
 }

--- a/proton-c/src/error.c
+++ b/proton-c/src/error.c
@@ -129,6 +129,7 @@ const char *pn_code(int code)
   case PN_ARG_ERR: return "PN_ARG_ERR";
   case PN_TIMEOUT: return "PN_TIMEOUT";
   case PN_INTR: return "PN_INTR";
+  case PN_OUT_OF_MEMORY: return "PN_OUT_OF_MEMORY";
   default: return "<unknown>";
   }
 }

--- a/proton-c/src/transport/transport.c
+++ b/proton-c/src/transport/transport.c
@@ -798,35 +798,34 @@ bool pni_disposition_batchable(pn_disposition_t *disposition)
   }
 }
 
-void pni_disposition_encode(pn_disposition_t *disposition, pn_data_t *data)
+static int pni_disposition_encode(pn_disposition_t *disposition, pn_data_t *data)
 {
   pn_condition_t *cond = &disposition->condition;
   switch (disposition->type) {
   case PN_RECEIVED:
-    pn_data_put_list(data);
-    pn_data_enter(data);
-    pn_data_put_uint(data, disposition->section_number);
-    pn_data_put_ulong(data, disposition->section_offset);
-    pn_data_exit(data);
-    break;
+    {
+      PN_RETURN_IF_ERROR(pn_data_put_list(data));
+      if (!pn_data_enter(data)) return PN_ERR;
+      PN_RETURN_IF_ERROR(pn_data_put_uint(data, disposition->section_number));
+      PN_RETURN_IF_ERROR(pn_data_put_ulong(data, disposition->section_offset));
+      if (!pn_data_exit(data)) return PN_ERR;
+      return 0;
+    }
   case PN_ACCEPTED:
   case PN_RELEASED:
-    return;
+    return 0;
   case PN_REJECTED:
-    pn_data_fill(data, "[?DL[sSC]]", pn_condition_is_set(cond), ERROR,
+    return pn_data_fill(data, "[?DL[sSC]]", pn_condition_is_set(cond), ERROR,
                  pn_condition_get_name(cond),
                  pn_condition_get_description(cond),
                  pn_condition_info(cond));
-    break;
   case PN_MODIFIED:
-    pn_data_fill(data, "[ooC]",
+    return pn_data_fill(data, "[ooC]",
                  disposition->failed,
                  disposition->undeliverable,
                  disposition->annotations);
-    break;
   default:
-    pn_data_copy(data, disposition->data);
-    break;
+    return pn_data_copy(data, disposition->data);
   }
 }
 
@@ -2133,11 +2132,11 @@ static int pni_post_disp(pn_transport_t *transport, pn_delivery_t *delivery)
 
   if (!pni_disposition_batchable(&delivery->local)) {
     pn_data_clear(transport->disp_data);
-    pni_disposition_encode(&delivery->local, transport->disp_data);
+    PN_RETURN_IF_ERROR(pni_disposition_encode(&delivery->local, transport->disp_data));
     return pn_post_frame(transport, AMQP_FRAME_TYPE, ssn->state.local_channel,
-                         "DL[oIIo?DLC]", DISPOSITION,
-                         role, state->id, state->id, delivery->local.settled,
-                         (bool)code, code, transport->disp_data);
+      "DL[oIIo?DLC]", DISPOSITION,
+      role, state->id, state->id, delivery->local.settled,
+      (bool)code, code, transport->disp_data);
   }
 
   if (ssn_state->disp && code == ssn_state->disp_code &&
@@ -2186,8 +2185,7 @@ static int pni_process_tpwork_sender(pn_transport_t *transport, pn_delivery_t *d
       size_t full_size = bytes.size;
       pn_bytes_t tag = pn_buffer_bytes(delivery->tag);
       pn_data_clear(transport->disp_data);
-      pni_disposition_encode(&delivery->local, transport->disp_data);
-
+      PN_RETURN_IF_ERROR(pni_disposition_encode(&delivery->local, transport->disp_data));
       int count = pni_post_amqp_transfer_frame(transport,
                                               ssn_state->local_channel,
                                               link_state->local_handle,

--- a/proton-c/src/windows/iocp.c
+++ b/proton-c/src/windows/iocp.c
@@ -304,7 +304,7 @@ pn_socket_t pni_iocp_end_accept(iocpdesc_t *ld, sockaddr *addr, socklen_t *addrl
     pni_events_update(ld, ld->events & ~PN_READABLE);  // No pending accepts
 
   pn_socket_t accept_sock;
-  if (result->base.status) {
+  if (FAILED(result->base.status)) {
     accept_sock = INVALID_SOCKET;
     pni_win32_error(ld->error, "accept failure", result->base.status);
     if (ld->iocp->iocp_trace)
@@ -424,7 +424,7 @@ static void complete_connect(connect_result_t *result, HRESULT status)
     return;
   }
 
-  if (status) {
+  if (FAILED(status)) {
     iocpdesc_fail(iocpd, status, "Connect failure");
   } else {
     release_sys_sendbuf(iocpd->socket);


### PR DESCRIPTION
-Fix one realloc leak and the fact that the realloc result was not checked. This rippled through codec.c as more functions needed to have error checking. Also, more fixes regarding return values being checked need to be done throughout message.c, transport.c, etc., but the amount of changes is significant, so it needs to be done in several chunks.