### PR TITLE
PROTON-1098 : support one or more data sections in amqpMessage

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/amqp/messaging/DataList.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/amqp/messaging/DataList.java
@@ -1,0 +1,36 @@
+package org.apache.qpid.proton.amqp.messaging;
+
+import java.util.function.Consumer;
+
+public class DataList 
+	implements Section
+{
+	private final Iterable<Data> _dataList;
+	
+	public DataList(final Iterable<Data> dataList)
+	{
+		this._dataList = dataList;
+	}
+	
+	public Iterable<Data> getValue()
+	{
+		return this._dataList;
+	}
+	
+	@Override
+    public String toString()
+    {
+        final StringBuilder dataListStr = new StringBuilder();
+        dataListStr.append("DataList{");
+        this._dataList.forEach(new Consumer<Data>()
+        {
+			@Override
+			public void accept(Data data)
+			{
+				dataListStr.append(data.toString());
+			}
+		});
+        dataListStr.append('}');
+        return dataListStr.toString();
+    }
+}

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/AMQPDefinedTypes.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/AMQPDefinedTypes.java
@@ -70,6 +70,7 @@ public class AMQPDefinedTypes
         PropertiesType.register( decoder, encoder );
         ApplicationPropertiesType.register(decoder, encoder);
         DataType.register(decoder, encoder);
+        DataListType.register(decoder, encoder);
         AmqpSequenceType.register(decoder, encoder);
         AmqpValueType.register(decoder, encoder);
         FooterType.register(decoder, encoder);

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DataListType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DataListType.java
@@ -1,0 +1,68 @@
+package org.apache.qpid.proton.codec.messaging;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.DataList;
+import org.apache.qpid.proton.codec.AMQPType;
+import org.apache.qpid.proton.codec.TypeEncoding;
+import org.apache.qpid.proton.codec.Decoder;
+import org.apache.qpid.proton.codec.EncoderImpl;
+
+public class DataListType 
+	implements AMQPType<DataList>
+{
+	private final EncoderImpl _encoder;
+	
+	private DataListType(final EncoderImpl encoder)
+	{
+		this._encoder = encoder;
+	}
+
+	@Override
+	public Class<DataList> getTypeClass()
+	{
+		return DataList.class;
+	}
+
+	@Override
+	public TypeEncoding<DataList> getEncoding(DataList val)
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TypeEncoding<DataList> getCanonicalEncoding()
+	{
+		return null;
+	}
+
+	@Override
+	public Collection<? extends TypeEncoding<DataList>> getAllEncodings()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void write(DataList val)
+	{
+		final AMQPType dataType = this._encoder.getTypeFromClass(Data.class);
+		val.getValue().forEach(new Consumer<Data>()
+		{
+			@Override
+			public void accept(Data data)
+			{
+				dataType.write(data);
+			}
+		});
+	}
+	
+	public static void register(Decoder decoder, EncoderImpl encoder)
+	{
+		// there is no special Descriptor for DataListType; other than the individual 'DataType';
+		// so I believe - no Decoder needs to be registered
+		DataListType type = new DataListType(encoder);
+		encoder.register(type);
+	}
+}


### PR DESCRIPTION
This is a suggestion on how to implement the feature request PROTON-1098 and is NOT COMPLETE, although, the code works (while sending the message - I am able to send an AmqpMessage with Multiple Data sections using this implementation).

Usage:
While sending a Message, instead of creating the message with Data section, the following can be done:
		Message amqpMessage = Proton.message();
		amqpMessage.setBody(new DataList(dataList))

(tagging the proton-j expert: @gemmellr to do the needful)