### PR TITLE
[PROTON-1096]: expose seting MessageFormat on Transfer frames in proton-j

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/Delivery.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/Delivery.java
@@ -42,6 +42,8 @@ public interface Delivery extends Extendable
     /** TODO is this required?? */
     public int getMessageFormat();
 
+    public void setMessageFormat(int messageFormat);
+
     /**
      * updates the state of the delivery
      *

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/DeliveryImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/DeliveryImpl.java
@@ -50,6 +50,7 @@ public class DeliveryImpl implements Delivery
     private boolean _remoteSettled;
     private DeliveryState _remoteDeliveryState;
     private DeliveryState _defaultDeliveryState = null;
+    private int _messageFormat = 0;
 
     /**
      * A bit-mask representing the outstanding work on this delivery received from the transport layer
@@ -104,8 +105,14 @@ public class DeliveryImpl implements Delivery
 
     public int getMessageFormat()
     {
-        return 0;
+        return this._messageFormat;
     }
+
+	@Override
+	public void setMessageFormat(int messageFormat)
+	{
+		this._messageFormat = messageFormat;
+	}
 
     public void disposition(final DeliveryState state)
     {

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -567,7 +567,7 @@ public class TransportImpl extends EndpointImpl
                 transfer.setMore(true);
             }
 
-            transfer.setMessageFormat(UnsignedInteger.ZERO);
+            transfer.setMessageFormat(UnsignedInteger.valueOf(delivery.getMessageFormat()));
 
             ByteBuffer payload = delivery.getData() ==  null ? null :
                 ByteBuffer.wrap(delivery.getData(), delivery.getDataOffset(),


### PR DESCRIPTION
This is a feature request from windows azure eventhubs team.

I (sreeram, from windows azure eventHubs team) am building eventHubs Java SDK and taking a dependency on proton-j (which will be available on GitHub, hopefully, soon). EventHubs amqp client will need to set Custom MessageFormat to enable a Critical scenario for Sending (Send Batch) messages to EventHubs from our JavaClient.

https://issues.apache.org/jira/browse/PROTON-1096 