### PR TITLE
Expose get/set on 'properties Map' of Link 'Attach' performative

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/Link.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/Link.java
@@ -21,6 +21,7 @@
 package org.apache.qpid.proton.engine;
 
 import java.util.EnumSet;
+import java.util.Map;
 
 import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
 import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
@@ -180,6 +181,19 @@ public interface Link extends Endpoint
     @Deprecated
     void setRemoteSenderSettleMode(SenderSettleMode remoteSenderSettleMode);
 
+    /**
+     * @see #setAttachProperties(Map)
+     */
+    Map getAttachProperties();
+    
+    /**
+     * Sets properties on the Attach frame, while attaching the Link to the Session.
+     * Hence, {@link #setAttachProperties(Map)} should be called during link-setup, i.e., before calling {@link #open()}.
+     * 
+     * Attach properties has no effect on Proton. Application is responsible for interpreting the properties. 
+     */
+    void setAttachProperties(Map properties);
+    
     public int drained();
 
     public int getRemoteCredit();

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/LinkImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/LinkImpl.java
@@ -21,6 +21,7 @@
 package org.apache.qpid.proton.engine.impl;
 
 import java.util.EnumSet;
+import java.util.Map;
 
 import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
 import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
@@ -52,7 +53,7 @@ public abstract class LinkImpl extends EndpointImpl implements Link
     private SenderSettleMode _remoteSenderSettleMode;
     private ReceiverSettleMode _receiverSettleMode;
     private ReceiverSettleMode _remoteReceiverSettleMode;
-
+    private Map _attachProperties;
 
     private LinkNode<LinkImpl> _node;
     private boolean _drain;
@@ -360,6 +361,18 @@ public abstract class LinkImpl extends EndpointImpl implements Link
     {
         _receiverSettleMode = receiverSettleMode;
     }
+
+	@Override
+	public Map getAttachProperties()
+	{
+		return this._attachProperties;
+	}
+
+	@Override
+	public void setAttachProperties(Map properties)
+	{
+		this._attachProperties = properties;
+	}
 
     @Override
     public ReceiverSettleMode getRemoteReceiverSettleMode()

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -768,6 +768,11 @@ public class TransportImpl extends EndpointImpl
                             {
                                 attach.setTarget(link.getTarget());
                             }
+                            
+                            if(link.getAttachProperties() != null)
+                            {
+                            	attach.setProperties(link.getAttachProperties());
+                            }
 
                             attach.setRole(endpoint instanceof ReceiverImpl ? Role.RECEIVER : Role.SENDER);
 


### PR DESCRIPTION
Hello Folks!

I (sreeram, from windows azure eventHubs team) am starting to build eventHubs Java SDK and taking a dependency on proton-j (which will be available on GitHub, hopefully, soon). EventHubs amqp client will need to set AttachProperties to enable Critical scenarios for us.

Currently, in the proton-j framework - all attach performative fields are exposed using the Link Interface. So, following the pattern I added new Get/Set methods for setting AttachProperties.

Please embrace this code change as soon as possible.

Thanks!
Sree