### PR TITLE
NO-JIRA: Fix break in Javascript bindings build

### DIFF
--- a/proton-c/bindings/javascript/CMakeLists.txt
+++ b/proton-c/bindings/javascript/CMakeLists.txt
@@ -192,11 +192,11 @@ target_link_libraries(qpid-proton-bitcode)
 
 
 # Compile the send-async.c and recv-async.c examples into JavaScript
-include_directories(${PN_PATH}/../examples/c/include)
-add_executable(send-async.js ${PN_PATH}/../examples/c/messenger/send-async.c)
+include_directories(${Proton_SOURCE_DIR}/examples/c/include)
+add_executable(send-async.js ${Proton_SOURCE_DIR}/examples/c/messenger/send-async.c)
 target_link_libraries(send-async.js qpid-proton-bitcode)
 
-add_executable(recv-async.js ${PN_PATH}/../examples/c/messenger/recv-async.c)
+add_executable(recv-async.js ${Proton_SOURCE_DIR}/examples/c/messenger/recv-async.c)
 target_link_libraries(recv-async.js qpid-proton-bitcode)
 
 set_target_properties(

--- a/proton-c/bindings/javascript/CMakeLists.txt
+++ b/proton-c/bindings/javascript/CMakeLists.txt
@@ -192,6 +192,7 @@ target_link_libraries(qpid-proton-bitcode)
 
 
 # Compile the send-async.c and recv-async.c examples into JavaScript
+include_directories(${PN_PATH}/../examples/c/include)
 add_executable(send-async.js ${PN_PATH}/../examples/c/messenger/send-async.c)
 target_link_libraries(send-async.js qpid-proton-bitcode)
 


### PR DESCRIPTION
Attempting to build Proton with Emscripten on the path fails with the following
message:
/home/prestona/git/qpid-proton/examples/c/messenger/recv-async.c:26:10: fatal
error: 'pncompat/misc_funcs.inc' file not found
#include "pncompat/misc_funcs.inc"
         ^
1 error generated.

This appears to have been introduced by commit
84e416e389fe74ec7a1cab9252af2342fc95b83f