### PR TITLE
Fixing broken documentation links

### DIFF
--- a/docs/markdown/index.md
+++ b/docs/markdown/index.md
@@ -1,9 +1,9 @@
 
 Proton is a library for speaking AMQP, including:
 
-- The AMQP [Messenger API](messenger/index.html), a simple but powerful interface to send and receive
+- The AMQP [Messenger API](messenger/index.md), a simple but powerful interface to send and receive
   messages over AMQP.
-- The [AMQP Protocol Engine](engine/engine.html), a succinct encapsulation of the full
+- The [AMQP Protocol Engine](engine/engine.md), a succinct encapsulation of the full
   AMQP protocol machinery.
 
 Proton is designed for maximum embeddability:

--- a/docs/markdown/messenger/index.md
+++ b/docs/markdown/messenger/index.md
@@ -3,11 +3,11 @@ Proton Messenger Documentation
 
 Proton Messenger is a high-level API that lets you build simple but powerful messaging systems.
 
-- Use the [Linux Quick Start](quick-start-linux.html) to download, build, and run your first Messenger example in two minutes.
+- Use the [Linux Quick Start](quick-start-linux.md) to download, build, and run your first Messenger example in two minutes.
 
-- Examples and explanations of Messenger's [Sending and Receiving](sending-and-receiving.html) capabilities.
+- Examples and explanations of Messenger's [Sending and Receiving](sending-and-receiving.md) capabilities.
 
-- Use [Message Disposition](message-disposition.html) functionality to create reliable messaging systems.
+- Use [Message Disposition](message-disposition.md) functionality to create reliable messaging systems.
 
-- Messenger's [Addressing and Routing](addressing-and-routing.html) capabilities allow you to separate application code from installation-specific configuration information.
+- Messenger's [Addressing and Routing](addressing-and-routing.md) capabilities allow you to separate application code from installation-specific configuration information.
 


### PR DESCRIPTION
Several links were changed from *.html to *.md. 