### PR TITLE
Schema parsing should not be so greedy

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/messenger/impl/Address.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/messenger/impl/Address.java
@@ -58,10 +58,12 @@ public class Address
     {
         clear();
         int start = 0;
-        int schemeEnd = address.indexOf("://", start);
-        if (schemeEnd >= 0) {
-            _scheme = address.substring(start, schemeEnd);
-            start = schemeEnd + 3;
+        if (address.startsWith("amqp://")) {
+            _scheme = "amqp";
+            start = 7;
+        } else if (address.startsWith("amqps://")) {
+            _scheme = "amqps";
+            start = 8;
         }
 
         String uphp;

--- a/proton-j/src/test/java/org/apache/qpid/proton/messenger/impl/AddressTest.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/messenger/impl/AddressTest.java
@@ -38,6 +38,7 @@ public class AddressTest {
     {
         testParse("host", null, null, null, "host", null, null);
         testParse("host:423", null, null, null, "host", "423", null);
+        testParse("host:423/topic://topicname", null, null, null, "host", "423", "topic://topicname");
         testParse("user@host", null, "user", null, "host", null, null);
         testParse("user:1243^&^:pw@host:423", null, "user", "1243^&^:pw", "host", "423", null);
         testParse("user:1243^&^:pw@host:423/Foo.bar:90087", null, "user", "1243^&^:pw", "host", "423", "Foo.bar:90087");
@@ -57,6 +58,7 @@ public class AddressTest {
         testParse("amqp://user:1243^&^:pw@[::1]:amqp/Foo.bar:90087", "amqp", "user", "1243^&^:pw", "::1", "amqp", "Foo.bar:90087");
         testParse("amqp://host", "amqp", null, null, "host", null, null);
         testParse("amqp://user@host", "amqp", "user", null, "host", null, null);
+        testParse("amqps://user@host", "amqps", "user", null, "host", null, null);
         testParse("amqp://user@host/path:%", "amqp", "user", null, "host", null, "path:%");
         testParse("amqp://user@host:5674/path:%", "amqp", "user", null, "host", "5674", "path:%");
         testParse("amqp://user@host/path:%", "amqp", "user", null, "host", null, "path:%");


### PR DESCRIPTION
Hi,

Current address schema parser doesn't work if `://` string is included in a path. The reasons to include `://` in a path are as follows:
- it is not against AMQP address specification
- ActiveMQ AMQP module uses [1] `topic://`prefix to indicate that message should be dispatched to broker topic, not queue (and other broker implementations could do the same)

So to connect to ActiveMQ's topic named `topicname`, you could use the following AMQP address - `host:423/topic://topicname` . The problem with current `Address` implementation is that it will interpret `://` in `topic://` as a schema separator.

Since `://` is optional in address and the only two acceptable schemas are `amqp` and `ampqs`, I think we should narrow schema parsing to those two values.

What do you think? 

[1] http://activemq.apache.org/amqp.html