### PR TITLE
PROTON-984: Document proton-j time units

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/Transport.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/Transport.java
@@ -224,6 +224,10 @@ public interface Transport extends Endpoint
 
     ErrorCondition getCondition();
 
+    /**
+     * 
+     * @param timeout in ???UNITS???
+     */
     void setIdleTimeout(int timeout);
     int getIdleTimeout();
     int getRemoteIdleTimeout();

--- a/proton-j/src/main/java/org/apache/qpid/proton/reactor/Reactor.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/reactor/Reactor.java
@@ -71,11 +71,13 @@ public interface Reactor {
     Record attachments();
 
     /**
-     * @param timeout a timeout value, to associate with this instance of
+     * ??PURPOSE??
+     * 
+     * @param timeout a timeout value ??UNITS??, to associate with this instance of
      *        the reactor.  This can be retrieved using the
-     *        {@link #getTimeout()} method.
+     *        {@link #getTimeout()} method
      */
-    void setTimeout(long timeout);
+    void setTimeout(long timeout); 
 
     /**
      * @return the value previously set using {@link #setTimeout(long)} or


### PR DESCRIPTION
Can somebody help me fill out the blanks here? I think proton-j uses milliseconds throughout, and what does Reactor#setTimeout() do?