### PR TITLE
Fix nullPointerException in event impl in the Reactor.onSessionInit codePaths

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/EventImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/EventImpl.java
@@ -239,10 +239,12 @@ class EventImpl implements Event
             return (Transport) context;
         } else if (context instanceof Connection) {
         	return ((Connection)context).getTransport();	
-        } else if (context instanceof Session) {
-        	return ((Session)context).getConnection().getTransport();
         } else {
-            return null;
+        	Session session = getSession();
+        	if (session == null) {
+        		return null;
+        	}
+        	return session.getConnection().getTransport();
         }
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/EventImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/EventImpl.java
@@ -239,6 +239,8 @@ class EventImpl implements Event
             return (Transport) context;
         } else if (context instanceof Connection) {
         	return ((Connection)context).getTransport();	
+        } else if (context instanceof Session) {
+        	return ((Session)context).getConnection().getTransport();
         } else {
             return null;
         }


### PR DESCRIPTION
Eventhubs java client depends on Proton-j Reactor APIs. While running our stress scenarios - we encountered a NullPointerException in this codepath - onSessionInit command (it happens transiently though). Will fill in with full stack trace if I encounter this error again.

(tagging @gemmellr for helping with merge).