### PR TITLE
proton-c: fix C compiler detection with _ARG1/_ARG2

### DIFF
--- a/proton-c/CMakeLists.txt
+++ b/proton-c/CMakeLists.txt
@@ -218,7 +218,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
     set (COMPILE_LANGUAGE_FLAGS "-std=c99")
     set (COMPILE_PLATFORM_FLAGS "-std=gnu99")
 
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION
+    execute_process(COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1} ${CMAKE_C_COMPILER_ARG2} -dumpversion OUTPUT_VARIABLE GCC_VERSION
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     if (${GCC_VERSION} VERSION_LESS "4.3.0")
       # Only a concern if contibuting code back.


### PR DESCRIPTION
The C compiler commandline in CMake is composed by the concatenation of
CMAKE_C_COMPILER + CMAKE_C_COMPILER_ARG1 + CMAKE_C_COMPILER_ARG2.

In most use cases the two additional argument variables are empty, thus
CMAKE_C_COMPILER can be used without any noticeable difference.

The Buildroot embedded Linux build system [0], however, optionally exploits the
CMAKE_C_COMPILER_ARG1 variable to speed up the cross-compilation of CMake-based
packages using ccache. It does so by setting [1]:

  CMAKE_C_COMPILER      = /path/to/ccache
  CMAKE_C_COMPILER_ARG1 = /path/to/cross-gcc

This works fine with other CMake-based packages, but proton-c's CMakeLists.txt
calls gcc to extract the compiler version. It does so by calling
"${CMAKE_C_COMPILER} -dumpversion", without honoring the two extra arguments.
Within Buildroot with ccache enabled, this means calling
"/path/to/ccache -dumpversion", which fails with the error:

  ccache: invalid option -- 'd'

Fix the compiler check by adding the two arguments.

[0] http://buildroot.net/
[1] http://git.buildroot.net/buildroot/tree/support/misc/toolchainfile.cmake.in?id=2015.05

Signed-off-by: Luca Ceresoli <luca@lucaceresoli.net>