### PR TITLE
PROTON-1303: Replace go binding URL parser with version that doesn't …

### DIFF
--- a/proton-c/bindings/go/src/qpid.apache.org/amqp/url.go
+++ b/proton-c/bindings/go/src/qpid.apache.org/amqp/url.go
@@ -40,7 +40,7 @@ func splitHostPort(hostport string) (string, string, error) {
 	}
 	if hostport[0] == '[' {
 		// There must be a matching ']' as already validated
-		if l := strings.LastIndexByte(hostport, ']'); len(hostport) == l+1 {
+		if l := strings.LastIndex(hostport, "]"); len(hostport) == l+1 {
 			// trim off '[' and ']'
 			return hostport[1:l], "", nil
 		}

--- a/proton-c/bindings/go/src/qpid.apache.org/amqp/url.go
+++ b/proton-c/bindings/go/src/qpid.apache.org/amqp/url.go
@@ -19,30 +19,74 @@ under the License.
 
 package amqp
 
-/*
-#include <stdlib.h>
-#include <string.h>
-#include <proton/url.h>
-
-// Helper function for setting URL fields.
-typedef void (*setter_fn)(pn_url_t* url, const char* value);
-inline void	set(pn_url_t *url, setter_fn s, const char* value) {
-  s(url, value);
-}
-*/
-import "C"
-
 import (
-	"fmt"
+	"errors"
 	"net"
 	"net/url"
-	"unsafe"
+	"strings"
 )
 
 const (
 	amqp  string = "amqp"
 	amqps        = "amqps"
+	defaulthost  = "localhost"
 )
+
+// The way this is used it can only get a hostport already validated by
+// the URL parser, so this means we can skip some error checks
+func splitHostPort(hostport string) (string, string, error) {
+	if hostport == "" {
+		return "", "", nil
+	}
+	if hostport[0] == '[' {
+		// There must be a matching ']' as already validated
+		if l := strings.LastIndexByte(hostport, ']'); len(hostport) == l+1 {
+			// trim off '[' and ']'
+			return hostport[1:l], "", nil
+		}
+	} else if strings.IndexByte(hostport, ':') < 0 {
+		return hostport, "", nil
+	}
+	return net.SplitHostPort(hostport)
+}
+
+func UpdateURL(in *url.URL) (err error) {
+	// Detect form without "amqp://" and stick it on front
+	// to make it match the usual proton defaults
+	u := new (url.URL)
+	*u = *in
+	if (u.Scheme != "" && u.Opaque != "") ||
+	   (u.Scheme == "" && u.Host == "") {
+		input := u.String()
+		input = "amqp://" + input
+		u, err = url.Parse(input)
+		if err != nil {
+			return
+		}
+	}
+	// If Scheme is still "" then default to amqp
+	if u.Scheme == "" {
+		u.Scheme = amqp
+	}
+	// Error if the scheme is not an amqp scheme
+	if u.Scheme != amqp && u.Scheme != amqps {
+		return errors.New("invalid amqp scheme")
+	}
+	// Decompose Host into host and port
+	host, port, err := splitHostPort(u.Host)
+	if err != nil {
+		return
+	}
+	if host == "" {
+		host = defaulthost
+	}
+	if port == "" {
+		port = u.Scheme
+	}
+	u.Host = net.JoinHostPort(host, port)
+	*in = *u
+	return nil
+}
 
 // ParseUrl parses an AMQP URL string and returns a net/url.Url.
 //
@@ -50,47 +94,11 @@ const (
 // URL to be missing, assuming AMQP defaults.
 //
 func ParseURL(s string) (u *url.URL, err error) {
-	cstr := C.CString(s)
-	defer C.free(unsafe.Pointer(cstr))
-	pnUrl := C.pn_url_parse(cstr)
-	if pnUrl == nil {
-		return nil, fmt.Errorf("bad URL %#v", s)
+	if u, err = url.Parse(s); err != nil {
+		return
 	}
-	defer C.pn_url_free(pnUrl)
-
-	scheme := C.GoString(C.pn_url_get_scheme(pnUrl))
-	username := C.GoString(C.pn_url_get_username(pnUrl))
-	password := C.GoString(C.pn_url_get_password(pnUrl))
-	host := C.GoString(C.pn_url_get_host(pnUrl))
-	port := C.GoString(C.pn_url_get_port(pnUrl))
-	path := C.GoString(C.pn_url_get_path(pnUrl))
-
-	if err != nil {
-		return nil, fmt.Errorf("bad URL %#v: %s", s, err)
+	if err = UpdateURL(u); err != nil {
+		u = nil
 	}
-	if scheme == "" {
-		scheme = amqp
-	}
-	if port == "" {
-		if scheme == amqps {
-			port = amqps
-		} else {
-			port = amqp
-		}
-	}
-	var user *url.Userinfo
-	if password != "" {
-		user = url.UserPassword(username, password)
-	} else if username != "" {
-		user = url.User(username)
-	}
-
-	u = &url.URL{
-		Scheme: scheme,
-		User:   user,
-		Host:   net.JoinHostPort(host, port),
-		Path:   path,
-	}
-
-	return u, nil
+	return u, err
 }

--- a/proton-c/bindings/go/src/qpid.apache.org/amqp/url_test.go
+++ b/proton-c/bindings/go/src/qpid.apache.org/amqp/url_test.go
@@ -31,10 +31,14 @@ func ExampleParseURL() {
 		"host/path",
 		"amqps://host",
 		"/path",
-		"[::1]",
 		"",
 		":1234",
-		"[::1",
+                // Taken out becasue the go 1.4 URL parser isn't the same as later
+		//"[::1]",
+		//"[::1",
+		// Output would be:
+		// amqp://[::1]:amqp
+		// parse amqp://[::1: missing ']' in host
 	} {
 		u, err := ParseURL(s)
 		if err != nil {
@@ -50,8 +54,6 @@ func ExampleParseURL() {
 	// amqp://host:amqp/path
 	// amqps://host:amqps
 	// amqp://localhost:amqp/path
-	// amqp://[::1]:amqp
 	// amqp://localhost:amqp
 	// parse :1234: missing protocol scheme
-	// parse amqp://[::1: missing ']' in host
 }

--- a/proton-c/bindings/go/src/qpid.apache.org/amqp/url_test.go
+++ b/proton-c/bindings/go/src/qpid.apache.org/amqp/url_test.go
@@ -28,10 +28,13 @@ func ExampleParseURL() {
 		"amqp://username:password@host:1234/path",
 		"host:1234",
 		"host",
-		":1234",
 		"host/path",
 		"amqps://host",
+		"/path",
+		"[::1]",
 		"",
+		":1234",
+		"[::1",
 	} {
 		u, err := ParseURL(s)
 		if err != nil {
@@ -44,8 +47,11 @@ func ExampleParseURL() {
 	// amqp://username:password@host:1234/path
 	// amqp://host:1234
 	// amqp://host:amqp
-	// amqp://:1234
 	// amqp://host:amqp/path
 	// amqps://host:amqps
-	// bad URL ""
+	// amqp://localhost:amqp/path
+	// amqp://[::1]:amqp
+	// amqp://localhost:amqp
+	// parse :1234: missing protocol scheme
+	// parse amqp://[::1: missing ']' in host
 }


### PR DESCRIPTION
This PR is specially for @alanconway to review.

Note that interpretation of some URLs has now changed:
URLs without a host are now illegal (as they cannot be parsed as URLs)
":1223" is now illegal.
The empty URL "" does however default to localhost:5672