### PR TITLE
optimizations on Decoder/Encoder

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/TestDecoder.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/TestDecoder.java
@@ -18,7 +18,12 @@
  */
 package org.apache.qpid.proton;
 
-import org.apache.qpid.proton.TestDecoder;
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Decimal128;
 import org.apache.qpid.proton.amqp.Decimal32;
@@ -29,9 +34,10 @@ import org.apache.qpid.proton.amqp.UnsignedInteger;
 import org.apache.qpid.proton.amqp.UnsignedLong;
 import org.apache.qpid.proton.amqp.UnsignedShort;
 import org.apache.qpid.proton.codec.AMQPDefinedTypes;
-
+import org.apache.qpid.proton.codec.DecoderFactory;
 import org.apache.qpid.proton.codec.DecoderImpl;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
 
 import java.nio.ByteBuffer;
 import java.util.Date;
@@ -46,51 +52,178 @@ import java.util.UUID;
  * Data object.
  */
 
-public class TestDecoder {
+public class TestDecoder
+{
     private DecoderImpl decoder;
     private EncoderImpl encoder;
-    private ByteBuffer buffer;
+    private ReadableBuffer buffer;
 
-    TestDecoder(byte[] data) {
-        decoder = new DecoderImpl();
-	encoder = new EncoderImpl(decoder);
-	AMQPDefinedTypes.registerAllTypes(decoder, encoder);
-	buffer = ByteBuffer.allocate(data.length);
-	buffer.put(data);
-	buffer.rewind();
-        decoder.setByteBuffer(buffer);
+    TestDecoder(byte[] data)
+    {
+        decoder = DecoderFactory.getSingleton().getDecoder();
+        encoder = DecoderFactory.getSingleton().getEncoder();
+
+
+        buffer = new ReadableBuffer.ByteBufferReader(ByteBuffer.wrap(data));
     }
 
-    public Boolean readBoolean() { return decoder.readBoolean(); }
-    public Byte readByte() { return decoder.readByte(); }
-    public Short readShort() { return decoder.readShort(); }
-    public Integer readInteger() { return decoder.readInteger(); }
-    public Long readLong() { return decoder.readLong(); }
-    public UnsignedByte readUnsignedByte() { return decoder.readUnsignedByte(); }
-    public UnsignedShort readUnsignedShort() { return decoder.readUnsignedShort(); }
-    public UnsignedInteger readUnsignedInteger() { return decoder.readUnsignedInteger(); }
-    public UnsignedLong readUnsignedLong() { return decoder.readUnsignedLong(); }
-    public Character readCharacter() { return decoder.readCharacter(); }
-    public Float readFloat() { return decoder.readFloat(); }
-    public Double readDouble() { return decoder.readDouble(); }
-    public UUID readUUID() { return decoder.readUUID(); }
-    public Decimal32 readDecimal32() { return decoder.readDecimal32(); }
-    public Decimal64 readDecimal64() { return decoder.readDecimal64(); }
-    public Decimal128 readDecimal128() { return decoder.readDecimal128(); }
-    public Date readTimestamp() { return decoder.readTimestamp(); }
-    public Binary readBinary() { return decoder.readBinary(); }
-    public Symbol readSymbol() { return decoder.readSymbol(); }
-    public String readString() { return decoder.readString(); }
-    public List readList() { return decoder.readList(); }
-    public Map readMap() { return decoder.readMap(); }
-    public Object[] readArray() { return decoder.readArray(); }
-    public boolean[] readBooleanArray() { return decoder.readBooleanArray(); }
-    public byte[] readByteArray() { return decoder.readByteArray(); }
-    public short[] readShortArray() { return decoder.readShortArray(); }
-    public int[] readIntegerArray() { return decoder.readIntegerArray(); }
-    public long[] readLongArray() { return decoder.readLongArray(); }
-    public float[] readFloatArray() { return decoder.readFloatArray(); }
-    public double[] readDoubleArray() { return decoder.readDoubleArray(); }
-    public char[] readCharacterArray() { return decoder.readCharacterArray(); }
-    public Object readObject() { return decoder.readObject(); }
+    public Boolean readBoolean()
+    {
+        return decoder.readBoolean(buffer);
+    }
+
+    public Byte readByte()
+    {
+        return decoder.readByte(buffer);
+    }
+
+    public Short readShort()
+    {
+        return decoder.readShort(buffer);
+    }
+
+    public Integer readInteger()
+    {
+        return decoder.readInteger(buffer);
+    }
+
+    public Long readLong()
+    {
+        return decoder.readLong(buffer);
+    }
+
+    public UnsignedByte readUnsignedByte()
+    {
+        return decoder.readUnsignedByte(buffer);
+    }
+
+    public UnsignedShort readUnsignedShort()
+    {
+        return decoder.readUnsignedShort(buffer);
+    }
+
+    public UnsignedInteger readUnsignedInteger()
+    {
+        return decoder.readUnsignedInteger(buffer);
+    }
+
+    public UnsignedLong readUnsignedLong()
+    {
+        return decoder.readUnsignedLong(buffer);
+    }
+
+    public Character readCharacter()
+    {
+        return decoder.readCharacter(buffer);
+    }
+
+    public Float readFloat()
+    {
+        return decoder.readFloat(buffer);
+    }
+
+    public Double readDouble()
+    {
+        return decoder.readDouble(buffer);
+    }
+
+    public UUID readUUID()
+    {
+        return decoder.readUUID(buffer);
+    }
+
+    public Decimal32 readDecimal32()
+    {
+        return decoder.readDecimal32(buffer);
+    }
+
+    public Decimal64 readDecimal64()
+    {
+        return decoder.readDecimal64(buffer);
+    }
+
+    public Decimal128 readDecimal128()
+    {
+        return decoder.readDecimal128(buffer);
+    }
+
+    public Date readTimestamp()
+    {
+        return decoder.readTimestamp(buffer);
+    }
+
+    public Binary readBinary()
+    {
+        return decoder.readBinary(buffer);
+    }
+
+    public Symbol readSymbol()
+    {
+        return decoder.readSymbol(buffer);
+    }
+
+    public String readString()
+    {
+        return decoder.readString(buffer);
+    }
+
+    public List readList()
+    {
+        return decoder.readList(buffer);
+    }
+
+    public Map readMap()
+    {
+        return decoder.readMap(buffer);
+    }
+
+    public Object[] readArray()
+    {
+        return decoder.readArray(buffer);
+    }
+
+    public boolean[] readBooleanArray()
+    {
+        return decoder.readBooleanArray(buffer);
+    }
+
+    public byte[] readByteArray()
+    {
+        return decoder.readByteArray(buffer);
+    }
+
+    public short[] readShortArray()
+    {
+        return decoder.readShortArray(buffer);
+    }
+
+    public int[] readIntegerArray()
+    {
+        return decoder.readIntegerArray(buffer);
+    }
+
+    public long[] readLongArray()
+    {
+        return decoder.readLongArray(buffer);
+    }
+
+    public float[] readFloatArray()
+    {
+        return decoder.readFloatArray(buffer);
+    }
+
+    public double[] readDoubleArray()
+    {
+        return decoder.readDoubleArray(buffer);
+    }
+
+    public char[] readCharacterArray()
+    {
+        return decoder.readCharacterArray(buffer);
+    }
+
+    public Object readObject()
+    {
+        return decoder.readObject(buffer);
+    }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/AMQPDefinedTypes.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/AMQPDefinedTypes.java
@@ -39,7 +39,7 @@ import org.apache.qpid.proton.codec.transport.*;
 
 public class AMQPDefinedTypes
 {
-    public static void registerAllTypes(Decoder decoder, EncoderImpl encoder)
+    public static void registerAllTypes(DecoderImpl decoder, EncoderImpl encoder)
     {
         registerTransportTypes(decoder, encoder);
         registerMessagingTypes(decoder, encoder);
@@ -48,7 +48,7 @@ public class AMQPDefinedTypes
     }
 
 
-    public static void registerTransportTypes(Decoder decoder, EncoderImpl encoder)
+    public static void registerTransportTypes(DecoderImpl decoder, EncoderImpl encoder)
     {
         OpenType.register(decoder, encoder);
         BeginType.register(decoder, encoder);
@@ -62,7 +62,7 @@ public class AMQPDefinedTypes
         ErrorConditionType.register(decoder, encoder);
     }
 
-    public static void registerMessagingTypes(Decoder decoder, EncoderImpl encoder)
+    public static void registerMessagingTypes(DecoderImpl decoder, EncoderImpl encoder)
     {
         HeaderType.register(decoder, encoder);
         DeliveryAnnotationsType.register(decoder, encoder);
@@ -86,7 +86,7 @@ public class AMQPDefinedTypes
         DeleteOnNoLinksOrMessagesType.register(decoder, encoder);
     }
 
-    public static void registerTransactionTypes(Decoder decoder, EncoderImpl encoder)
+    public static void registerTransactionTypes(DecoderImpl decoder, EncoderImpl encoder)
     {
         CoordinatorType.register(decoder, encoder);
         DeclareType.register(decoder, encoder);
@@ -95,7 +95,7 @@ public class AMQPDefinedTypes
         TransactionalStateType.register(decoder, encoder);
     }
 
-    public static void registerSecurityTypes(Decoder decoder, EncoderImpl encoder)
+    public static void registerSecurityTypes(DecoderImpl decoder, EncoderImpl encoder)
     {
         SaslMechanismsType.register(decoder, encoder);
         SaslInitType.register(decoder, encoder);

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/AMQPType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/AMQPType.java
@@ -32,5 +32,5 @@ public interface AMQPType<V>
 
     Collection<? extends TypeEncoding<V>> getAllEncodings();
 
-    void write(V val);
+    void write(WritableBuffer buffer, V val);
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/AbstractPrimitiveType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/AbstractPrimitiveType.java
@@ -22,11 +22,11 @@ package org.apache.qpid.proton.codec;
 
 abstract class AbstractPrimitiveType<T> implements PrimitiveType<T>
 {
-    public final void write(T val)
+    public final void write(WritableBuffer buffer, T val)
     {
         final TypeEncoding<T> encoding = getEncoding(val);
-        encoding.writeConstructor();
-        encoding.writeValue(val);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, val);
     }
 
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/AbstractPrimitiveTypeEncoding.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/AbstractPrimitiveTypeEncoding.java
@@ -20,6 +20,7 @@
  */
 package org.apache.qpid.proton.codec;
 
+
 abstract class AbstractPrimitiveTypeEncoding<T> implements PrimitiveTypeEncoding<T>
 {
     private final EncoderImpl _encoder;
@@ -31,9 +32,9 @@ abstract class AbstractPrimitiveTypeEncoding<T> implements PrimitiveTypeEncoding
         _decoder = decoder;
     }
 
-    public final void writeConstructor()
+    public final void writeConstructor(WritableBuffer buffer)
     {
-        _encoder.writeRaw(getEncodingCode());
+        _encoder.writeRaw(buffer, getEncodingCode());
     }
 
     public int getConstructorSize()
@@ -53,13 +54,19 @@ abstract class AbstractPrimitiveTypeEncoding<T> implements PrimitiveTypeEncoding
         return getType().getTypeClass();
     }
 
-    protected DecoderImpl getDecoder()
+    // TODO make it back to protected
+    public DecoderImpl getDecoder()
     {
         return _decoder;
     }
 
 
     public boolean encodesJavaPrimitive()
+    {
+        return false;
+    }
+
+    public boolean isArray()
     {
         return false;
     }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/ArrayType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/ArrayType.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 
 public class ArrayType implements PrimitiveType<Object[]>
 {
+
     private final EncoderImpl _encoder;
     private final BooleanType _booleanType;
     private final ByteType _byteType;
@@ -38,20 +39,20 @@ public class ArrayType implements PrimitiveType<Object[]>
 
     public static interface ArrayEncoding extends PrimitiveTypeEncoding<Object[]>
     {
-        void writeValue(boolean[] a);
-        void writeValue(byte[] a);
-        void writeValue(short[] a);
-        void writeValue(int[] a);
-        void writeValue(long[] a);
-        void writeValue(float[] a);
-        void writeValue(double[] a);
-        void writeValue(char[] a);
+        void writeValue(WritableBuffer buffer, boolean[] a);
+        void writeValue(WritableBuffer buffer, byte[] a);
+        void writeValue(WritableBuffer buffer, short[] a);
+        void writeValue(WritableBuffer buffer, int[] a);
+        void writeValue(WritableBuffer buffer, long[] a);
+        void writeValue(WritableBuffer buffer, float[] a);
+        void writeValue(WritableBuffer buffer, double[] a);
+        void writeValue(WritableBuffer buffer, char[] a);
 
         void setValue(Object[] val, TypeEncoding encoder, int size);
 
         int getSizeBytes();
 
-        Object readValueArray();
+        Object readValueArray(ReadableBuffer buffer);
     }
 
     private final ArrayEncoding _shortArrayEncoding;
@@ -293,18 +294,18 @@ public class ArrayType implements PrimitiveType<Object[]>
         return Arrays.asList(_shortArrayEncoding, _arrayEncoding);
     }
 
-    public void write(final Object[] val)
+    public void write(WritableBuffer buffer, final Object[] val)
     {
         ArrayEncoding encoding = getEncoding(val);
-        encoding.writeConstructor();
-        encoding.writeValue(val);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, val);
     }
 
-    public void write(boolean[] a)
+    public void write(WritableBuffer buffer, boolean[] a)
     {
         ArrayEncoding encoding = getEncoding(a);
-        encoding.writeConstructor();
-        encoding.writeValue(a);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, a);
     }
 
     private ArrayEncoding getEncoding(final boolean[] a)
@@ -325,11 +326,11 @@ public class ArrayType implements PrimitiveType<Object[]>
         return true;
     }
 
-    public void write(byte[] a)
+    public void write(WritableBuffer buffer, byte[] a)
     {
         ArrayEncoding encoding = getEncoding(a);
-        encoding.writeConstructor();
-        encoding.writeValue(a);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, a);
     }
 
     private ArrayEncoding getEncoding(final byte[] a)
@@ -337,11 +338,11 @@ public class ArrayType implements PrimitiveType<Object[]>
         return a.length < 254 ? _shortArrayEncoding : _arrayEncoding;
     }
 
-    public void write(short[] a)
+    public void write(WritableBuffer buffer, short[] a)
     {
         ArrayEncoding encoding = getEncoding(a);
-        encoding.writeConstructor();
-        encoding.writeValue(a);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, a);
     }
 
     private ArrayEncoding getEncoding(final short[] a)
@@ -349,11 +350,11 @@ public class ArrayType implements PrimitiveType<Object[]>
         return a.length < 127 ? _shortArrayEncoding : _arrayEncoding;
     }
 
-    public void write(int[] a)
+    public void write(WritableBuffer buffer, int[] a)
     {
         ArrayEncoding encoding = getEncoding(a);
-        encoding.writeConstructor();
-        encoding.writeValue(a);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, a);
     }
 
     private ArrayEncoding getEncoding(final int[] a)
@@ -373,11 +374,11 @@ public class ArrayType implements PrimitiveType<Object[]>
         return true;
     }
 
-    public void write(long[] a)
+    public void write(WritableBuffer buffer, long[] a)
     {
         ArrayEncoding encoding = getEncoding(a);
-        encoding.writeConstructor();
-        encoding.writeValue(a);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, a);
     }
 
     private ArrayEncoding getEncoding(final long[] a)
@@ -397,11 +398,11 @@ public class ArrayType implements PrimitiveType<Object[]>
         return true;
     }
 
-    public void write(float[] a)
+    public void write(WritableBuffer buffer, float[] a)
     {
         ArrayEncoding encoding = getEncoding(a);
-        encoding.writeConstructor();
-        encoding.writeValue(a);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, a);
     }
 
     private ArrayEncoding getEncoding(final float[] a)
@@ -409,11 +410,11 @@ public class ArrayType implements PrimitiveType<Object[]>
         return a.length < 63 ? _shortArrayEncoding : _arrayEncoding;
     }
 
-    public void write(double[] a)
+    public void write(WritableBuffer buffer, double[] a)
     {
         ArrayEncoding encoding = getEncoding(a);
-        encoding.writeConstructor();
-        encoding.writeValue(a);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, a);
     }
 
     private ArrayEncoding getEncoding(final double[] a)
@@ -421,11 +422,11 @@ public class ArrayType implements PrimitiveType<Object[]>
         return a.length < 31 ? _shortArrayEncoding : _arrayEncoding;
     }
 
-    public void write(char[] a)
+    public void write(WritableBuffer buffer, char[] a)
     {
         ArrayEncoding encoding = getEncoding(a);
-        encoding.writeConstructor();
-        encoding.writeValue(a);
+        encoding.writeConstructor(buffer);
+        encoding.writeValue(buffer, a);
     }
 
     private ArrayEncoding getEncoding(final char[] a)
@@ -433,170 +434,164 @@ public class ArrayType implements PrimitiveType<Object[]>
         return a.length < 63 ? _shortArrayEncoding : _arrayEncoding;
     }
 
+
+
     private class AllArrayEncoding
             extends LargeFloatingSizePrimitiveTypeEncoding<Object[]>
             implements ArrayEncoding
     {
 
-        private Object[] _val;
-        private TypeEncoding _underlyingEncoder;
-        private int _size;
+
+
+        public boolean isArray()
+        {
+            return true;
+        }
 
         AllArrayEncoding(final EncoderImpl encoder, final DecoderImpl decoder)
         {
             super(encoder, decoder);
         }
 
-        public void writeValue(final boolean[] a)
+        public void writeValue(WritableBuffer buffer, final boolean[] a)
         {
             BooleanType.BooleanEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw(4 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, 4 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null));
-            getEncoder().writeRaw(a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(boolean b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
 
         }
 
-        public void writeValue(final byte[] a)
+        public void writeValue(WritableBuffer buffer, final byte[] a)
         {
             ByteType.ByteEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw(4 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, 4 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null));
-            getEncoder().writeRaw(a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(byte b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final short[] a)
+        public void writeValue(WritableBuffer buffer, final short[] a)
         {
             ShortType.ShortEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw(4 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, 4 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null));
-            getEncoder().writeRaw(a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(short b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final int[] a)
+        public void writeValue(WritableBuffer buffer, final int[] a)
         {
 
             IntegerType.IntegerEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw(4 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, 4 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null));
-            getEncoder().writeRaw(a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(int b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final long[] a)
+        public void writeValue(WritableBuffer buffer, final long[] a)
         {
 
             LongType.LongEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw(4 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, 4 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null));
-            getEncoder().writeRaw(a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(long b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final float[] a)
+        public void writeValue(WritableBuffer buffer, final float[] a)
         {
 
             FloatType.FloatEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw(4 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, 4 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null));
-            getEncoder().writeRaw(a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(float b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final double[] a)
+        public void writeValue(WritableBuffer buffer, final double[] a)
         {
 
             DoubleType.DoubleEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw(4 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, 4 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null));
-            getEncoder().writeRaw(a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(double b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final char[] a)
+        public void writeValue(WritableBuffer buffer, final char[] a)
         {
 
             CharacterType.CharacterEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw(4 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, 4 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null));
-            getEncoder().writeRaw(a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(char b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
         public void setValue(final Object[] val, final TypeEncoding encoder, final int size)
         {
-            _val = val;
-            _underlyingEncoder = encoder;
-            _size = size;
+            CachedCalculation.setCachedValue(val, encoder, size);
         }
 
         @Override
-        protected void writeEncodedValue(final Object[] val)
+        protected void writeEncodedValue(WritableBuffer buffer, final Object[] val)
         {
-            TypeEncoding underlyingEncoder;
+            TypeEncoding underlyingEncoder = calculateEncoder(val, getEncoder());
 
-            if(_val != val)
-            {
-                _val = val;
-                _underlyingEncoder = underlyingEncoder = calculateEncoder(val, getEncoder());
-                _size =  calculateSize(val, underlyingEncoder);
-            }
-            else
-            {
-                underlyingEncoder = _underlyingEncoder;
-            }
-            getEncoder().writeRaw(val.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, val.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(Object o : val)
             {
-                underlyingEncoder.writeValue(o);
+                underlyingEncoder.writeValue(buffer, o);
             }
         }
 
         @Override
         protected int getEncodedValueSize(final Object[] val)
         {
-            if(_val != val)
+            CachedCalculation cachedCalculation = CachedCalculation.getCache();
+            if(cachedCalculation.getVal() != val)
             {
-                _val = val;
-                _underlyingEncoder = calculateEncoder(val, getEncoder());
-                _size = calculateSize(val, _underlyingEncoder);
+                TypeEncoding underlyingEncoder = calculateEncoder(val, getEncoder());
+
+                cachedCalculation.setValue(val, underlyingEncoder, calculateSize(val, underlyingEncoder));
             }
-            return 4 + _size;
+            return 4 + cachedCalculation.getSize();
         }
 
         @Override
@@ -615,20 +610,20 @@ public class ArrayType implements PrimitiveType<Object[]>
             return getType() == encoding.getType();
         }
 
-        public Object[] readValue()
+        public Object[] readValue(ReadableBuffer buffer)
         {
             DecoderImpl decoder = getDecoder();
-            int size = decoder.readRawInt();
-            int count = decoder.readRawInt();
-            return decodeArray(decoder, count);
+            int size = decoder.readRawInt(buffer);
+            int count = decoder.readRawInt(buffer);
+            return decodeArray(buffer, decoder, count);
         }
 
-        public Object readValueArray()
+        public Object readValueArray(ReadableBuffer buffer)
         {
             DecoderImpl decoder = getDecoder();
-            int size = decoder.readRawInt();
-            int count = decoder.readRawInt();
-            return decodeArrayAsObject(decoder, count);
+            int size = decoder.readRawInt(buffer);
+            int count = decoder.readRawInt(buffer);
+            return decodeArrayAsObject(buffer, decoder, count);
         }
 
 
@@ -641,150 +636,150 @@ public class ArrayType implements PrimitiveType<Object[]>
             extends SmallFloatingSizePrimitiveTypeEncoding<Object[]>
             implements ArrayEncoding
     {
-
-        private Object[] _val;
-        private TypeEncoding _underlyingEncoder;
-        private int _size;
+        public boolean isArray()
+        {
+            return true;
+        }
 
         ShortArrayEncoding(final EncoderImpl encoder, final DecoderImpl decoder)
         {
             super(encoder, decoder);
         }
 
-        public void writeValue(final boolean[] a)
+        public void writeValue(WritableBuffer buffer, final boolean[] a)
         {
             BooleanType.BooleanEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw((byte)(1 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, (byte)(1 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null)));
-            getEncoder().writeRaw((byte)a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(boolean b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
 
         }
 
-        public void writeValue(final byte[] a)
+        public void writeValue(WritableBuffer buffer, final byte[] a)
         {
             ByteType.ByteEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw((byte)(1 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, (byte)(1 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null)));
-            getEncoder().writeRaw((byte)a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(byte b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final short[] a)
+        public void writeValue(WritableBuffer buffer, final short[] a)
         {
             ShortType.ShortEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw((byte)(1 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, (byte)(1 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null)));
-            getEncoder().writeRaw((byte)a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(short b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final int[] a)
+        public void writeValue(WritableBuffer buffer, final int[] a)
         {
 
             IntegerType.IntegerEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw((byte)(1 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, (byte)(1 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null)));
-            getEncoder().writeRaw((byte)a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(int b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final long[] a)
+        public void writeValue(WritableBuffer buffer, final long[] a)
         {
 
             LongType.LongEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw((byte)(1 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, (byte)(1 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null)));
-            getEncoder().writeRaw((byte)a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(long b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final float[] a)
+        public void writeValue(WritableBuffer buffer, final float[] a)
         {
 
             FloatType.FloatEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw((byte)(1 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, (byte)(1 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null)));
-            getEncoder().writeRaw((byte)a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(float b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final double[] a)
+        public void writeValue(WritableBuffer buffer, final double[] a)
         {
 
             DoubleType.DoubleEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw((byte)(1 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, (byte)(1 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null)));
-            getEncoder().writeRaw((byte)a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(double b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
-        public void writeValue(final char[] a)
+        public void writeValue(WritableBuffer buffer, final char[] a)
         {
 
             CharacterType.CharacterEncoding underlyingEncoder = getUnderlyingEncoding(a);
-            getEncoder().writeRaw((byte)(1 + underlyingEncoder.getConstructorSize()
+            getEncoder().writeRaw(buffer, (byte)(1 + underlyingEncoder.getConstructorSize()
                                   + a.length*underlyingEncoder.getValueSize(null)));
-            getEncoder().writeRaw((byte)a.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)a.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(char b : a)
             {
-                underlyingEncoder.writeValue(b);
+                underlyingEncoder.writeValue(buffer, b);
             }
         }
 
         public void setValue(final Object[] val, final TypeEncoding encoder, final int size)
         {
-            _val = val;
-            _underlyingEncoder = encoder;
-            _size = size;
+            CachedCalculation.setCachedValue(val, encoder, size);
         }
 
         @Override
-        protected void writeEncodedValue(final Object[] val)
+        protected void writeEncodedValue(WritableBuffer buffer, final Object[] val)
         {
             TypeEncoding underlyingEncoder;
 
-            if(_val != val)
+            CachedCalculation cachedCalculation = CachedCalculation.getCache();
+
+
+            if(cachedCalculation.getVal() != val)
             {
-                _val = val;
-                _underlyingEncoder = underlyingEncoder = calculateEncoder(val, getEncoder());
-                _size =  calculateSize(val, underlyingEncoder);
+                underlyingEncoder = calculateEncoder(val, getEncoder());
+                cachedCalculation.setValue(val, underlyingEncoder, calculateSize(val, underlyingEncoder));
             }
             else
             {
-                underlyingEncoder = _underlyingEncoder;
+                underlyingEncoder = cachedCalculation.getUnderlyingEncoder();
             }
-            getEncoder().writeRaw((byte)val.length);
-            underlyingEncoder.writeConstructor();
+            getEncoder().writeRaw(buffer, (byte)val.length);
+            underlyingEncoder.writeConstructor(buffer);
             for(Object o : val)
             {
                 if(o.getClass().isArray() && o.getClass().getComponentType().isPrimitive())
@@ -797,42 +792,42 @@ public class ArrayType implements PrimitiveType<Object[]>
                     if(componentType == Boolean.TYPE)
                     {
                         boolean[] componentArray = (boolean[]) o;
-                        arrayEncoding.writeValue(componentArray);
+                        arrayEncoding.writeValue(buffer, componentArray);
                     }
                     else if(componentType == Byte.TYPE)
                     {
                         byte[] componentArray = (byte[]) o;
-                        arrayEncoding.writeValue(componentArray);
+                        arrayEncoding.writeValue(buffer, componentArray);
                     }
                     else if(componentType == Short.TYPE)
                     {
                         short[] componentArray = (short[]) o;
-                        arrayEncoding.writeValue(componentArray);
+                        arrayEncoding.writeValue(buffer, componentArray);
                     }
                     else if(componentType == Integer.TYPE)
                     {
                         int[] componentArray = (int[]) o;
-                        arrayEncoding.writeValue(componentArray);
+                        arrayEncoding.writeValue(buffer, componentArray);
                     }
                     else if(componentType == Long.TYPE)
                     {
                         long[] componentArray = (long[]) o;
-                        arrayEncoding.writeValue(componentArray);
+                        arrayEncoding.writeValue(buffer, componentArray);
                     }
                     else if(componentType == Float.TYPE)
                     {
                         float[] componentArray = (float[]) o;
-                        arrayEncoding.writeValue(componentArray);
+                        arrayEncoding.writeValue(buffer, componentArray);
                     }
                     else if(componentType == Double.TYPE)
                     {
                         double[] componentArray = (double[]) o;
-                        arrayEncoding.writeValue(componentArray);
+                        arrayEncoding.writeValue(buffer, componentArray);
                     }
                     else if(componentType == Character.TYPE)
                     {
                         char[] componentArray = (char[]) o;
-                        arrayEncoding.writeValue(componentArray);
+                        arrayEncoding.writeValue(buffer, componentArray);
                     }
                     else
                     {
@@ -842,7 +837,7 @@ public class ArrayType implements PrimitiveType<Object[]>
                 }
                 else
                 {
-                    underlyingEncoder.writeValue(o);
+                    underlyingEncoder.writeValue(buffer, o);
                 }
             }
         }
@@ -850,13 +845,14 @@ public class ArrayType implements PrimitiveType<Object[]>
         @Override
         protected int getEncodedValueSize(final Object[] val)
         {
-            if(_val != val)
+            CachedCalculation cachedCalculation = CachedCalculation.getCache();
+            if(cachedCalculation.getVal() != val)
             {
-                _val = val;
-                _underlyingEncoder = calculateEncoder(val, getEncoder());
-                _size = calculateSize(val, _underlyingEncoder);
+                TypeEncoding underlyingEncoder = calculateEncoder(val, getEncoder());
+
+                cachedCalculation.setValue(val, underlyingEncoder, calculateSize(val, underlyingEncoder));
             }
-            return 1 + _size;
+            return 1 + cachedCalculation.getSize();
         }
 
         @Override
@@ -875,20 +871,20 @@ public class ArrayType implements PrimitiveType<Object[]>
             return getType() == encoding.getType();
         }
 
-        public Object[] readValue()
+        public Object[] readValue(ReadableBuffer buffer)
         {
             DecoderImpl decoder = getDecoder();
-            int size = ((int)decoder.readRawByte()) & 0xFF;
-            int count = ((int)decoder.readRawByte()) & 0xFF;
-            return decodeArray(decoder, count);
+            int size = ((int)decoder.readRawByte(buffer)) & 0xFF;
+            int count = ((int)decoder.readRawByte(buffer)) & 0xFF;
+            return decodeArray(buffer, decoder, count);
         }
 
-        public Object readValueArray()
+        public Object readValueArray(ReadableBuffer buffer)
         {
             DecoderImpl decoder = getDecoder();
-            int size = ((int)decoder.readRawByte()) & 0xFF;
-            int count = ((int)decoder.readRawByte()) & 0xFF;
-            return decodeArrayAsObject(decoder, count);
+            int size = ((int)decoder.readRawByte(buffer)) & 0xFF;
+            int count = ((int)decoder.readRawByte(buffer)) & 0xFF;
+            return decodeArrayAsObject(buffer, decoder, count);
         }
 
     }
@@ -967,19 +963,19 @@ public class ArrayType implements PrimitiveType<Object[]>
         return _characterType.getCanonicalEncoding();
     }
 
-    private static Object[] decodeArray(final DecoderImpl decoder, final int count)
+//    private static Object[] decodeArray(final DecoderImpl decoder, final int count)
+    private static Object[] decodeArray(ReadableBuffer buffer, final DecoderImpl decoder, final int count)
     {
-        TypeConstructor constructor = decoder.readConstructor();
-        return decodeNonPrimitive(decoder, constructor, count);
+        TypeConstructor constructor = decoder.readConstructor(buffer);
+        return decodeNonPrimitive(decoder, buffer, constructor, count);
     }
 
-    private static Object[] decodeNonPrimitive(final DecoderImpl decoder,
-                                               final TypeConstructor constructor,
+    private static Object[] decodeNonPrimitive(final DecoderImpl decoder, ReadableBuffer buffer, final TypeConstructor constructor,
                                                final int count)
     {
-        if (count > decoder.getByteBufferRemaining()) {
+        if (count > decoder.getByteBufferRemaining(buffer)) {
             throw new IllegalArgumentException("Array element count "+count+" is specified to be greater than the amount of data available ("+
-                                               decoder.getByteBufferRemaining()+")");
+                                               decoder.getByteBufferRemaining(buffer)+")");
         }
 
         if(constructor instanceof ArrayEncoding)
@@ -989,7 +985,7 @@ public class ArrayType implements PrimitiveType<Object[]>
             Object[] array = new Object[count];
             for(int i = 0; i < count; i++)
             {
-                array[i] = arrayEncoding.readValueArray();
+                array[i] = arrayEncoding.readValueArray(buffer);
             }
 
             return array;
@@ -1000,50 +996,50 @@ public class ArrayType implements PrimitiveType<Object[]>
 
             for(int i = 0; i < count; i++)
             {
-                array[i] = constructor.readValue();
+                array[i] = constructor.readValue(buffer);
             }
 
             return array;
         }
     }
 
-    private static Object decodeArrayAsObject(final DecoderImpl decoder, final int count)
+    private static Object decodeArrayAsObject(ReadableBuffer buffer, final DecoderImpl decoder, final int count)
     {
-        TypeConstructor constructor = decoder.readConstructor();
+        TypeConstructor constructor = decoder.readConstructor(buffer);
         if(constructor.encodesJavaPrimitive())
         {
-            if (count > decoder.getByteBufferRemaining()) {
+            if (count > decoder.getByteBufferRemaining(buffer)) {
                 throw new IllegalArgumentException("Array element count "+count+" is specified to be greater than the amount of data available ("+
-                                                   decoder.getByteBufferRemaining()+")");
+                                                   decoder.getByteBufferRemaining(buffer)+")");
             }
 
             if(constructor instanceof BooleanType.BooleanEncoding)
             {
-                return decodeBooleanArray((BooleanType.BooleanEncoding) constructor, count);
+                return decodeBooleanArray(buffer, (BooleanType.BooleanEncoding) constructor, count);
             }
             else if(constructor instanceof ByteType.ByteEncoding)
             {
-                return decodeByteArray((ByteType.ByteEncoding)constructor, count);
+                return decodeByteArray(buffer, (ByteType.ByteEncoding)constructor, count);
             }
             else if(constructor instanceof ShortType.ShortEncoding)
             {
-                return decodeShortArray((ShortType.ShortEncoding)constructor, count);
+                return decodeShortArray(buffer, (ShortType.ShortEncoding)constructor, count);
             }
             else if(constructor instanceof IntegerType.IntegerEncoding)
             {
-                return decodeIntArray((IntegerType.IntegerEncoding)constructor, count);
+                return decodeIntArray(buffer, (IntegerType.IntegerEncoding)constructor, count);
             }
             else if(constructor instanceof LongType.LongEncoding)
             {
-                return decodeLongArray((LongType.LongEncoding) constructor, count);
+                return decodeLongArray(buffer, (LongType.LongEncoding) constructor, count);
             }
             else if(constructor instanceof FloatType.FloatEncoding)
             {
-                return decodeFloatArray((FloatType.FloatEncoding) constructor, count);
+                return decodeFloatArray(buffer, (FloatType.FloatEncoding) constructor, count);
             }
             else if(constructor instanceof DoubleType.DoubleEncoding)
             {
-                return decodeDoubleArray((DoubleType.DoubleEncoding)constructor, count);
+                return decodeDoubleArray(buffer, (DoubleType.DoubleEncoding)constructor, count);
             }
             else
             {
@@ -1053,91 +1049,91 @@ public class ArrayType implements PrimitiveType<Object[]>
         }
         else
         {
-            return decodeNonPrimitive(decoder, constructor, count);
+            return decodeNonPrimitive(decoder, buffer, constructor, count);
         }
 
     }
 
-    private static boolean[] decodeBooleanArray(BooleanType.BooleanEncoding constructor, final int count)
+    private static boolean[] decodeBooleanArray(ReadableBuffer buffer, BooleanType.BooleanEncoding constructor, final int count)
     {
         boolean[] array = new boolean[count];
 
         for(int i = 0; i < count; i++)
         {
-            array[i] = constructor.readPrimitiveValue();
+            array[i] = constructor.readPrimitiveValue(buffer);
         }
 
         return array;
     }
 
-    private static byte[] decodeByteArray(ByteType.ByteEncoding constructor , final int count)
+    private static byte[] decodeByteArray(ReadableBuffer buffer, ByteType.ByteEncoding constructor , final int count)
     {
         byte[] array = new byte[count];
 
         for(int i = 0; i < count; i++)
         {
-            array[i] = constructor.readPrimitiveValue();
+            array[i] = constructor.readPrimitiveValue(buffer);
         }
 
         return array;
     }
 
-    private static short[] decodeShortArray(ShortType.ShortEncoding constructor, final int count)
+    private static short[] decodeShortArray(ReadableBuffer buffer, ShortType.ShortEncoding constructor, final int count)
     {
         short[] array = new short[count];
 
         for(int i = 0; i < count; i++)
         {
-            array[i] = constructor.readPrimitiveValue();
+            array[i] = constructor.readPrimitiveValue(buffer);
         }
 
         return array;
     }
 
-    private static int[] decodeIntArray(IntegerType.IntegerEncoding constructor, final int count)
+    private static int[] decodeIntArray(ReadableBuffer buffer, IntegerType.IntegerEncoding constructor, final int count)
     {
         int[] array = new int[count];
 
         for(int i = 0; i < count; i++)
         {
-            array[i] = constructor.readPrimitiveValue();
+            array[i] = constructor.readPrimitiveValue(buffer);
         }
 
         return array;
     }
 
 
-    private static long[] decodeLongArray(LongType.LongEncoding constructor, final int count)
+    private static long[] decodeLongArray(ReadableBuffer buffer, LongType.LongEncoding constructor, final int count)
     {
         long[] array = new long[count];
 
         for(int i = 0; i < count; i++)
         {
-            array[i] = constructor.readPrimitiveValue();
+            array[i] = constructor.readPrimitiveValue(buffer);
         }
 
         return array;
     }
 
-    private static float[] decodeFloatArray(FloatType.FloatEncoding constructor, final int count)
+    private static float[] decodeFloatArray(ReadableBuffer buffer, FloatType.FloatEncoding constructor, final int count)
     {
         float[] array = new float[count];
 
         for(int i = 0; i < count; i++)
         {
-            array[i] = constructor.readPrimitiveValue();
+            array[i] = constructor.readPrimitiveValue(buffer);
         }
 
         return array;
     }
 
-    private static double[] decodeDoubleArray(DoubleType.DoubleEncoding constructor, final int count)
+    private static double[] decodeDoubleArray(ReadableBuffer buffer, DoubleType.DoubleEncoding constructor, final int count)
     {
         double[] array = new double[count];
 
         for(int i = 0; i < count; i++)
         {
-            array[i] = constructor.readPrimitiveValue();
+            array[i] = constructor.readPrimitiveValue(buffer);
         }
 
         return array;

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/BigIntegerType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/BigIntegerType.java
@@ -26,11 +26,11 @@ import java.util.Collection;
 
 public class BigIntegerType extends AbstractPrimitiveType<BigInteger> {
 
-    public static interface BigIntegerEncoding extends PrimitiveTypeEncoding<BigInteger>
+    public interface BigIntegerEncoding extends PrimitiveTypeEncoding<BigInteger>
     {
-        void write(BigInteger l);
-        void writeValue(BigInteger l);
-        public BigInteger readPrimitiveValue();
+        void write(WritableBuffer buffer, BigInteger l);
+        void writeValue(WritableBuffer buffer, BigInteger l);
+        BigInteger readPrimitiveValue(ReadableBuffer buffer);
     }
 
     private static final BigInteger BIG_BYTE_MIN = BigInteger.valueOf(Byte.MIN_VALUE);
@@ -101,15 +101,15 @@ public class BigIntegerType extends AbstractPrimitiveType<BigInteger> {
             return BigIntegerType.this;
         }
 
-        public void writeValue(final BigInteger val)
+        public void writeValue(WritableBuffer buffer, final BigInteger val)
         {
-            getEncoder().writeRaw(longValueExact(val));
+            getEncoder().writeRaw(buffer, longValueExact(val));
         }
         
-        public void write(final BigInteger l)
+        public void write(WritableBuffer buffer, final BigInteger l)
         {
-            writeConstructor();
-            getEncoder().writeRaw(longValueExact(l));
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, longValueExact(l));
             
         }
 
@@ -118,14 +118,14 @@ public class BigIntegerType extends AbstractPrimitiveType<BigInteger> {
             return (getType() == encoding.getType());
         }
 
-        public BigInteger readValue()
+        public BigInteger readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
-        public BigInteger readPrimitiveValue()
+        public BigInteger readPrimitiveValue(ReadableBuffer buffer)
         {
-            return BigInteger.valueOf(getDecoder().readLong());
+            return BigInteger.valueOf(getDecoder().readLong(buffer));
         }
 
 
@@ -155,15 +155,15 @@ public class BigIntegerType extends AbstractPrimitiveType<BigInteger> {
             return 1;
         }
 
-        public void write(final BigInteger l)
+        public void write(WritableBuffer buffer, final BigInteger l)
         {
-            writeConstructor();
-            getEncoder().writeRaw(l.byteValue());
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, l.byteValue());
         }
 
-        public BigInteger readPrimitiveValue()
+        public BigInteger readPrimitiveValue(ReadableBuffer buffer)
         {
-            return BigInteger.valueOf(getDecoder().readRawByte());
+            return BigInteger.valueOf(getDecoder().readRawByte(buffer));
         }
 
         public BigIntegerType getType()
@@ -171,9 +171,9 @@ public class BigIntegerType extends AbstractPrimitiveType<BigInteger> {
             return BigIntegerType.this;
         }
 
-        public void writeValue(final BigInteger val)
+        public void writeValue(WritableBuffer buffer, final BigInteger val)
         {
-            getEncoder().writeRaw(val.byteValue());
+            getEncoder().writeRaw(buffer, val.byteValue());
         }
 
         public boolean encodesSuperset(final TypeEncoding<BigInteger> encoder)
@@ -181,9 +181,9 @@ public class BigIntegerType extends AbstractPrimitiveType<BigInteger> {
             return encoder == this;
         }
 
-        public BigInteger readValue()
+        public BigInteger readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/BinaryType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/BinaryType.java
@@ -75,9 +75,9 @@ public class BinaryType extends AbstractPrimitiveType<Binary>
         }
 
         @Override
-        protected void writeEncodedValue(final Binary val)
+        protected void writeEncodedValue(WritableBuffer buffer, final Binary val)
         {
-            getEncoder().writeRaw(val.getArray(), val.getArrayOffset(), val.getLength());
+            getEncoder().writeRaw(buffer, val.getArray(), val.getArrayOffset(), val.getLength());
         }
 
         @Override
@@ -103,16 +103,11 @@ public class BinaryType extends AbstractPrimitiveType<Binary>
             return (getType() == encoding.getType());
         }
 
-        public Binary readValue()
+        public Binary readValue(ReadableBuffer buffer)
         {
-            final DecoderImpl decoder = getDecoder();
-            int size = decoder.readRawInt();
-            if (size > decoder.getByteBufferRemaining()) {
-                throw new IllegalArgumentException("Binary data size "+size+" is specified to be greater than the amount of data available ("+
-                                                   decoder.getByteBufferRemaining()+")");
-            }
+            int size = getDecoder().readRawInt(buffer);
             byte[] data = new byte[size];
-            decoder.readRaw(data, 0, size);
+            getDecoder().readRaw(buffer, data, 0, size);
             return new Binary(data);
         }
     }
@@ -128,9 +123,9 @@ public class BinaryType extends AbstractPrimitiveType<Binary>
         }
 
         @Override
-        protected void writeEncodedValue(final Binary val)
+        protected void writeEncodedValue(WritableBuffer buffer, final Binary val)
         {
-            getEncoder().writeRaw(val.getArray(), val.getArrayOffset(), val.getLength());
+            getEncoder().writeRaw(buffer, val.getArray(), val.getArrayOffset(), val.getLength());
         }
 
         @Override
@@ -156,11 +151,11 @@ public class BinaryType extends AbstractPrimitiveType<Binary>
             return encoder == this;
         }
 
-        public Binary readValue()
+        public Binary readValue(ReadableBuffer buffer)
         {
-            int size = ((int)getDecoder().readRawByte()) & 0xff;
+            int size = ((int)getDecoder().readRawByte(buffer)) & 0xff;
             byte[] data = new byte[size];
-            getDecoder().readRaw(data, 0, size);
+            getDecoder().readRaw(buffer, data, 0, size);
             return new Binary(data);
         }
     }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/BooleanType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/BooleanType.java
@@ -35,10 +35,10 @@ public final class BooleanType extends AbstractPrimitiveType<Boolean>
 
     public static interface BooleanEncoding extends PrimitiveTypeEncoding<Boolean>
     {
-        void write(boolean b);
-        void writeValue(boolean b);
+        void write(WritableBuffer buffer, boolean b);
+        void writeValue(WritableBuffer buffer, boolean b);
 
-        boolean readPrimitiveValue();
+        boolean readPrimitiveValue(ReadableBuffer buffer);
     }
 
     BooleanType(final EncoderImpl encoder, final DecoderImpl decoder)
@@ -66,9 +66,9 @@ public final class BooleanType extends AbstractPrimitiveType<Boolean>
         return val ? _trueEncoder : _falseEncoder;
     }
 
-    public void writeValue(final boolean val)
+    public void writeValue(WritableBuffer buffer, final boolean val)
     {
-        getEncoding(val).write(val);
+        getEncoding(val).write(buffer, val);
     }
 
 
@@ -109,16 +109,16 @@ public final class BooleanType extends AbstractPrimitiveType<Boolean>
             return BooleanType.this;
         }
 
-        public void writeValue(final Boolean val)
+        public void writeValue(WritableBuffer buffer, final Boolean val)
         {
         }
 
-        public void write(final boolean b)
+        public void write(WritableBuffer buffer, final boolean b)
         {
-            writeConstructor();
+            writeConstructor(buffer);
         }
 
-        public void writeValue(final boolean b)
+        public void writeValue(WritableBuffer buffer, final boolean b)
         {
         }
 
@@ -127,12 +127,12 @@ public final class BooleanType extends AbstractPrimitiveType<Boolean>
             return encoding == this;
         }
 
-        public Boolean readValue()
+        public Boolean readValue(ReadableBuffer buffer)
         {
             return Boolean.TRUE;
         }
 
-        public boolean readPrimitiveValue()
+        public boolean readPrimitiveValue(ReadableBuffer buffers)
         {
             return true;
         }
@@ -170,20 +170,20 @@ public final class BooleanType extends AbstractPrimitiveType<Boolean>
             return BooleanType.this;
         }
 
-        public void writeValue(final Boolean val)
+        public void writeValue(WritableBuffer buffer, final Boolean val)
         {
         }
 
-        public void write(final boolean b)
+        public void write(WritableBuffer buffer, final boolean b)
         {
-            writeConstructor();
+            writeConstructor(buffer);
         }
 
-        public void writeValue(final boolean b)
+        public void writeValue(WritableBuffer buffer, final boolean b)
         {
         }
 
-        public boolean readPrimitiveValue()
+        public boolean readPrimitiveValue(ReadableBuffer buffer)
         {
             return false;
         }
@@ -193,7 +193,7 @@ public final class BooleanType extends AbstractPrimitiveType<Boolean>
             return encoding == this;
         }
 
-        public Boolean readValue()
+        public Boolean readValue(ReadableBuffer buffer)
         {
             return Boolean.FALSE;
         }
@@ -231,26 +231,26 @@ public final class BooleanType extends AbstractPrimitiveType<Boolean>
             return EncodingCodes.BOOLEAN;
         }
 
-        public void writeValue(final Boolean val)
+        public void writeValue(WritableBuffer buffer, final Boolean val)
         {
-            getEncoder().writeRaw(val ? BYTE_1 : BYTE_0);
+            getEncoder().writeRaw(buffer, val ? BYTE_1 : BYTE_0);
         }
 
-        public void write(final boolean val)
+        public void write(WritableBuffer buffer, final boolean val)
         {
-            writeConstructor();
-            getEncoder().writeRaw(val ? BYTE_1 : BYTE_0);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, val ? BYTE_1 : BYTE_0);
         }
 
-        public void writeValue(final boolean b)
+        public void writeValue(WritableBuffer buffer, final boolean b)
         {
-            getEncoder().writeRaw(b ? BYTE_1 : BYTE_0);
+            getEncoder().writeRaw(buffer, b ? BYTE_1 : BYTE_0);
         }
 
-        public boolean readPrimitiveValue()
+        public boolean readPrimitiveValue(ReadableBuffer buffer)
         {
 
-            return getDecoder().readRawByte() != BYTE_0;
+            return getDecoder().readRawByte(buffer) != BYTE_0;
         }
 
         public boolean encodesSuperset(final TypeEncoding<Boolean> encoding)
@@ -258,9 +258,9 @@ public final class BooleanType extends AbstractPrimitiveType<Boolean>
             return (getType() == encoding.getType());
         }
 
-        public Boolean readValue()
+        public Boolean readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue() ? Boolean.TRUE : Boolean.FALSE;
+            return readPrimitiveValue(buffer) ? Boolean.TRUE : Boolean.FALSE;
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/ByteBufferDecoder.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/ByteBufferDecoder.java
@@ -20,11 +20,6 @@
  */
 package org.apache.qpid.proton.codec;
 
-import java.nio.ByteBuffer;
-
-public interface ByteBufferDecoder extends Decoder
+public interface ByteBufferDecoder extends Decoder<ReadableBuffer>
 {
-    public void setByteBuffer(ByteBuffer buffer);
-
-    public int getByteBufferRemaining();
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/ByteBufferEncoder.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/ByteBufferEncoder.java
@@ -20,9 +20,7 @@
  */
 package org.apache.qpid.proton.codec;
 
-import java.nio.ByteBuffer;
 
-public interface ByteBufferEncoder extends Encoder
+public interface ByteBufferEncoder extends Encoder<WritableBuffer>
 {
-    public void setByteBuffer(ByteBuffer buf);
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/ByteType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/ByteType.java
@@ -55,9 +55,9 @@ public class ByteType extends AbstractPrimitiveType<Byte>
         return Collections.singleton(_byteEncoding);
     }
 
-    public void writeType(byte b)
+    public void writeType(WritableBuffer buffer, byte b)
     {
-        _byteEncoding.write(b);
+        _byteEncoding.write(buffer, b);
     }
 
 
@@ -86,21 +86,21 @@ public class ByteType extends AbstractPrimitiveType<Byte>
             return ByteType.this;
         }
 
-        public void writeValue(final Byte val)
+        public void writeValue(WritableBuffer buffer, final Byte val)
         {
-            getEncoder().writeRaw(val);
+            getEncoder().writeRaw(buffer, val);
         }
 
 
-        public void write(final byte val)
+        public void write(WritableBuffer buffer, final byte val)
         {
-            writeConstructor();
-            getEncoder().writeRaw(val);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, val);
         }
 
-        public void writeValue(final byte val)
+        public void writeValue(WritableBuffer buffer, final byte val)
         {
-            getEncoder().writeRaw(val);
+            getEncoder().writeRaw(buffer, val);
         }
 
         public boolean encodesSuperset(final TypeEncoding<Byte> encoding)
@@ -108,14 +108,14 @@ public class ByteType extends AbstractPrimitiveType<Byte>
             return (getType() == encoding.getType());
         }
 
-        public Byte readValue()
+        public Byte readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
-        public byte readPrimitiveValue()
+        public byte readPrimitiveValue(ReadableBuffer buffer)
         {
-            return getDecoder().readRawByte();
+            return getDecoder().readRawByte(buffer);
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/CachedCalculation.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/CachedCalculation.java
@@ -1,0 +1,89 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.proton.codec;
+
+/**
+ * This class provides a placeholder to cache size calculations through ThreadLocals.
+ *
+ * In some decoders we pre-calculate the size, and reuse the same calculation at a later point when actually writing
+ * the data
+ */
+public class CachedCalculation
+ {
+     private Object _val;
+     private TypeEncoding _underlyingEncoder;
+     private int _size;
+
+     public CachedCalculation setValue(Object val, TypeEncoding underlyingEncoder, int size)
+     {
+         this._val = val;
+         this._underlyingEncoder = underlyingEncoder;
+         this._size = size;
+         return this;
+     }
+
+     public CachedCalculation setValue(Object val, int size)
+     {
+         return setValue(val, null, size);
+     }
+
+     public Object getVal()
+     {
+         return _val;
+     }
+
+     public TypeEncoding getUnderlyingEncoder()
+     {
+         return _underlyingEncoder;
+     }
+
+     public int getSize()
+     {
+         return _size;
+     }
+
+
+     private static ThreadLocal<CachedCalculation> threadLocalCalculatedArraySize = new ThreadLocal<CachedCalculation>();
+
+
+     public static CachedCalculation getCache()
+     {
+         CachedCalculation local = threadLocalCalculatedArraySize.get();
+         if (local == null)
+         {
+             local = new CachedCalculation();
+             threadLocalCalculatedArraySize.set(local);
+         }
+
+         return local;
+     }
+
+     public static CachedCalculation setCachedValue(Object val, TypeEncoding encoding, int size)
+     {
+         return getCache().setValue(val, encoding, size);
+     }
+
+     public static CachedCalculation setCachedValue(Object val, int size)
+     {
+         return getCache().setValue(val, size);
+     }
+}

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/CharacterType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/CharacterType.java
@@ -55,9 +55,9 @@ public class CharacterType extends AbstractPrimitiveType<Character>
         return Collections.singleton(_characterEncoding);
     }
 
-    public void write(char c)
+    public void write(WritableBuffer buffer, char c)
     {
-        _characterEncoding.write(c);
+        _characterEncoding.write(buffer, c);
     }
 
     public class CharacterEncoding extends FixedSizePrimitiveTypeEncoding<Character>
@@ -85,20 +85,20 @@ public class CharacterType extends AbstractPrimitiveType<Character>
             return CharacterType.this;
         }
 
-        public void writeValue(final Character val)
+        public void writeValue(WritableBuffer buffer, final Character val)
         {
-            getEncoder().writeRaw((int)val.charValue() & 0xffff);
+            getEncoder().writeRaw(buffer, (int)val.charValue() & 0xffff);
         }
 
-        public void writeValue(final char val)
+        public void writeValue(WritableBuffer buffer, final char val)
         {
-            getEncoder().writeRaw((int)val & 0xffff);
+            getEncoder().writeRaw(buffer, (int)val & 0xffff);
         }
 
-        public void write(final char c)
+        public void write(WritableBuffer buffer, final char c)
         {
-            writeConstructor();
-            getEncoder().writeRaw((int)c & 0xffff);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, (int)c & 0xffff);
 
         }
 
@@ -107,14 +107,14 @@ public class CharacterType extends AbstractPrimitiveType<Character>
             return (getType() == encoding.getType());
         }
 
-        public Character readValue()
+        public Character readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
-        public char readPrimitiveValue()
+        public char readPrimitiveValue(ReadableBuffer buffer)
         {
-            return (char) (getDecoder().readRawInt() & 0xffff);
+            return (char) (getDecoder().readRawInt(buffer) & 0xffff);
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/Decimal128Type.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/Decimal128Type.java
@@ -82,10 +82,10 @@ public class Decimal128Type extends AbstractPrimitiveType<Decimal128>
             return Decimal128Type.this;
         }
 
-        public void writeValue(final Decimal128 val)
+        public void writeValue(WritableBuffer buffer, final Decimal128 val)
         {
-            getEncoder().writeRaw(val.getMostSignificantBits());
-            getEncoder().writeRaw(val.getLeastSignificantBits());
+            getEncoder().writeRaw(buffer, val.getMostSignificantBits());
+            getEncoder().writeRaw(buffer, val.getLeastSignificantBits());
         }
 
         public boolean encodesSuperset(final TypeEncoding<Decimal128> encoding)
@@ -93,10 +93,10 @@ public class Decimal128Type extends AbstractPrimitiveType<Decimal128>
             return (getType() == encoding.getType());
         }
 
-        public Decimal128 readValue()
+        public Decimal128 readValue(ReadableBuffer buffer)
         {
-            long msb = getDecoder().readRawLong();
-            long lsb = getDecoder().readRawLong();
+            long msb = getDecoder().readRawLong(buffer);
+            long lsb = getDecoder().readRawLong(buffer);
             return new Decimal128(msb, lsb);
         }
     }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/Decimal32Type.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/Decimal32Type.java
@@ -82,9 +82,9 @@ public class Decimal32Type extends AbstractPrimitiveType<Decimal32>
             return Decimal32Type.this;
         }
 
-        public void writeValue(final Decimal32 val)
+        public void writeValue(WritableBuffer buffer, final Decimal32 val)
         {
-            getEncoder().writeRaw(val.getBits());
+            getEncoder().writeRaw(buffer, val.getBits());
         }
 
         public boolean encodesSuperset(final TypeEncoding<Decimal32> encoding)
@@ -92,9 +92,9 @@ public class Decimal32Type extends AbstractPrimitiveType<Decimal32>
             return (getType() == encoding.getType());
         }
 
-        public Decimal32 readValue()
+        public Decimal32 readValue(ReadableBuffer buffer)
         {
-            return new Decimal32(getDecoder().readRawInt());
+            return new Decimal32(getDecoder().readRawInt(buffer));
         }
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/Decimal64Type.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/Decimal64Type.java
@@ -82,9 +82,9 @@ public class Decimal64Type extends AbstractPrimitiveType<Decimal64>
             return Decimal64Type.this;
         }
 
-        public void writeValue(final Decimal64 val)
+        public void writeValue(WritableBuffer buffer, final Decimal64 val)
         {
-            getEncoder().writeRaw(val.getBits());
+            getEncoder().writeRaw(buffer, val.getBits());
         }
 
         public boolean encodesSuperset(final TypeEncoding<Decimal64> encoding)
@@ -92,9 +92,9 @@ public class Decimal64Type extends AbstractPrimitiveType<Decimal64>
             return (getType() == encoding.getType());
         }
 
-        public Decimal64 readValue()
+        public Decimal64 readValue(ReadableBuffer buffer)
         {
-            return new Decimal64(getDecoder().readRawLong());
+            return new Decimal64(getDecoder().readRawLong(buffer));
         }
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/Decoder.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/Decoder.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public interface Decoder
+public interface Decoder<B>
 {
     public static interface ListProcessor<T>
     {
@@ -43,105 +43,105 @@ public interface Decoder
     }
 
 
-    Boolean readBoolean();
-    Boolean readBoolean(Boolean defaultVal);
-    boolean readBoolean(boolean defaultVal);
+    Boolean readBoolean(B buffer);
+    Boolean readBoolean(B buffer, Boolean defaultVal);
+    boolean readBoolean(B buffer, boolean defaultVal);
 
-    Byte readByte();
-    Byte readByte(Byte defaultVal);
-    byte readByte(byte defaultVal);
+    Byte readByte(B buffer);
+    Byte readByte(B buffer, Byte defaultVal);
+    byte readByte(B buffer, byte defaultVal);
 
-    Short readShort();
-    Short readShort(Short defaultVal);
-    short readShort(short defaultVal);
+    Short readShort(B buffer);
+    Short readShort(B buffer, Short defaultVal);
+    short readShort(B buffer, short defaultVal);
 
-    Integer readInteger();
-    Integer readInteger(Integer defaultVal);
-    int readInteger(int defaultVal);
+    Integer readInteger(B buffer);
+    Integer readInteger(B buffer, Integer defaultVal);
+    int readInteger(B buffer, int defaultVal);
 
-    Long readLong();
-    Long readLong(Long defaultVal);
-    long readLong(long defaultVal);
+    Long readLong(B buffer);
+    Long readLong(B buffer, Long defaultVal);
+    long readLong(B buffer, long defaultVal);
 
-    UnsignedByte readUnsignedByte();
-    UnsignedByte readUnsignedByte(UnsignedByte defaultVal);
+    UnsignedByte readUnsignedByte(B buffer);
+    UnsignedByte readUnsignedByte(B buffer, UnsignedByte defaultVal);
 
-    UnsignedShort readUnsignedShort();
-    UnsignedShort readUnsignedShort(UnsignedShort defaultVal);
+    UnsignedShort readUnsignedShort(B buffer);
+    UnsignedShort readUnsignedShort(B buffer, UnsignedShort defaultVal);
 
-    UnsignedInteger readUnsignedInteger();
-    UnsignedInteger readUnsignedInteger(UnsignedInteger defaultVal);
+    UnsignedInteger readUnsignedInteger(B buffer);
+    UnsignedInteger readUnsignedInteger(B buffer, UnsignedInteger defaultVal);
 
-    UnsignedLong readUnsignedLong();
-    UnsignedLong readUnsignedLong(UnsignedLong defaultVal);
+    UnsignedLong readUnsignedLong(B buffer);
+    UnsignedLong readUnsignedLong(B buffer, UnsignedLong defaultVal);
 
-    Character readCharacter();
-    Character readCharacter(Character defaultVal);
-    char readCharacter(char defaultVal);
+    Character readCharacter(B buffer);
+    Character readCharacter(B buffer, Character defaultVal);
+    char readCharacter(B buffer, char defaultVal);
 
-    Float readFloat();
-    Float readFloat(Float defaultVal);
-    float readFloat(float defaultVal);
+    Float readFloat(B buffer);
+    Float readFloat(B buffer, Float defaultVal);
+    float readFloat(B buffer, float defaultVal);
 
-    Double readDouble();
-    Double readDouble(Double defaultVal);
-    double readDouble(double defaultVal);
+    Double readDouble(B buffer);
+    Double readDouble(B buffer, Double defaultVal);
+    double readDouble(B buffer, double defaultVal);
 
-    UUID readUUID();
-    UUID readUUID(UUID defaultValue);
+    UUID readUUID(B buffer);
+    UUID readUUID(B buffer, UUID defaultValue);
 
-    Decimal32 readDecimal32();
-    Decimal32 readDecimal32(Decimal32 defaultValue);
+    Decimal32 readDecimal32(B buffer);
+    Decimal32 readDecimal32(B buffer, Decimal32 defaultValue);
 
-    Decimal64 readDecimal64();
-    Decimal64 readDecimal64(Decimal64 defaultValue);
+    Decimal64 readDecimal64(B buffer);
+    Decimal64 readDecimal64(B buffer, Decimal64 defaultValue);
 
-    Decimal128 readDecimal128();
-    Decimal128 readDecimal128(Decimal128 defaultValue);
+    Decimal128 readDecimal128(B buffer);
+    Decimal128 readDecimal128(B buffer, Decimal128 defaultValue);
 
-    Date readTimestamp();
-    Date readTimestamp(Date defaultValue);
+    Date readTimestamp(B buffer);
+    Date readTimestamp(B buffer, Date defaultValue);
 
-    Binary readBinary();
-    Binary readBinary(Binary defaultValue);
+    Binary readBinary(B buffer);
+    Binary readBinary(B buffer, Binary defaultValue);
 
-    Symbol readSymbol();
-    Symbol readSymbol(Symbol defaultValue);
+    Symbol readSymbol(B buffer);
+    Symbol readSymbol(B buffer, Symbol defaultValue);
 
-    String readString();
-    String readString(String defaultValue);
+    String readString(B buffer);
+    String readString(B buffer, String defaultValue);
 
-    List readList();
-    <T> void readList(ListProcessor<T> processor);
+    List readList(B buffer);
+    <T> void readList(B buffer, ListProcessor<T> processor);
 
-    Map readMap();
+    Map readMap(B buffer);
 
-    <T> T[] readArray(Class<T> clazz);
+    <T> T[] readArray(B buffer, Class<T> clazz);
 
-    Object[] readArray();
+    Object[] readArray(B buffer);
 
-    boolean[] readBooleanArray();
-    byte[] readByteArray();
-    short[] readShortArray();
-    int[] readIntegerArray();
-    long[] readLongArray();
-    float[] readFloatArray();
-    double[] readDoubleArray();
-    char[] readCharacterArray();
+    boolean[] readBooleanArray(B buffer);
+    byte[] readByteArray(B buffer);
+    short[] readShortArray(B buffer);
+    int[] readIntegerArray(B buffer);
+    long[] readLongArray(B buffer);
+    float[] readFloatArray(B buffer);
+    double[] readDoubleArray(B buffer);
+    char[] readCharacterArray(B buffer);
 
-    <T> T[] readMultiple(Class<T> clazz);
+    <T> T[] readMultiple(B buffer, Class<T> clazz);
 
-    Object[] readMultiple();
-    byte[] readByteMultiple();
-    short[] readShortMultiple();
-    int[] readIntegerMultiple();
-    long[] readLongMultiple();
-    float[] readFloatMultiple();
-    double[] readDoubleMultiple();
-    char[] readCharacterMultiple();
+    Object[] readMultiple(B buffer);
+    byte[] readByteMultiple(B buffer);
+    short[] readShortMultiple(B buffer);
+    int[] readIntegerMultiple(B buffer);
+    long[] readLongMultiple(B buffer);
+    float[] readFloatMultiple(B buffer);
+    double[] readDoubleMultiple(B buffer);
+    char[] readCharacterMultiple(B buffer);
 
-    Object readObject();
-    Object readObject(Object defaultValue);
+    Object readObject(B buffer);
+    Object readObject(B buffer, Object defaultValue);
 
     void register(final Object descriptor, final DescribedTypeConstructor dtc);
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/DecoderFactory.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/DecoderFactory.java
@@ -18,25 +18,48 @@
  * under the License.
  *
  */
+
 package org.apache.qpid.proton.codec;
 
-abstract class LargeFloatingSizePrimitiveTypeEncoding<T> extends FloatingSizePrimitiveTypeEncoding<T>
+/**
+ * Integrates factory for Decode and Encoder.
+ */
+public class DecoderFactory
 {
 
-    LargeFloatingSizePrimitiveTypeEncoding(final EncoderImpl encoder, DecoderImpl decoder)
-    {
-        super(encoder, decoder);
+    static DecoderImpl decoder = new DecoderImpl();
+    static EncoderImpl encoder = new EncoderImpl(decoder);
+
+    public DecoderFactory() {
+       AMQPDefinedTypes.registerAllTypes(decoder, encoder);
     }
 
-    @Override
-    public int getSizeBytes()
-    {
-        return 4;
+    private static final DecoderFactory theInstance = new DecoderFactory();
+
+   /**
+    * gets a singleton shared pair of Decode and Encoder
+    * @return
+    */
+   public static DecoderFactory getSingleton() {
+        return theInstance;
     }
 
-    @Override
-    protected void writeSize(WritableBuffer buffer, final T val)
-    {
-        getEncoder().writeRaw(buffer, getEncodedValueSize(val));
+   /**
+    * Produces a new Decode Encoder pair to be customized.
+    * @return
+    */
+    public static DecoderFactory newFactory() {
+        return new DecoderFactory();
     }
+
+    public final DecoderImpl getDecoder()
+    {
+        return decoder;
+    }
+
+    public final EncoderImpl getEncoder()
+    {
+        return encoder;
+    }
+
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/DescribedTypeConstructor.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/DescribedTypeConstructor.java
@@ -22,7 +22,7 @@ package org.apache.qpid.proton.codec;
 
 public interface DescribedTypeConstructor<V>
 {
-    V newInstance(Object described);
+    V newInstance(ReadableBuffer buffer, TypeConstructor typeConstructor);
 
     Class getTypeClass();
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/DoubleType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/DoubleType.java
@@ -55,9 +55,9 @@ public class DoubleType extends AbstractPrimitiveType<Double>
         return Collections.singleton(_doubleEncoding);
     }
 
-    public void write(double d)
+    public void write(WritableBuffer buffer, double d)
     {
-        _doubleEncoding.write(d);
+        _doubleEncoding.write(buffer, d);
     }
     
     public class DoubleEncoding extends FixedSizePrimitiveTypeEncoding<Double>
@@ -85,20 +85,20 @@ public class DoubleType extends AbstractPrimitiveType<Double>
             return DoubleType.this;
         }
 
-        public void writeValue(final Double val)
+        public void writeValue(WritableBuffer buffer, final Double val)
         {
-            getEncoder().writeRaw(val.doubleValue());
+            getEncoder().writeRaw(buffer, val.doubleValue());
         }
 
-        public void writeValue(final double val)
+        public void writeValue(WritableBuffer buffer, final double val)
         {
-            getEncoder().writeRaw(val);
+            getEncoder().writeRaw(buffer, val);
         }
 
-        public void write(final double d)
+        public void write(WritableBuffer buffer, final double d)
         {
-            writeConstructor();
-            getEncoder().writeRaw(d);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, d);
             
         }
 
@@ -107,14 +107,14 @@ public class DoubleType extends AbstractPrimitiveType<Double>
             return (getType() == encoding.getType());
         }
 
-        public Double readValue()
+        public Double readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
-        public double readPrimitiveValue()
+        public double readPrimitiveValue(ReadableBuffer buffer)
         {
-            return getDecoder().readRawDouble();
+            return getDecoder().readRawDouble(buffer);
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/DynamicTypeConstructor.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/DynamicTypeConstructor.java
@@ -32,11 +32,16 @@ public class DynamicTypeConstructor implements TypeConstructor
         _underlyingEncoding = underlyingEncoding;
     }
 
-    public Object readValue()
+    public boolean isArray()
+    {
+        return false;
+    }
+
+    public Object readValue(ReadableBuffer buffer)
     {
         try
         {
-            return _describedTypeConstructor.newInstance(_underlyingEncoding.readValue());
+            return _describedTypeConstructor.newInstance(buffer, _underlyingEncoding);
         }
         catch (NullPointerException npe)
         {

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/Encoder.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/Encoder.java
@@ -36,84 +36,84 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public interface Encoder
+public interface Encoder<B>
 {
-    void writeNull();
+    void writeNull(B buffer);
 
-    void writeBoolean(boolean bool);
+    void writeBoolean(B buffer,boolean bool);
 
-    void writeBoolean(Boolean bool);
+    void writeBoolean(B buffer,Boolean bool);
 
-    void writeUnsignedByte(UnsignedByte ubyte);
+    void writeUnsignedByte(B buffer,UnsignedByte ubyte);
 
-    void writeUnsignedShort(UnsignedShort ushort);
+    void writeUnsignedShort(B buffer,UnsignedShort ushort);
 
-    void writeUnsignedInteger(UnsignedInteger ushort);
+    void writeUnsignedInteger(B buffer,UnsignedInteger ushort);
 
-    void writeUnsignedLong(UnsignedLong ulong);
+    void writeUnsignedLong(B buffer,UnsignedLong ulong);
 
-    void writeByte(byte b);
+    void writeByte(B buffer,byte b);
 
-    void writeByte(Byte b);
+    void writeByte(B buffer,Byte b);
 
-    void writeShort(short s);
+    void writeShort(B buffer,short s);
 
-    void writeShort(Short s);
+    void writeShort(B buffer,Short s);
 
-    void writeInteger(int i);
+    void writeInteger(B buffer,int i);
 
-    void writeInteger(Integer i);
+    void writeInteger(B buffer,Integer i);
 
-    void writeLong(long l);
+    void writeLong(B buffer,long l);
 
-    void writeLong(Long l);
+    void writeLong(B buffer,Long l);
 
-    void writeFloat(float f);
+    void writeFloat(B buffer,float f);
 
-    void writeFloat(Float f);
+    void writeFloat(B buffer,Float f);
 
-    void writeDouble(double d);
+    void writeDouble(B buffer,double d);
 
-    void writeDouble(Double d);
+    void writeDouble(B buffer,Double d);
 
-    void writeDecimal32(Decimal32 d);
+    void writeDecimal32(B buffer,Decimal32 d);
 
-    void writeDecimal64(Decimal64 d);
+    void writeDecimal64(B buffer,Decimal64 d);
 
-    void writeDecimal128(Decimal128 d);
+    void writeDecimal128(B buffer,Decimal128 d);
 
-    void writeCharacter(char c);
+    void writeCharacter(B buffer,char c);
 
-    void writeCharacter(Character c);
+    void writeCharacter(B buffer,Character c);
 
-    void writeTimestamp(long d);
-    void writeTimestamp(Date d);
+    void writeTimestamp(B buffer,long d);
+    void writeTimestamp(B buffer,Date d);
 
-    void writeUUID(UUID uuid);
+    void writeUUID(B buffer,UUID uuid);
 
-    void writeBinary(Binary b);
+    void writeBinary(B buffer,Binary b);
 
-    void writeString(String s);
+    void writeString(B buffer,String s);
 
-    void writeSymbol(Symbol s);
+    void writeSymbol(B buffer,Symbol s);
 
-    void writeList(List l);
+    void writeList(B buffer,List l);
 
-    void writeMap(Map m);
+    void writeMap(B buffer,Map m);
 
-    void writeDescribedType(DescribedType d);
+    void writeDescribedType(B buffer,DescribedType d);
 
-    void writeArray(boolean[] a);
-    void writeArray(byte[] a);
-    void writeArray(short[] a);
-    void writeArray(int[] a);
-    void writeArray(long[] a);
-    void writeArray(float[] a);
-    void writeArray(double[] a);
-    void writeArray(char[] a);
-    void writeArray(Object[] a);
+    void writeArray(B buffer,boolean[] a);
+    void writeArray(B buffer,byte[] a);
+    void writeArray(B buffer,short[] a);
+    void writeArray(B buffer,int[] a);
+    void writeArray(B buffer,long[] a);
+    void writeArray(B buffer,float[] a);
+    void writeArray(B buffer,double[] a);
+    void writeArray(B buffer,char[] a);
+    void writeArray(B buffer,Object[] a);
 
-    void writeObject(Object o);
+    void writeObject(B buffer,Object o);
 
     <V> void register(AMQPType<V> type);
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/EncoderImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/EncoderImpl.java
@@ -20,12 +20,11 @@
  */
 package org.apache.qpid.proton.codec;
 
-import java.nio.ByteBuffer;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Decimal128;
@@ -43,11 +42,9 @@ public final class EncoderImpl implements ByteBufferEncoder
     private static final byte DESCRIBED_TYPE_OP = (byte)0;
 
 
-    private WritableBuffer _buffer;
-
-    private final Map<Class, AMQPType> _typeRegistry = new HashMap<Class, AMQPType>();
-    private Map<Object, AMQPType> _describedDescriptorRegistry = new HashMap<Object, AMQPType>();
-    private Map<Class, AMQPType>  _describedTypesClassRegistry = new HashMap<Class, AMQPType>();
+    private final Map<Class, AMQPType> _typeRegistry = new ConcurrentHashMap<>();
+    private Map<Object, AMQPType> _describedDescriptorRegistry = new ConcurrentHashMap<>();
+    private Map<Class, AMQPType>  _describedTypesClassRegistry = new ConcurrentHashMap<>();
 
     private final NullType              _nullType;
     private final BooleanType           _booleanType;
@@ -79,12 +76,6 @@ public final class EncoderImpl implements ByteBufferEncoder
     private final MapType               _mapType;
 
     private final ArrayType             _arrayType;
-
-    EncoderImpl(ByteBuffer buffer, DecoderImpl decoder)
-    {
-        this(decoder);
-        setByteBuffer(buffer);
-    }
 
     public EncoderImpl(DecoderImpl decoder)
     {
@@ -132,17 +123,6 @@ public final class EncoderImpl implements ByteBufferEncoder
 
 
     }
-
-    public void setByteBuffer(final ByteBuffer buf)
-    {
-        _buffer = new WritableBuffer.ByteBufferWrapper(buf);
-    }
-
-    public void setByteBuffer(final WritableBuffer buf)
-    {
-        _buffer = buf;
-    }
-
 
     @Override
     public AMQPType getType(final Object element)
@@ -219,448 +199,448 @@ public final class EncoderImpl implements ByteBufferEncoder
         _describedTypesClassRegistry.put(clazz, type);
     }
 
-    public void writeNull()
+    public void writeNull(WritableBuffer buffer)
     {
-        _nullType.write();
+        _nullType.write(buffer);
     }
 
-    public void writeBoolean(final boolean bool)
+    public void writeBoolean(WritableBuffer buffer, final boolean bool)
     {
-        _booleanType.writeValue(bool);
+        _booleanType.writeValue(buffer, bool);
     }
 
-    public void writeBoolean(final Boolean bool)
+    public void writeBoolean(WritableBuffer buffer, final Boolean bool)
     {
         if(bool == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _booleanType.write(bool);
+            _booleanType.write(buffer, bool);
         }
     }
 
-    public void writeUnsignedByte(final UnsignedByte ubyte)
+    public void writeUnsignedByte(WritableBuffer buffer, final UnsignedByte ubyte)
     {
         if(ubyte == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _unsignedByteType.write(ubyte);
+            _unsignedByteType.write(buffer, ubyte);
         }
     }
 
-    public void writeUnsignedShort(final UnsignedShort ushort)
+    public void writeUnsignedShort(WritableBuffer buffer, final UnsignedShort ushort)
     {
         if(ushort == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _unsignedShortType.write(ushort);
+            _unsignedShortType.write(buffer, ushort);
         }
     }
 
-    public void writeUnsignedInteger(final UnsignedInteger uint)
+    public void writeUnsignedInteger(WritableBuffer buffer, final UnsignedInteger uint)
     {
         if(uint == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _unsignedIntegerType.write(uint);
+            _unsignedIntegerType.write(buffer, uint);
         }
     }
 
-    public void writeUnsignedLong(final UnsignedLong ulong)
+    public void writeUnsignedLong(WritableBuffer buffer, final UnsignedLong ulong)
     {
         if(ulong == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _unsignedLongType.write(ulong);
+            _unsignedLongType.write(buffer, ulong);
         }
     }
 
-    public void writeByte(final byte b)
+    public void writeByte(WritableBuffer buffer, final byte b)
     {
-        _byteType.write(b);
+        _byteType.write(buffer, b);
     }
 
-    public void writeByte(final Byte b)
+    public void writeByte(WritableBuffer buffer, final Byte b)
     {
         if(b == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            writeByte(b.byteValue());
+            writeByte(buffer, b.byteValue());
         }
     }
 
-    public void writeShort(final short s)
+    public void writeShort(WritableBuffer buffer, final short s)
     {
-        _shortType.write(s);
+        _shortType.write(buffer, s);
     }
 
-    public void writeShort(final Short s)
+    public void writeShort(WritableBuffer buffer, final Short s)
     {
         if(s == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            writeShort(s.shortValue());
+            writeShort(buffer, s.shortValue());
         }
     }
 
-    public void writeInteger(final int i)
+    public void writeInteger(WritableBuffer buffer, final int i)
     {
-        _integerType.write(i);
+        _integerType.write(buffer, i);
     }
 
-    public void writeInteger(final Integer i)
+    public void writeInteger(WritableBuffer buffer, final Integer i)
     {
         if(i == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            writeInteger(i.intValue());
+            writeInteger(buffer, i.intValue());
         }
     }
 
-    public void writeLong(final long l)
+    public void writeLong(WritableBuffer buffer, final long l)
     {
-        _longType.write(l);
+        _longType.write(buffer, l);
     }
 
-    public void writeLong(final Long l)
+    public void writeLong(WritableBuffer buffer, final Long l)
     {
 
         if(l == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            writeLong(l.longValue());
+            writeLong(buffer, l.longValue());
         }
     }
 
-    public void writeFloat(final float f)
+    public void writeFloat(WritableBuffer buffer, final float f)
     {
-        _floatType.write(f);
+        _floatType.write(buffer, f);
     }
 
-    public void writeFloat(final Float f)
+    public void writeFloat(WritableBuffer buffer, final Float f)
     {
         if(f == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            writeFloat(f.floatValue());
+            writeFloat(buffer, f.floatValue());
         }
     }
 
-    public void writeDouble(final double d)
+    public void writeDouble(WritableBuffer buffer, final double d)
     {
-        _doubleType.write(d);
+        _doubleType.write(buffer, d);
     }
 
-    public void writeDouble(final Double d)
-    {
-        if(d == null)
-        {
-            writeNull();
-        }
-        else
-        {
-            writeDouble(d.doubleValue());
-        }
-    }
-
-    public void writeDecimal32(final Decimal32 d)
+    public void writeDouble(WritableBuffer buffer, final Double d)
     {
         if(d == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _decimal32Type.write(d);
+            writeDouble(buffer, d.doubleValue());
         }
     }
 
-    public void writeDecimal64(final Decimal64 d)
+    public void writeDecimal32(WritableBuffer buffer, final Decimal32 d)
     {
         if(d == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _decimal64Type.write(d);
+            _decimal32Type.write(buffer, d);
         }
     }
 
-    public void writeDecimal128(final Decimal128 d)
+    public void writeDecimal64(WritableBuffer buffer, final Decimal64 d)
     {
         if(d == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _decimal128Type.write(d);
+            _decimal64Type.write(buffer, d);
         }
     }
 
-    public void writeCharacter(final char c)
+    public void writeDecimal128(WritableBuffer buffer, final Decimal128 d)
+    {
+        if(d == null)
+        {
+            writeNull(buffer);
+        }
+        else
+        {
+            _decimal128Type.write(buffer, d);
+        }
+    }
+
+    public void writeCharacter(WritableBuffer buffer, final char c)
     {
         // TODO - java character may be half of a pair, should probably throw exception then
-        _characterType.write(c);
+        _characterType.write(buffer, c);
     }
 
-    public void writeCharacter(final Character c)
+    public void writeCharacter(WritableBuffer buffer, final Character c)
     {
         if(c == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            writeCharacter(c.charValue());
+            writeCharacter(buffer, c.charValue());
         }
     }
 
-    public void writeTimestamp(final long d)
+    public void writeTimestamp(WritableBuffer buffer, final long d)
     {
-        _timestampType.write(d);
+        _timestampType.write(buffer, d);
     }
 
-    public void writeTimestamp(final Date d)
+    public void writeTimestamp(WritableBuffer buffer, final Date d)
     {
         if(d == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            writeTimestamp(d.getTime());
+            writeTimestamp(buffer, d.getTime());
         }
     }
 
-    public void writeUUID(final UUID uuid)
+    public void writeUUID(WritableBuffer buffer, final UUID uuid)
     {
         if(uuid == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _uuidType.write(uuid);
+            _uuidType.write(buffer, uuid);
         }
 
     }
 
-    public void writeBinary(final Binary b)
+    public void writeBinary(WritableBuffer buffer, final Binary b)
     {
         if(b == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _binaryType.write(b);
+            _binaryType.write(buffer, b);
         }
     }
 
-    public void writeString(final String s)
+    public void writeString(WritableBuffer buffer, final String s)
     {
         if(s == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _stringType.write(s);
+            _stringType.write(buffer, s);
         }
     }
 
-    public void writeSymbol(final Symbol s)
+    public void writeSymbol(WritableBuffer buffer, final Symbol s)
     {
         if(s == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _symbolType.write(s);
+            _symbolType.write(buffer, s);
         }
 
     }
 
-    public void writeList(final List l)
+    public void writeList(WritableBuffer buffer, final List l)
     {
         if(l == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _listType.write(l);
+            _listType.write(buffer, l);
         }
     }
 
-    public void writeMap(final Map m)
+    public void writeMap(WritableBuffer buffer, final Map m)
     {
 
         if(m == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _mapType.write(m);
+            _mapType.write(buffer, m);
         }
     }
 
-    public void writeDescribedType(final DescribedType d)
+    public void writeDescribedType(WritableBuffer buffer, final DescribedType d)
     {
         if(d == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _buffer.put(DESCRIBED_TYPE_OP);
-            writeObject(d.getDescriptor());
-            writeObject(d.getDescribed());
+            buffer.put(DESCRIBED_TYPE_OP);
+            writeObject(buffer, d.getDescriptor());
+            writeObject(buffer, d.getDescribed());
         }
     }
 
-    public void writeArray(final boolean[] a)
+    public void writeArray(WritableBuffer buffer, final boolean[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeArray(final byte[] a)
+    public void writeArray(WritableBuffer buffer, final byte[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeArray(final short[] a)
+    public void writeArray(WritableBuffer buffer, final short[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeArray(final int[] a)
+    public void writeArray(WritableBuffer buffer, final int[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeArray(final long[] a)
+    public void writeArray(WritableBuffer buffer, final long[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeArray(final float[] a)
+    public void writeArray(WritableBuffer buffer, final float[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeArray(final double[] a)
+    public void writeArray(WritableBuffer buffer, final double[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeArray(final char[] a)
+    public void writeArray(WritableBuffer buffer, final char[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeArray(final Object[] a)
+    public void writeArray(WritableBuffer buffer, final Object[] a)
     {
         if(a == null)
         {
-            writeNull();
+            writeNull(buffer);
         }
         else
         {
-            _arrayType.write(a);
+            _arrayType.write(buffer, a);
         }
     }
 
-    public void writeObject(final Object o)
+    public void writeObject(WritableBuffer buffer, final Object o)
     {
         AMQPType type = _typeRegistry.get(o == null ? Void.class : o.getClass());
 
@@ -673,35 +653,35 @@ public final class EncoderImpl implements ByteBufferEncoder
                 {
                     if(componentType == Boolean.TYPE)
                     {
-                        writeArray((boolean[])o);
+                        writeArray(buffer, (boolean[])o);
                     }
                     else if(componentType == Byte.TYPE)
                     {
-                        writeArray((byte[])o);
+                        writeArray(buffer, (byte[])o);
                     }
                     else if(componentType == Short.TYPE)
                     {
-                        writeArray((short[])o);
+                        writeArray(buffer, (short[])o);
                     }
                     else if(componentType == Integer.TYPE)
                     {
-                        writeArray((int[])o);
+                        writeArray(buffer, (int[])o);
                     }
                     else if(componentType == Long.TYPE)
                     {
-                        writeArray((long[])o);
+                        writeArray(buffer, (long[])o);
                     }
                     else if(componentType == Float.TYPE)
                     {
-                        writeArray((float[])o);
+                        writeArray(buffer, (float[])o);
                     }
                     else if(componentType == Double.TYPE)
                     {
-                        writeArray((double[])o);
+                        writeArray(buffer, (double[])o);
                     }
                     else if(componentType == Character.TYPE)
                     {
-                        writeArray((char[])o);
+                        writeArray(buffer, (char[])o);
                     }
                     else
                     {
@@ -710,20 +690,20 @@ public final class EncoderImpl implements ByteBufferEncoder
                 }
                 else
                 {
-                    writeArray((Object[]) o);
+                    writeArray(buffer, (Object[]) o);
                 }
             }
             else if(o instanceof List)
             {
-                writeList((List)o);
+                writeList(buffer, (List)o);
             }
             else if(o instanceof Map)
             {
-                writeMap((Map)o);
+                writeMap(buffer, (Map)o);
             }
             else if(o instanceof DescribedType)
             {
-                writeDescribedType((DescribedType)o);
+                writeDescribedType(buffer, (DescribedType)o);
             }
             else
             {
@@ -734,46 +714,46 @@ public final class EncoderImpl implements ByteBufferEncoder
         }
         else
         {
-            type.write(o);
+            type.write(buffer, o);
         }
     }
 
-    public void writeRaw(final byte b)
+    public void writeRaw(WritableBuffer buffer, final byte b)
     {
-        _buffer.put(b);
+        buffer.put(b);
     }
 
-    void writeRaw(final short s)
+    void writeRaw(WritableBuffer buffer, final short s)
     {
-        _buffer.putShort(s);
+        buffer.putShort(s);
     }
 
-    void writeRaw(final int i)
+    void writeRaw(WritableBuffer buffer, final int i)
     {
-        _buffer.putInt(i);
+        buffer.putInt(i);
     }
 
-    void writeRaw(final long l)
+    void writeRaw(WritableBuffer buffer, final long l)
     {
-        _buffer.putLong(l);
+        buffer.putLong(l);
     }
 
-    void writeRaw(final float f)
+    void writeRaw(WritableBuffer buffer, final float f)
     {
-        _buffer.putFloat(f);
+        buffer.putFloat(f);
     }
 
-    void writeRaw(final double d)
+    void writeRaw(WritableBuffer buffer, final double d)
     {
-        _buffer.putDouble(d);
+        buffer.putDouble(d);
     }
 
-    void writeRaw(byte[] src, int offset, int length)
+    void writeRaw(WritableBuffer buffer, byte[] src, int offset, int length)
     {
-        _buffer.put(src, offset, length);
+        buffer.put(src, offset, length);
     }
 
-    void writeRaw(String string)
+    void writeRaw(WritableBuffer _buffer, String string)
     {
         final int length = string.length();
         int c;

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/FloatType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/FloatType.java
@@ -55,9 +55,9 @@ public class FloatType extends AbstractPrimitiveType<Float>
         return Collections.singleton(_floatEncoding);
     }
 
-    public void write(float f)
+    public void write(WritableBuffer buffer, float f)
     {
-        _floatEncoding.write(f);
+        _floatEncoding.write(buffer, f);
     }
     
     public class FloatEncoding extends FixedSizePrimitiveTypeEncoding<Float>
@@ -85,21 +85,21 @@ public class FloatType extends AbstractPrimitiveType<Float>
             return FloatType.this;
         }
 
-        public void writeValue(final Float val)
+        public void writeValue(WritableBuffer buffer, final Float val)
         {
-            getEncoder().writeRaw(val.floatValue());
+            getEncoder().writeRaw(buffer, val.floatValue());
         }
 
-        public void writeValue(final float val)
+        public void writeValue(WritableBuffer buffer, final float val)
         {
-            getEncoder().writeRaw(val);
+            getEncoder().writeRaw(buffer, val);
         }
 
 
-        public void write(final float f)
+        public void write(WritableBuffer buffer, final float f)
         {
-            writeConstructor();
-            getEncoder().writeRaw(f);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, f);
             
         }
 
@@ -108,14 +108,14 @@ public class FloatType extends AbstractPrimitiveType<Float>
             return (getType() == encoding.getType());
         }
 
-        public Float readValue()
+        public Float readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
-        public float readPrimitiveValue()
+        public float readPrimitiveValue(ReadableBuffer buffer)
         {
-            return getDecoder().readRawFloat();
+            return getDecoder().readRawFloat(buffer);
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/FloatingSizePrimitiveTypeEncoding.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/FloatingSizePrimitiveTypeEncoding.java
@@ -35,15 +35,15 @@ abstract class FloatingSizePrimitiveTypeEncoding<T> extends AbstractPrimitiveTyp
 
     abstract int getSizeBytes();
 
-    public void writeValue(final T val)
+    public void writeValue(WritableBuffer buffer, final T val)
     {
-        writeSize(val);
-        writeEncodedValue(val);
+        writeSize(buffer, val);
+        writeEncodedValue(buffer, val);
     }
 
-    protected abstract void writeEncodedValue(final T val);
+    protected abstract void writeEncodedValue(WritableBuffer buffer, final T val);
 
-    protected abstract void writeSize(final T val);
+    protected abstract void writeSize(WritableBuffer buffer, final T val);
 
     public int getValueSize(final T val)
     {

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/IntegerType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/IntegerType.java
@@ -28,9 +28,9 @@ public class IntegerType extends AbstractPrimitiveType<Integer>
 
     public static interface IntegerEncoding extends PrimitiveTypeEncoding<Integer>
     {
-        void write(int i);
-        void writeValue(int i);
-        int readPrimitiveValue();
+        void write(WritableBuffer buffer, int i);
+        void writeValue(WritableBuffer buffer, int i);
+        int readPrimitiveValue(ReadableBuffer buffer);
     }
 
     private IntegerEncoding _integerEncoding;
@@ -71,15 +71,15 @@ public class IntegerType extends AbstractPrimitiveType<Integer>
         return Arrays.asList(_integerEncoding, _smallIntegerEncoding);
     }
 
-    public void write(int i)
+    public void write(WritableBuffer buffer, int i)
     {
         if(i >= -128 && i <= 127)
         {
-            _smallIntegerEncoding.write(i);
+            _smallIntegerEncoding.write(buffer, i);
         }
         else
         {
-            _integerEncoding.write(i);
+            _integerEncoding.write(buffer, i);
         }
     }
     
@@ -108,26 +108,26 @@ public class IntegerType extends AbstractPrimitiveType<Integer>
             return IntegerType.this;
         }
 
-        public void writeValue(final Integer val)
+        public void writeValue(WritableBuffer buffer, final Integer val)
         {
-            getEncoder().writeRaw(val.intValue());
+            getEncoder().writeRaw(buffer, val.intValue());
         }
         
-        public void write(final int i)
+        public void write(WritableBuffer buffer, final int i)
         {
-            writeConstructor();
-            getEncoder().writeRaw(i);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, i);
             
         }
 
-        public void writeValue(final int i)
+        public void writeValue(WritableBuffer buffer, final int i)
         {
-            getEncoder().writeRaw(i);
+            getEncoder().writeRaw(buffer, i);
         }
 
-        public int readPrimitiveValue()
+        public int readPrimitiveValue(ReadableBuffer buffer)
         {
-            return getDecoder().readRawInt();
+            return getDecoder().readRawInt(buffer);
         }
 
         public boolean encodesSuperset(final TypeEncoding<Integer> encoding)
@@ -135,9 +135,9 @@ public class IntegerType extends AbstractPrimitiveType<Integer>
             return (getType() == encoding.getType());
         }
 
-        public Integer readValue()
+        public Integer readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
 
@@ -167,20 +167,20 @@ public class IntegerType extends AbstractPrimitiveType<Integer>
             return 1;
         }
 
-        public void write(final int i)
+        public void write(WritableBuffer buffer, final int i)
         {
-            writeConstructor();
-            getEncoder().writeRaw((byte)i);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, (byte)i);
         }
 
-        public void writeValue(final int i)
+        public void writeValue(WritableBuffer buffer, final int i)
         {
-            getEncoder().writeRaw((byte)i);
+            getEncoder().writeRaw(buffer, (byte)i);
         }
 
-        public int readPrimitiveValue()
+        public int readPrimitiveValue(ReadableBuffer buffer)
         {
-            return getDecoder().readRawByte();
+            return getDecoder().readRawByte(buffer);
         }
 
         public IntegerType getType()
@@ -188,9 +188,9 @@ public class IntegerType extends AbstractPrimitiveType<Integer>
             return IntegerType.this;
         }
 
-        public void writeValue(final Integer val)
+        public void writeValue(WritableBuffer buffer, final Integer val)
         {
-            getEncoder().writeRaw((byte)val.intValue());
+            getEncoder().writeRaw(buffer, (byte)val.intValue());
         }
 
         public boolean encodesSuperset(final TypeEncoding<Integer> encoder)
@@ -198,9 +198,9 @@ public class IntegerType extends AbstractPrimitiveType<Integer>
             return encoder == this;
         }
 
-        public Integer readValue()
+        public Integer readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/LongType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/LongType.java
@@ -28,9 +28,9 @@ public class LongType extends AbstractPrimitiveType<Long>
 
     public static interface LongEncoding extends PrimitiveTypeEncoding<Long>
     {
-        void write(long l);
-        void writeValue(long l);
-        public long readPrimitiveValue();
+        void write(WritableBuffer buffer, long l);
+        void writeValue(WritableBuffer buffer, long l);
+        public long readPrimitiveValue(ReadableBuffer buffer);
     }
     
     private LongEncoding _longEncoding;
@@ -70,15 +70,15 @@ public class LongType extends AbstractPrimitiveType<Long>
         return Arrays.asList(_smallLongEncoding, _longEncoding);
     }
 
-    public void write(long l)
+    public void write(WritableBuffer buffer, long l)
     {
         if(l >= -128l && l <= 127l)
         {
-            _smallLongEncoding.write(l);
+            _smallLongEncoding.write(buffer, l);
         }
         else
         {
-            _longEncoding.write(l);
+            _longEncoding.write(buffer, l);
         }
     }
     
@@ -107,21 +107,21 @@ public class LongType extends AbstractPrimitiveType<Long>
             return LongType.this;
         }
 
-        public void writeValue(final Long val)
+        public void writeValue(WritableBuffer buffer, final Long val)
         {
-            getEncoder().writeRaw(val.longValue());
+            getEncoder().writeRaw(buffer, val.longValue());
         }
         
-        public void write(final long l)
+        public void write(WritableBuffer buffer, final long l)
         {
-            writeConstructor();
-            getEncoder().writeRaw(l);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, l);
             
         }
 
-        public void writeValue(final long l)
+        public void writeValue(WritableBuffer buffer, final long l)
         {
-            getEncoder().writeRaw(l);
+            getEncoder().writeRaw(buffer, l);
         }
 
         public boolean encodesSuperset(final TypeEncoding<Long> encoding)
@@ -129,14 +129,14 @@ public class LongType extends AbstractPrimitiveType<Long>
             return (getType() == encoding.getType());
         }
 
-        public Long readValue()
+        public Long readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
-        public long readPrimitiveValue()
+        public long readPrimitiveValue(ReadableBuffer buffer)
         {
-            return getDecoder().readRawLong();
+            return getDecoder().readRawLong(buffer);
         }
 
 
@@ -166,20 +166,20 @@ public class LongType extends AbstractPrimitiveType<Long>
             return 1;
         }
 
-        public void write(final long l)
+        public void write(WritableBuffer buffer, final long l)
         {
-            writeConstructor();
-            getEncoder().writeRaw((byte)l);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, (byte)l);
         }
 
-        public void writeValue(final long l)
+        public void writeValue(WritableBuffer buffer, final long l)
         {
-            getEncoder().writeRaw((byte)l);
+            getEncoder().writeRaw(buffer, (byte)l);
         }
 
-        public long readPrimitiveValue()
+        public long readPrimitiveValue(ReadableBuffer buffer)
         {
-            return (long) getDecoder().readRawByte();
+            return (long) getDecoder().readRawByte(buffer);
         }
 
         public LongType getType()
@@ -187,9 +187,9 @@ public class LongType extends AbstractPrimitiveType<Long>
             return LongType.this;
         }
 
-        public void writeValue(final Long val)
+        public void writeValue(WritableBuffer buffer, final Long val)
         {
-            getEncoder().writeRaw((byte)val.longValue());
+            getEncoder().writeRaw(buffer, (byte)val.longValue());
         }
 
         public boolean encodesSuperset(final TypeEncoding<Long> encoder)
@@ -197,9 +197,9 @@ public class LongType extends AbstractPrimitiveType<Long>
             return encoder == this;
         }
 
-        public Long readValue()
+        public Long readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/MapType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/MapType.java
@@ -92,18 +92,15 @@ public class MapType extends AbstractPrimitiveType<Map>
             implements MapEncoding
     {
 
-        private Map _value;
-        private int _length;
-
         public AllMapEncoding(final EncoderImpl encoder, final DecoderImpl decoder)
         {
             super(encoder, decoder);
         }
 
         @Override
-        protected void writeEncodedValue(final Map val)
+        protected void writeEncodedValue(WritableBuffer buffer, final Map val)
         {
-            getEncoder().writeRaw(2 * val.size());
+            getEncoder().writeRaw(buffer, 2 * val.size());
             
 
             Iterator<Map.Entry> iter = val.entrySet().iterator();
@@ -112,18 +109,19 @@ public class MapType extends AbstractPrimitiveType<Map>
             {
                 Map.Entry element = iter.next();
                 TypeEncoding elementEncoding = getEncoder().getType(element.getKey()).getEncoding(element.getKey());
-                elementEncoding.writeConstructor();
-                elementEncoding.writeValue(element.getKey());
+                elementEncoding.writeConstructor(buffer);
+                elementEncoding.writeValue(buffer, element.getKey());
                 elementEncoding = getEncoder().getType(element.getValue()).getEncoding(element.getValue());
-                elementEncoding.writeConstructor();
-                elementEncoding.writeValue(element.getValue());
+                elementEncoding.writeConstructor(buffer);
+                elementEncoding.writeValue(buffer, element.getValue());
             }
         }
 
         @Override
         protected int getEncodedValueSize(final Map val)
         {
-            return 4 + ((val == _value) ? _length : calculateSize(val, getEncoder()));
+            CachedCalculation calculation = CachedCalculation.getCache();
+            return 4 + ((val == calculation.getVal()) ? calculation.getSize() : calculateSize(val, getEncoder()));
         }
 
 
@@ -143,23 +141,23 @@ public class MapType extends AbstractPrimitiveType<Map>
             return (getType() == encoding.getType());
         }
 
-        public Map readValue()
+        public Map readValue(ReadableBuffer buffer)
         {
 
             DecoderImpl decoder = getDecoder();
-            int size = decoder.readRawInt();
+            int size = decoder.readRawInt(buffer);
             // todo - limit the decoder with size
-            int count = decoder.readRawInt();
-            if (count > decoder.getByteBufferRemaining()) {
+            int count = decoder.readRawInt(buffer);
+            if (count > decoder.getByteBufferRemaining(buffer)) {
                 throw new IllegalArgumentException("Map element count "+count+" is specified to be greater than the amount of data available ("+
-                                                   decoder.getByteBufferRemaining()+")");
+                                                   decoder.getByteBufferRemaining(buffer)+")");
             }
             Map map = new LinkedHashMap(count);
             for(int i = 0; i < count; i++)
             {
-                Object key = decoder.readObject();
+                Object key = decoder.readObject(buffer);
                 i++;
-                Object value = decoder.readObject();
+                Object value = decoder.readObject(buffer);
                 map.put(key, value);
             }
             return map;
@@ -167,8 +165,7 @@ public class MapType extends AbstractPrimitiveType<Map>
 
         public void setValue(final Map value, final int length)
         {
-            _value = value;
-            _length = length;
+            CachedCalculation.setCachedValue(value, length);
         }
     }
 
@@ -177,18 +174,15 @@ public class MapType extends AbstractPrimitiveType<Map>
             implements MapEncoding
     {
 
-        private Map _value;
-        private int _length;
-
         public ShortMapEncoding(final EncoderImpl encoder, final DecoderImpl decoder)
         {
             super(encoder, decoder);
         }
 
         @Override
-        protected void writeEncodedValue(final Map val)
+        protected void writeEncodedValue(WritableBuffer buffer, final Map val)
         {
-            getEncoder().writeRaw((byte)(2*val.size()));
+            getEncoder().writeRaw(buffer, (byte)(2*val.size()));
                 
 
             Iterator<Map.Entry> iter = val.entrySet().iterator();
@@ -197,18 +191,19 @@ public class MapType extends AbstractPrimitiveType<Map>
             {
                 Map.Entry element = iter.next();
                 TypeEncoding elementEncoding = getEncoder().getType(element.getKey()).getEncoding(element.getKey());
-                elementEncoding.writeConstructor();
-                elementEncoding.writeValue(element.getKey());
+                elementEncoding.writeConstructor(buffer);
+                elementEncoding.writeValue(buffer, element.getKey());
                 elementEncoding = getEncoder().getType(element.getValue()).getEncoding(element.getValue());
-                elementEncoding.writeConstructor();
-                elementEncoding.writeValue(element.getValue());
+                elementEncoding.writeConstructor(buffer);
+                elementEncoding.writeValue(buffer, element.getValue());
             }
         }
 
         @Override
         protected int getEncodedValueSize(final Map val)
         {
-            return 1 + ((val == _value) ? _length : calculateSize(val, getEncoder()));
+            CachedCalculation calculation = CachedCalculation.getCache();
+            return 1 + ((val == calculation.getVal()) ? calculation.getSize() : calculateSize(val, getEncoder()));
         }
 
 
@@ -228,19 +223,19 @@ public class MapType extends AbstractPrimitiveType<Map>
             return encoder == this;
         }
 
-        public Map readValue()
+        public Map readValue(ReadableBuffer buffer)
         {
             DecoderImpl decoder = getDecoder();
-            int size = ((int)decoder.readRawByte()) & 0xff;
+            int size = ((int)decoder.readRawByte(buffer)) & 0xff;
             // todo - limit the decoder with size
-            int count = ((int)decoder.readRawByte()) & 0xff;
+            int count = ((int)decoder.readRawByte(buffer)) & 0xff;
 
             Map map = new LinkedHashMap(count);
             for(int i = 0; i < count; i++)
             {
-                Object key = decoder.readObject();
+                Object key = decoder.readObject(buffer);
                 i++;
-                Object value = decoder.readObject();
+                Object value = decoder.readObject(buffer);
                 map.put(key, value);
             }
             return map;
@@ -248,8 +243,7 @@ public class MapType extends AbstractPrimitiveType<Map>
 
         public void setValue(final Map value, final int length)
         {
-            _value = value;
-            _length = length;
+            CachedCalculation.setCachedValue(value, length);
         }
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/NullType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/NullType.java
@@ -55,9 +55,9 @@ public final class NullType extends AbstractPrimitiveType<Void>
         return Collections.singleton(_nullEncoding);
     }
 
-    public void write()
+    public void write(WritableBuffer buffer)
     {
-        _nullEncoding.write();
+        _nullEncoding.write(buffer);
     }
 
     private class NullEncoding extends FixedSizePrimitiveTypeEncoding<Void>
@@ -85,11 +85,11 @@ public final class NullType extends AbstractPrimitiveType<Void>
             return NullType.this;
         }
 
-        public void writeValue(final Void val)
+        public void writeValue(WritableBuffer buffer, final Void val)
         {
         }
 
-        public void writeValue()
+        public void writeValue(WritableBuffer buffer)
         {
         }
 
@@ -98,14 +98,14 @@ public final class NullType extends AbstractPrimitiveType<Void>
             return encoding == this;
         }
 
-        public Void readValue()
+        public Void readValue(ReadableBuffer buffer)
         {
             return null;
         }
 
-        public void write()
+        public void write(WritableBuffer buffer)
         {
-            writeConstructor();
+            writeConstructor(buffer);
         }
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/PrimitiveTypeEncoding.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/PrimitiveTypeEncoding.java
@@ -26,7 +26,7 @@ public interface PrimitiveTypeEncoding<T> extends TypeEncoding<T>, TypeConstruct
 
     byte getEncodingCode();
 
-    void writeConstructor();
+    void writeConstructor(WritableBuffer buffer);
 
     int getConstructorSize();
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/ReadableBuffer.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/ReadableBuffer.java
@@ -1,0 +1,248 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.proton.codec;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+
+/**
+ * Interface to abstract a buffer, just like {@link WritableBuffer}
+ */
+public interface ReadableBuffer
+{
+
+    void put(ReadableBuffer other);
+
+    byte get();
+
+    int getInt();
+
+    long getLong();
+
+    short getShort();
+
+    float getFloat();
+
+    double getDouble();
+
+    ReadableBuffer get(final byte[] data, final int offset, final int length);
+
+    ReadableBuffer get(final byte[] data);
+
+    ReadableBuffer position(int position);
+
+    ReadableBuffer slice();
+
+    ReadableBuffer flip();
+
+    ReadableBuffer limit(int limit);
+
+    int limit();
+
+    int remaining();
+
+    int position();
+
+    boolean hasRemaining();
+
+    ReadableBuffer duplicate();
+
+    ByteBuffer byteBuffer();
+
+
+
+    String readUTF8();
+
+    class ByteBufferReader implements ReadableBuffer
+    {
+        ByteBuffer buffer;
+
+        public static ByteBufferReader allocate(int size)
+        {
+            ByteBuffer allocated = ByteBuffer.allocate(size);
+            return new ByteBufferReader(allocated);
+        }
+
+        public ByteBufferReader(ByteBuffer buffer)
+        {
+            this.buffer = buffer;
+        }
+        @Override
+        public byte get()
+        {
+            return buffer.get();
+        }
+
+        @Override
+        public int getInt()
+        {
+            return buffer.getInt();
+        }
+
+        @Override
+        public long getLong()
+        {
+            return buffer.getLong();
+        }
+
+        @Override
+        public short getShort()
+        {
+            return buffer.getShort();
+        }
+
+        @Override
+        public float getFloat()
+        {
+            return buffer.getFloat();
+        }
+
+        @Override
+        public double getDouble()
+        {
+            return buffer.getDouble();
+        }
+
+        @Override
+        public int limit()
+        {
+            return buffer.limit();
+        }
+
+        @Override
+        public ReadableBuffer get(byte[] data, int offset, int length)
+        {
+            buffer.get(data, offset, length);
+            return this;
+        }
+
+        @Override
+        public ReadableBuffer get(byte[] data)
+        {
+            buffer.get(data);
+            return this;
+        }
+
+        @Override
+        public ReadableBuffer flip()
+        {
+            buffer.flip();
+            return this;
+        }
+
+
+        @Override
+        public ReadableBuffer position(int position)
+        {
+            buffer.position(position);
+            return this;
+        }
+
+        @Override
+        public ReadableBuffer slice()
+        {
+            return new ByteBufferReader(buffer.slice());
+        }
+
+        @Override
+        public ReadableBuffer limit(int limit)
+        {
+            buffer.limit(limit);
+            return this;
+        }
+
+        @Override
+        public int remaining()
+        {
+            return buffer.remaining();
+        }
+
+        @Override
+        public int position()
+        {
+            return buffer.position();
+        }
+
+        @Override
+        public boolean hasRemaining()
+        {
+            return buffer.hasRemaining();
+        }
+
+        @Override
+        public ReadableBuffer duplicate()
+        {
+            return new ByteBufferReader(buffer.duplicate());
+        }
+
+        @Override
+        public ByteBuffer byteBuffer()
+        {
+            return buffer;
+        }
+
+     // IN our tests on HornetQ this is pretty bad performance wise
+        private static final Charset Charset_UTF8 = Charset.forName("UTF-8");
+
+        @Override
+        public String readUTF8()
+        {
+
+            // By Clebert : This is the original implementation very if this is ok before we commit this.
+            // I have actually a better UTF8 decoder on HornetQ, as this one sucks!!!!!!!
+
+//            CharsetDecoder charsetDecoder = Charset_UTF8.newDecoder();
+//            try
+//            {
+//                CharBuffer charBuf = charsetDecoder.decode(buffer);
+//                return charBuf.toString();
+//            }
+//            catch (CharacterCodingException e)
+//            {
+//                throw new IllegalArgumentException("Cannot parse String");
+//            }
+
+            CharBuffer charBuf = Charset_UTF8.decode(buffer);
+            return charBuf.toString();
+        }
+
+        public void put(ReadableBuffer other)
+        {
+            this.buffer.put(other.byteBuffer());
+        }
+    }
+
+
+
+
+    class Test
+    {
+        public void main()
+        {
+            ByteBuffer buffer = null;
+            buffer.getLong();
+        }
+    }
+
+}

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/ShortType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/ShortType.java
@@ -44,9 +44,9 @@ public class ShortType extends AbstractPrimitiveType<Short>
         return _shortEncoding;
     }
 
-    public void write(short s)
+    public void write(WritableBuffer buffer, short s)
     {
-        _shortEncoding.write(s);
+        _shortEncoding.write(buffer, s);
     }
 
     public ShortEncoding getCanonicalEncoding()
@@ -84,21 +84,21 @@ public class ShortType extends AbstractPrimitiveType<Short>
             return ShortType.this;
         }
 
-        public void writeValue(final Short val)
+        public void writeValue(WritableBuffer buffer, final Short val)
         {
-            getEncoder().writeRaw(val);
+            getEncoder().writeRaw(buffer, val);
         }
 
-        public void writeValue(final short val)
+        public void writeValue(WritableBuffer buffer, final short val)
         {
-            getEncoder().writeRaw(val);
+            getEncoder().writeRaw(buffer, val);
         }
 
 
-        public void write(final short s)
+        public void write(final WritableBuffer buffer, final short s)
         {
-            writeConstructor();
-            getEncoder().writeRaw(s);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, s);
         }
 
         public boolean encodesSuperset(final TypeEncoding<Short> encoding)
@@ -106,14 +106,14 @@ public class ShortType extends AbstractPrimitiveType<Short>
             return (getType() == encoding.getType());
         }
 
-        public Short readValue()
+        public Short readValue(ReadableBuffer buffer)
         {
-            return readPrimitiveValue();
+            return readPrimitiveValue(buffer);
         }
 
-        public short readPrimitiveValue()
+        public short readPrimitiveValue(ReadableBuffer buffer)
         {
-            return getDecoder().readRawShort();
+            return getDecoder().readRawShort(buffer);
         }
 
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/SmallFloatingSizePrimitiveTypeEncoding.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/SmallFloatingSizePrimitiveTypeEncoding.java
@@ -35,8 +35,8 @@ abstract class SmallFloatingSizePrimitiveTypeEncoding<T> extends FloatingSizePri
     }
 
     @Override
-    protected void writeSize(final T val)
+    protected void writeSize(WritableBuffer buffer, final T val)
     {
-        getEncoder().writeRaw((byte)getEncodedValueSize(val));
+        getEncoder().writeRaw(buffer, (byte)getEncodedValueSize(val));
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/SymbolType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/SymbolType.java
@@ -26,8 +26,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SymbolType extends AbstractPrimitiveType<Symbol>
 {
@@ -35,12 +35,12 @@ public class SymbolType extends AbstractPrimitiveType<Symbol>
     private final SymbolEncoding _symbolEncoding;
     private final SymbolEncoding _shortSymbolEncoding;
 
-    private final Map<ByteBuffer, Symbol> _symbolCache = new HashMap<ByteBuffer, Symbol>();
+    private final Map<ByteBuffer, Symbol> _symbolCache = new ConcurrentHashMap<ByteBuffer, Symbol>();
     private DecoderImpl.TypeDecoder<Symbol> _symbolCreator =
             new DecoderImpl.TypeDecoder<Symbol>()
             {
 
-                public Symbol decode(final ByteBuffer buf)
+                public Symbol decode(final ReadableBuffer buf)
                 {
 
                     Symbol symbol = _symbolCache.get(buf);
@@ -103,14 +103,14 @@ public class SymbolType extends AbstractPrimitiveType<Symbol>
         }
 
         @Override
-        protected void writeEncodedValue(final Symbol val)
+        protected void writeEncodedValue(WritableBuffer buffer, final Symbol val)
         {
-            final int length = val.length();
             final EncoderImpl encoder = getEncoder();
 
+            final int length = val.length();
             for(int i = 0; i < length; i++)
             {
-                encoder.writeRaw((byte)val.charAt(i));
+                encoder.writeRaw(buffer, (byte)val.charAt(i));
             }
         }
 
@@ -137,11 +137,11 @@ public class SymbolType extends AbstractPrimitiveType<Symbol>
             return (getType() == encoding.getType());
         }
 
-        public Symbol readValue()
+        public Symbol readValue(ReadableBuffer buffer)
         {
             DecoderImpl decoder = getDecoder();
-            int size = decoder.readRawInt();
-            return decoder.readRaw(_symbolCreator, size);
+            int size = decoder.readRawInt(buffer);
+            return decoder.readRaw(buffer, _symbolCreator, size);
         }
     }
     
@@ -156,15 +156,16 @@ public class SymbolType extends AbstractPrimitiveType<Symbol>
         }
 
         @Override
-        protected void writeEncodedValue(final Symbol val)
+        protected void writeEncodedValue(WritableBuffer buffer, final Symbol val)
         {
 
-            final int length = val.length();
             final EncoderImpl encoder = getEncoder();
+
+            final int length = val.length();
 
             for(int i = 0; i < length; i++)
             {
-                encoder.writeRaw((byte)val.charAt(i));
+                encoder.writeRaw(buffer, (byte)val.charAt(i));
             }
         }
 
@@ -191,11 +192,11 @@ public class SymbolType extends AbstractPrimitiveType<Symbol>
             return encoder == this;
         }
 
-        public Symbol readValue()
+        public Symbol readValue(ReadableBuffer buffer)
         {
             DecoderImpl decoder = getDecoder();
-            int size = ((int)decoder.readRawByte()) & 0xff;
-            return decoder.readRaw(_symbolCreator, size);
+            int size = ((int)decoder.readRawByte(buffer)) & 0xff;
+            return decoder.readRaw(buffer, _symbolCreator, size);
         }
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/TimestampType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/TimestampType.java
@@ -56,9 +56,9 @@ public class TimestampType extends AbstractPrimitiveType<Date>
         return Collections.singleton(_timestampEncoding);
     }
 
-    public void write(long l)
+    public void write(WritableBuffer buffer, long l)
     {
-        _timestampEncoding.write(l);
+        _timestampEncoding.write(buffer, l);
     }
     
     private class TimestampEncoding extends FixedSizePrimitiveTypeEncoding<Date>
@@ -86,15 +86,15 @@ public class TimestampType extends AbstractPrimitiveType<Date>
             return TimestampType.this;
         }
 
-        public void writeValue(final Date val)
+        public void writeValue(WritableBuffer buffer, final Date val)
         {
-            getEncoder().writeRaw(val.getTime());
+            getEncoder().writeRaw(buffer, val.getTime());
         }
         
-        public void write(final long l)
+        public void write(WritableBuffer buffer, final long l)
         {
-            writeConstructor();
-            getEncoder().writeRaw(l);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, l);
             
         }
 
@@ -103,9 +103,9 @@ public class TimestampType extends AbstractPrimitiveType<Date>
             return (getType() == encoding.getType());
         }
 
-        public Date readValue()
+        public Date readValue(ReadableBuffer buffer)
         {
-            return new Date(getDecoder().readRawLong());
+            return new Date(getDecoder().readRawLong(buffer));
         }
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/TypeConstructor.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/TypeConstructor.java
@@ -22,9 +22,12 @@ package org.apache.qpid.proton.codec;
 
 public interface TypeConstructor<V>
 {
-    V readValue();
+    V readValue(ReadableBuffer buffer);
 
     boolean encodesJavaPrimitive();
 
     Class<V> getTypeClass();
+
+    boolean isArray();
+
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/TypeEncoding.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/TypeEncoding.java
@@ -24,11 +24,11 @@ public interface TypeEncoding<V>
 {
     AMQPType<V> getType();
 
-    void writeConstructor();
+    void writeConstructor(WritableBuffer buffer);
 
     int getConstructorSize();
 
-    void writeValue(V val);
+    void writeValue(WritableBuffer buffer, V val);
 
     int getValueSize(V val);
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/UUIDType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/UUIDType.java
@@ -81,10 +81,10 @@ public class UUIDType extends AbstractPrimitiveType<UUID>
             return UUIDType.this;
         }
 
-        public void writeValue(final UUID val)
+        public void writeValue(WritableBuffer buffer, final UUID val)
         {
-            getEncoder().writeRaw(val.getMostSignificantBits());
-            getEncoder().writeRaw(val.getLeastSignificantBits());
+            getEncoder().writeRaw(buffer, val.getMostSignificantBits());
+            getEncoder().writeRaw(buffer, val.getLeastSignificantBits());
         }
 
         public boolean encodesSuperset(final TypeEncoding<UUID> encoding)
@@ -92,10 +92,10 @@ public class UUIDType extends AbstractPrimitiveType<UUID>
             return (getType() == encoding.getType());
         }
 
-        public UUID readValue()
+        public UUID readValue(ReadableBuffer buffer)
         {
-            long msb = getDecoder().readRawLong();
-            long lsb = getDecoder().readRawLong();
+            long msb = getDecoder().readRawLong(buffer);
+            long lsb = getDecoder().readRawLong(buffer);
 
             return new UUID(msb, lsb);
         }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/UnsignedByteType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/UnsignedByteType.java
@@ -82,9 +82,9 @@ public class UnsignedByteType extends AbstractPrimitiveType<UnsignedByte>
             return UnsignedByteType.this;
         }
 
-        public void writeValue(final UnsignedByte val)
+        public void writeValue(WritableBuffer buffer, final UnsignedByte val)
         {
-            getEncoder().writeRaw(val.byteValue());
+            getEncoder().writeRaw(buffer, val.byteValue());
         }
 
         public boolean encodesSuperset(final TypeEncoding<UnsignedByte> encoding)
@@ -92,9 +92,9 @@ public class UnsignedByteType extends AbstractPrimitiveType<UnsignedByte>
             return (getType() == encoding.getType());
         }
 
-        public UnsignedByte readValue()
+        public UnsignedByte readValue(ReadableBuffer buffer)
         {
-            return UnsignedByte.valueOf(getDecoder().readRawByte());
+            return UnsignedByte.valueOf(getDecoder().readRawByte(buffer));
         }
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/UnsignedIntegerType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/UnsignedIntegerType.java
@@ -98,15 +98,15 @@ public class UnsignedIntegerType extends AbstractPrimitiveType<UnsignedInteger>
             return UnsignedIntegerType.this;
         }
 
-        public void writeValue(final UnsignedInteger val)
+        public void writeValue(WritableBuffer buffer, final UnsignedInteger val)
         {
-            getEncoder().writeRaw(val.intValue());
+            getEncoder().writeRaw(buffer,val.intValue());
         }
         
-        public void write(final int i)
+        public void write(WritableBuffer buffer, final int i)
         {
-            writeConstructor();
-            getEncoder().writeRaw(i);
+            writeConstructor(buffer);
+            getEncoder().writeRaw(buffer, i);
             
         }
 
@@ -115,9 +115,9 @@ public class UnsignedIntegerType extends AbstractPrimitiveType<UnsignedInteger>
             return (getType() == encoding.getType());
         }
 
-        public UnsignedInteger readValue()
+        public UnsignedInteger readValue(ReadableBuffer buffer)
         {
-            return UnsignedInteger.valueOf(getDecoder().readRawInt());
+            return UnsignedInteger.valueOf(getDecoder().readRawInt(buffer));
         }
     }
 
@@ -148,9 +148,9 @@ public class UnsignedIntegerType extends AbstractPrimitiveType<UnsignedInteger>
             return UnsignedIntegerType.this;
         }
 
-        public void writeValue(final UnsignedInteger val)
+        public void writeValue(WritableBuffer buffer, final UnsignedInteger val)
         {
-            getEncoder().writeRaw((byte)val.intValue());
+            getEncoder().writeRaw(buffer, (byte)val.intValue());
         }
 
         public boolean encodesSuperset(final TypeEncoding<UnsignedInteger> encoder)
@@ -158,9 +158,9 @@ public class UnsignedIntegerType extends AbstractPrimitiveType<UnsignedInteger>
             return encoder == this  || encoder instanceof ZeroUnsignedIntegerEncoding;
         }
 
-        public UnsignedInteger readValue()
+        public UnsignedInteger readValue(ReadableBuffer buffer)
         {
-            return UnsignedInteger.valueOf(((int)getDecoder().readRawByte()) & 0xff);
+            return UnsignedInteger.valueOf(((int)getDecoder().readRawByte(buffer)) & 0xff);
         }
     }
 
@@ -192,7 +192,7 @@ public class UnsignedIntegerType extends AbstractPrimitiveType<UnsignedInteger>
             return UnsignedIntegerType.this;
         }
 
-        public void writeValue(final UnsignedInteger val)
+        public void writeValue(WritableBuffer buffer, final UnsignedInteger val)
         {
         }
 
@@ -201,7 +201,7 @@ public class UnsignedIntegerType extends AbstractPrimitiveType<UnsignedInteger>
             return encoder == this;
         }
 
-        public UnsignedInteger readValue()
+        public UnsignedInteger readValue(ReadableBuffer buffer)
         {
             return UnsignedInteger.ZERO;
         }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/UnsignedLongType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/UnsignedLongType.java
@@ -98,9 +98,9 @@ public class UnsignedLongType extends AbstractPrimitiveType<UnsignedLong>
             return UnsignedLongType.this;
         }
 
-        public void writeValue(final UnsignedLong val)
+        public void writeValue(WritableBuffer buffer, final UnsignedLong val)
         {
-            getEncoder().writeRaw(val.longValue());
+            getEncoder().writeRaw(buffer, val.longValue());
         }
 
 
@@ -109,9 +109,9 @@ public class UnsignedLongType extends AbstractPrimitiveType<UnsignedLong>
             return (getType() == encoding.getType());
         }
 
-        public UnsignedLong readValue()
+        public UnsignedLong readValue(ReadableBuffer buffer)
         {
-            return UnsignedLong.valueOf(getDecoder().readRawLong());
+            return UnsignedLong.valueOf(getDecoder().readRawLong(buffer));
         }
     }
 
@@ -142,9 +142,9 @@ public class UnsignedLongType extends AbstractPrimitiveType<UnsignedLong>
             return UnsignedLongType.this;
         }
 
-        public void writeValue(final UnsignedLong val)
+        public void writeValue(WritableBuffer buffer, final UnsignedLong val)
         {
-            getEncoder().writeRaw((byte)val.longValue());
+            getEncoder().writeRaw(buffer, (byte)val.longValue());
         }
 
         public boolean encodesSuperset(final TypeEncoding<UnsignedLong> encoder)
@@ -152,9 +152,9 @@ public class UnsignedLongType extends AbstractPrimitiveType<UnsignedLong>
             return encoder == this  || encoder instanceof ZeroUnsignedLongEncoding;
         }
 
-        public UnsignedLong readValue()
+        public UnsignedLong readValue(ReadableBuffer buffer)
         {
-            return UnsignedLong.valueOf(((long)getDecoder().readRawByte())&0xffl);
+            return UnsignedLong.valueOf(((long)getDecoder().readRawByte(buffer))&0xffl);
         }
     }
     
@@ -186,7 +186,7 @@ public class UnsignedLongType extends AbstractPrimitiveType<UnsignedLong>
             return UnsignedLongType.this;
         }
 
-        public void writeValue(final UnsignedLong val)
+        public void writeValue(WritableBuffer buffer, final UnsignedLong val)
         {
         }
 
@@ -195,7 +195,7 @@ public class UnsignedLongType extends AbstractPrimitiveType<UnsignedLong>
             return encoder == this;
         }
 
-        public UnsignedLong readValue()
+        public UnsignedLong readValue(ReadableBuffer buffer)
         {
             return UnsignedLong.ZERO;
         }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/UnsignedShortType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/UnsignedShortType.java
@@ -82,9 +82,9 @@ public class UnsignedShortType extends AbstractPrimitiveType<UnsignedShort>
             return UnsignedShortType.this;
         }
 
-        public void writeValue(final UnsignedShort val)
+        public void writeValue(WritableBuffer buffer, final UnsignedShort val)
         {
-            getEncoder().writeRaw(val.shortValue());
+            getEncoder().writeRaw(buffer, val.shortValue());
         }
 
         public boolean encodesSuperset(final TypeEncoding<UnsignedShort> encoding)
@@ -92,9 +92,9 @@ public class UnsignedShortType extends AbstractPrimitiveType<UnsignedShort>
             return (getType() == encoding.getType());
         }
 
-        public UnsignedShort readValue()
+        public UnsignedShort readValue(ReadableBuffer buffer)
         {
-            return UnsignedShort.valueOf(getDecoder().readRawShort());
+            return UnsignedShort.valueOf(getDecoder().readRawShort(buffer));
         }
     }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/WritableBuffer.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/WritableBuffer.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 
 public interface WritableBuffer
 {
-    public void put(byte b);
+    void put(byte b);
 
     void putFloat(float f);
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/AcceptedType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/AcceptedType.java
@@ -29,6 +29,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 public final class AcceptedType extends AbstractDescribedType<Accepted,List> implements DescribedTypeConstructor<Accepted>
 {
@@ -64,8 +66,9 @@ public final class AcceptedType extends AbstractDescribedType<Accepted,List> imp
         return Accepted.class;
     }
 
-    public Accepted newInstance(Object described)
+    public Accepted newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
+        constructor.readValue(buffer); // just to skip the bytes... ignoring result
         return Accepted.getInstance();
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/AmqpSequenceType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/AmqpSequenceType.java
@@ -31,6 +31,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class AmqpSequenceType extends AbstractDescribedType<AmqpSequence,List> implements DescribedTypeConstructor<AmqpSequence>
@@ -58,9 +60,9 @@ public class AmqpSequenceType extends AbstractDescribedType<AmqpSequence,List> i
         return val.getValue();
     }
 
-    public AmqpSequence newInstance(Object described)
+    public AmqpSequence newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        return new AmqpSequence( (List) described );
+        return new AmqpSequence( (List) constructor.readValue(buffer) );
     }
 
     public Class<AmqpSequence> getTypeClass()

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/AmqpValueType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/AmqpValueType.java
@@ -31,6 +31,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class AmqpValueType extends AbstractDescribedType<AmqpValue,Object> implements DescribedTypeConstructor<AmqpValue>
@@ -58,9 +60,9 @@ public class AmqpValueType extends AbstractDescribedType<AmqpValue,Object> imple
         return val.getValue();
     }
 
-    public AmqpValue newInstance(Object described)
+    public AmqpValue newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        return new AmqpValue( described );
+        return new AmqpValue( constructor.readValue(buffer) );
     }
 
     public Class<AmqpValue> getTypeClass()

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/ApplicationPropertiesType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/ApplicationPropertiesType.java
@@ -31,6 +31,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class ApplicationPropertiesType  extends AbstractDescribedType<ApplicationProperties,Map> implements DescribedTypeConstructor<ApplicationProperties>
@@ -58,10 +60,9 @@ public class ApplicationPropertiesType  extends AbstractDescribedType<Applicatio
         return val.getValue();
     }
 
-
-    public ApplicationProperties newInstance(Object described)
+    public ApplicationProperties newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        return new ApplicationProperties( (Map) described );
+        return new ApplicationProperties( (Map) constructor.readValue(buffer) );
     }
 
     public Class<ApplicationProperties> getTypeClass()

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DataType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DataType.java
@@ -32,6 +32,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class DataType extends AbstractDescribedType<Data,Binary> implements DescribedTypeConstructor<Data>
@@ -59,9 +61,10 @@ public class DataType extends AbstractDescribedType<Data,Binary> implements Desc
         return val.getValue();
     }
 
-    public Data newInstance(Object described)
+
+    public Data newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        return new Data( (Binary) described );
+        return new Data( (Binary) constructor.readValue(buffer) );
     }
 
     public Class<Data> getTypeClass()

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeleteOnCloseType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeleteOnCloseType.java
@@ -32,6 +32,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class DeleteOnCloseType extends AbstractDescribedType<DeleteOnClose,List> implements DescribedTypeConstructor<DeleteOnClose>
@@ -60,8 +62,9 @@ public class DeleteOnCloseType extends AbstractDescribedType<DeleteOnClose,List>
         return Collections.EMPTY_LIST;
     }
 
-    public DeleteOnClose newInstance(Object described)
+    public DeleteOnClose newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
+        constructor.readValue(buffer); // just to skip
         return DeleteOnClose.getInstance();
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeleteOnNoLinksOrMessagesType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeleteOnNoLinksOrMessagesType.java
@@ -32,6 +32,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class DeleteOnNoLinksOrMessagesType extends AbstractDescribedType<DeleteOnNoLinksOrMessages,List> implements DescribedTypeConstructor<DeleteOnNoLinksOrMessages>
@@ -59,8 +61,9 @@ public class DeleteOnNoLinksOrMessagesType extends AbstractDescribedType<DeleteO
         return Collections.EMPTY_LIST;
     }
 
-    public DeleteOnNoLinksOrMessages newInstance(Object described)
+    public DeleteOnNoLinksOrMessages newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
+        constructor.readValue(buffer); // to skip the streaming
         return DeleteOnNoLinksOrMessages.getInstance();
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeleteOnNoLinksType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeleteOnNoLinksType.java
@@ -32,6 +32,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 public class DeleteOnNoLinksType extends AbstractDescribedType<DeleteOnNoLinks,List> implements DescribedTypeConstructor<DeleteOnNoLinks>
 {
@@ -59,8 +61,10 @@ public class DeleteOnNoLinksType extends AbstractDescribedType<DeleteOnNoLinks,L
     }
 
     @Override
-    public DeleteOnNoLinks newInstance(Object described)
+    public DeleteOnNoLinks newInstance(ReadableBuffer buffer,  TypeConstructor constructor)
     {
+        // it's not used but we have to read it to make sure it won't damage the sequence
+        constructor.readValue(buffer);
         return DeleteOnNoLinks.getInstance();
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeleteOnNoMessagesType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeleteOnNoMessagesType.java
@@ -32,6 +32,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class DeleteOnNoMessagesType extends AbstractDescribedType<DeleteOnNoMessages,List> implements DescribedTypeConstructor<DeleteOnNoMessages>
@@ -60,8 +62,9 @@ public class DeleteOnNoMessagesType extends AbstractDescribedType<DeleteOnNoMess
     }
 
     @Override
-    public DeleteOnNoMessages newInstance(Object described)
+    public DeleteOnNoMessages newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
+        constructor.readValue(buffer); // just to skip
         return DeleteOnNoMessages.getInstance();
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeliveryAnnotationsType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/DeliveryAnnotationsType.java
@@ -31,6 +31,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class DeliveryAnnotationsType extends AbstractDescribedType<DeliveryAnnotations,Map> implements DescribedTypeConstructor<DeliveryAnnotations>
@@ -59,9 +61,9 @@ public class DeliveryAnnotationsType extends AbstractDescribedType<DeliveryAnnot
     }
 
 
-    public DeliveryAnnotations newInstance(Object described)
+    public DeliveryAnnotations newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        return new DeliveryAnnotations( (Map) described );
+        return new DeliveryAnnotations( (Map) constructor.readValue(buffer) );
     }
 
     public Class<DeliveryAnnotations> getTypeClass()

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/FooterType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/FooterType.java
@@ -31,6 +31,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class FooterType extends AbstractDescribedType<Footer,Map> implements DescribedTypeConstructor<Footer>
@@ -58,9 +60,9 @@ public class FooterType extends AbstractDescribedType<Footer,Map> implements Des
         return val.getValue();
     }
 
-    public Footer newInstance(Object described)
+    public Footer newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        return new Footer( (Map) described );
+        return new Footer( (Map) constructor.readValue(buffer) );
     }
 
     public Class<Footer> getTypeClass()

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/HeaderType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/HeaderType.java
@@ -34,6 +34,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class HeaderType extends AbstractDescribedType<Header,List> implements DescribedTypeConstructor<Header>
@@ -114,9 +116,9 @@ public class HeaderType extends AbstractDescribedType<Header,List> implements De
 
     }
 
-    public Header newInstance(Object described)
+    public Header newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Header o = new Header();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/MessageAnnotationsType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/MessageAnnotationsType.java
@@ -32,6 +32,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class MessageAnnotationsType extends AbstractDescribedType<MessageAnnotations,Map> implements DescribedTypeConstructor<MessageAnnotations>
@@ -60,10 +62,9 @@ public class MessageAnnotationsType extends AbstractDescribedType<MessageAnnotat
         return val.getValue();
     }
 
-
-    public MessageAnnotations newInstance(Object described)
+    public MessageAnnotations newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        return new MessageAnnotations( (Map) described );
+        return new MessageAnnotations( (Map) constructor.readValue(buffer) );
     }
 
     public Class<MessageAnnotations> getTypeClass()

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/ModifiedType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/ModifiedType.java
@@ -33,6 +33,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class ModifiedType  extends AbstractDescribedType<Modified,List> implements DescribedTypeConstructor<Modified>
@@ -101,9 +103,9 @@ public class ModifiedType  extends AbstractDescribedType<Modified,List> implemen
 
     }
 
-    public Modified newInstance(Object described)
+    public Modified newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Modified o = new Modified();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/PropertiesType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/PropertiesType.java
@@ -1,4 +1,3 @@
-
 /*
 *
 * Licensed to the Apache Software Foundation (ASF) under one
@@ -35,14 +34,16 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
-public class PropertiesType  extends AbstractDescribedType<Properties,List> implements DescribedTypeConstructor<Properties>
+public class PropertiesType extends AbstractDescribedType<Properties, List> implements DescribedTypeConstructor<Properties>
 {
     private static final Object[] DESCRIPTORS =
-    {
-        UnsignedLong.valueOf(0x0000000000000073L), Symbol.valueOf("amqp:properties:list"),
-    };
+        {
+            UnsignedLong.valueOf(0x0000000000000073L), Symbol.valueOf("amqp:properties:list"),
+        };
 
     private static final UnsignedLong DESCRIPTOR = UnsignedLong.valueOf(0x0000000000000073L);
 
@@ -75,7 +76,7 @@ public class PropertiesType  extends AbstractDescribedType<Properties,List> impl
         public Object get(final int index)
         {
 
-            switch(index)
+            switch (index)
             {
                 case 0:
                     return _impl.getMessageId();
@@ -112,90 +113,91 @@ public class PropertiesType  extends AbstractDescribedType<Properties,List> impl
         public int size()
         {
             return _impl.getReplyToGroupId() != null
-                      ? 13
-                      : _impl.getGroupSequence() != null
-                      ? 12
-                      : _impl.getGroupId() != null
-                      ? 11
-                      : _impl.getCreationTime() != null
-                      ? 10
-                      : _impl.getAbsoluteExpiryTime() != null
-                      ? 9
-                      : _impl.getContentEncoding() != null
-                      ? 8
-                      : _impl.getContentType() != null
-                      ? 7
-                      : _impl.getCorrelationId() != null
-                      ? 6
-                      : _impl.getReplyTo() != null
-                      ? 5
-                      : _impl.getSubject() != null
-                      ? 4
-                      : _impl.getTo() != null
-                      ? 3
-                      : _impl.getUserId() != null
-                      ? 2
-                      : _impl.getMessageId() != null
-                      ? 1
-                      : 0;
+                ? 13
+                : _impl.getGroupSequence() != null
+                ? 12
+                : _impl.getGroupId() != null
+                ? 11
+                : _impl.getCreationTime() != null
+                ? 10
+                : _impl.getAbsoluteExpiryTime() != null
+                ? 9
+                : _impl.getContentEncoding() != null
+                ? 8
+                : _impl.getContentType() != null
+                ? 7
+                : _impl.getCorrelationId() != null
+                ? 6
+                : _impl.getReplyTo() != null
+                ? 5
+                : _impl.getSubject() != null
+                ? 4
+                : _impl.getTo() != null
+                ? 3
+                : _impl.getUserId() != null
+                ? 2
+                : _impl.getMessageId() != null
+                ? 1
+                : 0;
 
         }
 
     }
 
-        public Properties newInstance(Object described)
+
+
+    public Properties newInstance(ReadableBuffer buffer, TypeConstructor constructor)
+    {
+        List l = (List) constructor.readValue(buffer);
+
+        Properties o = new Properties();
+
+
+        switch (13 - l.size())
         {
-            List l = (List) described;
 
-            Properties o = new Properties();
-
-
-            switch(13 - l.size())
-            {
-
-                case 0:
-                    o.setReplyToGroupId( (String) l.get( 12 ) );
-                case 1:
-                    o.setGroupSequence( (UnsignedInteger) l.get( 11 ) );
-                case 2:
-                    o.setGroupId( (String) l.get( 10 ) );
-                case 3:
-                    o.setCreationTime( (Date) l.get( 9 ) );
-                case 4:
-                    o.setAbsoluteExpiryTime( (Date) l.get( 8 ) );
-                case 5:
-                    o.setContentEncoding( (Symbol) l.get( 7 ) );
-                case 6:
-                    o.setContentType( (Symbol) l.get( 6 ) );
-                case 7:
-                    o.setCorrelationId( (Object) l.get( 5 ) );
-                case 8:
-                    o.setReplyTo( (String) l.get( 4 ) );
-                case 9:
-                    o.setSubject( (String) l.get( 3 ) );
-                case 10:
-                    o.setTo( (String) l.get( 2 ) );
-                case 11:
-                    o.setUserId( (Binary) l.get( 1 ) );
-                case 12:
-                    o.setMessageId( (Object) l.get( 0 ) );
-            }
-
-
-            return o;
+            case 0:
+                o.setReplyToGroupId((String) l.get(12));
+            case 1:
+                o.setGroupSequence((UnsignedInteger) l.get(11));
+            case 2:
+                o.setGroupId((String) l.get(10));
+            case 3:
+                o.setCreationTime((Date) l.get(9));
+            case 4:
+                o.setAbsoluteExpiryTime((Date) l.get(8));
+            case 5:
+                o.setContentEncoding((Symbol) l.get(7));
+            case 6:
+                o.setContentType((Symbol) l.get(6));
+            case 7:
+                o.setCorrelationId((Object) l.get(5));
+            case 8:
+                o.setReplyTo((String) l.get(4));
+            case 9:
+                o.setSubject((String) l.get(3));
+            case 10:
+                o.setTo((String) l.get(2));
+            case 11:
+                o.setUserId((Binary) l.get(1));
+            case 12:
+                o.setMessageId((Object) l.get(0));
         }
 
-        public Class<Properties> getTypeClass()
-        {
-            return Properties.class;
-        }
 
+        return o;
+    }
+
+    public Class<Properties> getTypeClass()
+    {
+        return Properties.class;
+    }
 
 
     public static void register(Decoder decoder, EncoderImpl encoder)
     {
         PropertiesType type = new PropertiesType(encoder);
-        for(Object descriptor : DESCRIPTORS)
+        for (Object descriptor : DESCRIPTORS)
         {
             decoder.register(descriptor, type);
         }

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/ReceivedType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/ReceivedType.java
@@ -33,6 +33,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class ReceivedType extends AbstractDescribedType<Received,List> implements DescribedTypeConstructor<Received>
@@ -96,9 +98,11 @@ public final class ReceivedType extends AbstractDescribedType<Received,List> imp
         }
     }
 
-    public Received newInstance(Object described)
+
+
+    public Received newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Received o = new Received();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/RejectedType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/RejectedType.java
@@ -33,6 +33,8 @@ import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class RejectedType  extends AbstractDescribedType<Rejected,List> implements DescribedTypeConstructor<Rejected>
@@ -92,9 +94,9 @@ public class RejectedType  extends AbstractDescribedType<Rejected,List> implemen
         }
     }
 
-    public Rejected newInstance(Object described)
+    public Rejected newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Rejected o = new Rejected();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/ReleasedType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/ReleasedType.java
@@ -32,6 +32,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class ReleasedType extends AbstractDescribedType<Released,List> implements DescribedTypeConstructor<Released>
@@ -60,8 +62,9 @@ public class ReleasedType extends AbstractDescribedType<Released,List> implement
     }
 
 
-    public Released newInstance(Object described)
+    public Released newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
+        constructor.readValue(buffer); // to skip the stream only.. not used
         return Released.getInstance();
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/SourceType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/SourceType.java
@@ -37,6 +37,8 @@ import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
 import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
 import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class SourceType extends AbstractDescribedType<Source,List> implements DescribedTypeConstructor<Source>
@@ -137,9 +139,10 @@ public class SourceType extends AbstractDescribedType<Source,List> implements De
 
     }
 
-    public Source newInstance(Object described)
+
+    public Source newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Source o = new Source();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/TargetType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/messaging/TargetType.java
@@ -36,6 +36,8 @@ import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
 import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
 import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class TargetType extends AbstractDescribedType<Target,List> implements DescribedTypeConstructor<Target>
@@ -119,9 +121,9 @@ public class TargetType extends AbstractDescribedType<Target,List> implements De
         }
     }
 
-    public Target newInstance(Object described)
+    public Target newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Target o = new Target();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslChallengeType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslChallengeType.java
@@ -34,6 +34,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class SaslChallengeType extends AbstractDescribedType<SaslChallenge,List> implements DescribedTypeConstructor<SaslChallenge>
@@ -63,9 +65,9 @@ public class SaslChallengeType extends AbstractDescribedType<SaslChallenge,List>
 
 
 
-    public SaslChallenge newInstance(Object described)
+    public SaslChallenge newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         SaslChallenge o = new SaslChallenge();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslInitType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslInitType.java
@@ -34,6 +34,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class SaslInitType extends AbstractDescribedType<SaslInit,List> implements DescribedTypeConstructor<SaslInit>
@@ -100,9 +102,9 @@ public class SaslInitType extends AbstractDescribedType<SaslInit,List> implement
         }
     }
 
-    public SaslInit newInstance(Object described)
+    public SaslInit newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         SaslInit o = new SaslInit();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslMechanismsType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslMechanismsType.java
@@ -33,6 +33,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class SaslMechanismsType extends AbstractDescribedType<SaslMechanisms,List> implements DescribedTypeConstructor<SaslMechanisms>
@@ -60,9 +62,9 @@ public class SaslMechanismsType extends AbstractDescribedType<SaslMechanisms,Lis
         return Collections.singletonList(val.getSaslServerMechanisms());
     }
 
-    public SaslMechanisms newInstance(Object described)
+     public SaslMechanisms newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         SaslMechanisms o = new SaslMechanisms();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslOutcomeType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslOutcomeType.java
@@ -36,6 +36,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class SaslOutcomeType  extends AbstractDescribedType<SaslOutcome,List> implements DescribedTypeConstructor<SaslOutcome>
@@ -97,9 +99,9 @@ public class SaslOutcomeType  extends AbstractDescribedType<SaslOutcome,List> im
         }
     }
 
-    public SaslOutcome newInstance(Object described)
+    public SaslOutcome newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         SaslOutcome o = new SaslOutcome();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslResponseType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/security/SaslResponseType.java
@@ -34,6 +34,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class SaslResponseType extends AbstractDescribedType<SaslResponse,List> implements DescribedTypeConstructor<SaslResponse>
@@ -62,9 +64,9 @@ public class SaslResponseType extends AbstractDescribedType<SaslResponse,List> i
     }
 
 
-    public SaslResponse newInstance(Object described)
+    public SaslResponse newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         SaslResponse o = new SaslResponse();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/CoordinatorType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/CoordinatorType.java
@@ -32,6 +32,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class CoordinatorType extends AbstractDescribedType<Coordinator,List> implements DescribedTypeConstructor<Coordinator>
@@ -62,10 +64,9 @@ public class CoordinatorType extends AbstractDescribedType<Coordinator,List> imp
                 : Collections.singletonList(capabilities);
     }
 
-
-    public Coordinator newInstance(Object described)
+    public Coordinator newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Coordinator o = new Coordinator();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/DeclareType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/DeclareType.java
@@ -33,6 +33,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class DeclareType extends AbstractDescribedType<Declare,List> implements DescribedTypeConstructor<Declare>
@@ -61,9 +63,9 @@ public class DeclareType extends AbstractDescribedType<Declare,List> implements 
         return globalId == null ? Collections.EMPTY_LIST : Collections.singletonList(globalId);
     }
 
-    public Declare newInstance(Object described)
+    public Declare newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Declare o = new Declare();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/DeclaredType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/DeclaredType.java
@@ -34,6 +34,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class DeclaredType extends AbstractDescribedType<Declared,List> implements DescribedTypeConstructor<Declared>
@@ -61,9 +63,9 @@ public class DeclaredType extends AbstractDescribedType<Declared,List> implement
         return Collections.singletonList(val.getTxnId());
     }
 
-    public Declared newInstance(Object described)
+    public Declared newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Declared o = new Declared();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/DischargeType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/DischargeType.java
@@ -34,6 +34,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public class DischargeType extends AbstractDescribedType<Discharge,List> implements DescribedTypeConstructor<Discharge>
@@ -97,9 +99,9 @@ public class DischargeType extends AbstractDescribedType<Discharge,List> impleme
 
     }
 
-    public Discharge newInstance(Object described)
+    public Discharge newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Discharge o = new Discharge();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/TransactionalStateType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transaction/TransactionalStateType.java
@@ -35,6 +35,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 public class TransactionalStateType extends AbstractDescribedType<TransactionalState,List> implements DescribedTypeConstructor<TransactionalState>
 {
@@ -97,9 +99,9 @@ public class TransactionalStateType extends AbstractDescribedType<TransactionalS
 
     }
 
-    public TransactionalState newInstance(Object described)
+    public TransactionalState newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         TransactionalState o = new TransactionalState();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/AttachType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/AttachType.java
@@ -41,6 +41,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class AttachType extends AbstractDescribedType<Attach,List> implements DescribedTypeConstructor<Attach>
@@ -148,9 +150,9 @@ public final class AttachType extends AbstractDescribedType<Attach,List> impleme
 
     }
 
-    public Attach newInstance(Object described)
+    public Attach newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Attach o = new Attach();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/BeginType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/BeginType.java
@@ -36,6 +36,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class BeginType extends AbstractDescribedType<Begin,List> implements DescribedTypeConstructor<Begin>
@@ -115,9 +117,9 @@ public final class BeginType extends AbstractDescribedType<Begin,List> implement
         }
     }
 
-    public Begin newInstance(Object described)
+    public Begin newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Begin o = new Begin();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/CloseType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/CloseType.java
@@ -33,6 +33,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class CloseType extends AbstractDescribedType<Close,List> implements DescribedTypeConstructor<Close>
@@ -61,9 +63,9 @@ public final class CloseType extends AbstractDescribedType<Close,List> implement
         return error == null ? Collections.EMPTY_LIST : Collections.singletonList(error);
     }
 
-    public Close newInstance(Object described)
+    public Close newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Close o = new Close();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/DetachType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/DetachType.java
@@ -35,6 +35,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class DetachType extends AbstractDescribedType<Detach,List> implements DescribedTypeConstructor<Detach>
@@ -100,9 +102,9 @@ public final class DetachType extends AbstractDescribedType<Detach,List> impleme
         }
     }
 
-    public Detach newInstance(Object described)
+    public Detach newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Detach o = new Detach();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/EndType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/EndType.java
@@ -33,6 +33,8 @@ import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class EndType extends AbstractDescribedType<End,List> implements DescribedTypeConstructor<End>
@@ -61,10 +63,9 @@ public final class EndType extends AbstractDescribedType<End,List> implements De
         return errorCondition == null ? Collections.EMPTY_LIST : Collections.singletonList(errorCondition);
     }
 
-
-    public End newInstance(Object described)
+    public End newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         End o = new End();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/ErrorConditionType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/ErrorConditionType.java
@@ -34,6 +34,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class ErrorConditionType extends AbstractDescribedType<ErrorCondition,List> implements DescribedTypeConstructor<ErrorCondition>
@@ -100,9 +102,9 @@ public final class ErrorConditionType extends AbstractDescribedType<ErrorConditi
 
     }
 
-    public ErrorCondition newInstance(Object described)
+    public ErrorCondition newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         ErrorCondition o = new ErrorCondition();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/FlowType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/FlowType.java
@@ -35,6 +35,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class FlowType extends AbstractDescribedType<Flow,List> implements DescribedTypeConstructor<Flow>
@@ -127,9 +129,9 @@ public final class FlowType extends AbstractDescribedType<Flow,List> implements 
         }
     }
 
-    public Flow newInstance(Object described)
+    public Flow newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Flow o = new Flow();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/OpenType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/OpenType.java
@@ -36,6 +36,8 @@ import org.apache.qpid.proton.codec.DecodeException;
 import org.apache.qpid.proton.codec.Decoder;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
 public final class OpenType extends AbstractDescribedType<Open,List> implements DescribedTypeConstructor<Open>
@@ -132,9 +134,9 @@ public final class OpenType extends AbstractDescribedType<Open,List> implements 
 
     }
 
-    public Open newInstance(Object described)
+    public Open newInstance(ReadableBuffer buffer, TypeConstructor constructor)
     {
-        List l = (List) described;
+        List l = (List) constructor.readValue(buffer);
 
         Open o = new Open();
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/TransferType.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/transport/TransferType.java
@@ -1,4 +1,3 @@
-
 /*
 *
 * Licensed to the Apache Software Foundation (ASF) under one
@@ -35,23 +34,29 @@ import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
 import org.apache.qpid.proton.amqp.transport.Transfer;
 import org.apache.qpid.proton.codec.AbstractDescribedType;
 import org.apache.qpid.proton.codec.DecodeException;
-import org.apache.qpid.proton.codec.Decoder;
+import org.apache.qpid.proton.codec.DecoderImpl;
 import org.apache.qpid.proton.codec.DescribedTypeConstructor;
 import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.ListType;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.TypeConstructor;
 
 
-public final class TransferType extends AbstractDescribedType<Transfer,List> implements DescribedTypeConstructor<Transfer>
+public final class TransferType extends AbstractDescribedType<Transfer, List> implements DescribedTypeConstructor<Transfer>
 {
     private static final Object[] DESCRIPTORS =
-    {
-        UnsignedLong.valueOf(0x0000000000000014L), Symbol.valueOf("amqp:transfer:list"),
-    };
+        {
+            UnsignedLong.valueOf(0x0000000000000014L), Symbol.valueOf("amqp:transfer:list"),
+        };
 
     private static final UnsignedLong DESCRIPTOR = UnsignedLong.valueOf(0x0000000000000014L);
 
-    private TransferType(EncoderImpl encoder)
+    private final DecoderImpl _decoder;
+
+    public TransferType(DecoderImpl decoder, EncoderImpl encoder)
     {
         super(encoder);
+        this._decoder = decoder;
     }
 
 
@@ -80,7 +85,7 @@ public final class TransferType extends AbstractDescribedType<Transfer,List> imp
         public Object get(final int index)
         {
 
-            switch(index)
+            switch (index)
             {
                 case 0:
                     return _transfer.getHandle();
@@ -113,90 +118,106 @@ public final class TransferType extends AbstractDescribedType<Transfer,List> imp
         public int size()
         {
             return _transfer.getBatchable()
-                      ? 11
-                      : _transfer.getAborted()
-                      ? 10
-                      : _transfer.getResume()
-                      ? 9
-                      : _transfer.getState() != null
-                      ? 8
-                      : _transfer.getRcvSettleMode() != null
-                      ? 7
-                      : _transfer.getMore()
-                      ? 6
-                      : _transfer.getSettled() != null
-                      ? 5
-                      : _transfer.getMessageFormat() != null
-                      ? 4
-                      : _transfer.getDeliveryTag() != null
-                      ? 3
-                      : _transfer.getDeliveryId() != null
-                      ? 2
-                      : 1;
+                ? 11
+                : _transfer.getAborted()
+                ? 10
+                : _transfer.getResume()
+                ? 9
+                : _transfer.getState() != null
+                ? 8
+                : _transfer.getRcvSettleMode() != null
+                ? 7
+                : _transfer.getMore()
+                ? 6
+                : _transfer.getSettled() != null
+                ? 5
+                : _transfer.getMessageFormat() != null
+                ? 4
+                : _transfer.getDeliveryTag() != null
+                ? 3
+                : _transfer.getDeliveryId() != null
+                ? 2
+                : 1;
 
         }
 
     }
+    public Transfer newInstance(ReadableBuffer buffer, TypeConstructor constructor)
+    {
+        ListType.ListEncoding listEncoding = (ListType.ListEncoding)constructor;
 
-        public Transfer newInstance(Object described)
+        // This is for the prototype only, we should use the ListType directly here
+        int size = listEncoding.readCount(buffer, _decoder);
+
+        Transfer o = new Transfer();
+
+        if (size == 0)
         {
-            List l = (List) described;
+            throw new DecodeException("The handle field cannot be omitted");
+        }
 
-            Transfer o = new Transfer();
-
-            if(l.isEmpty())
-            {
-                throw new DecodeException("The handle field cannot be omitted");
-            }
-
-            switch(11 - l.size())
+        for (int i = 0; i < size; i++)
+        {
+            Object elementValue = listEncoding.readElement(buffer,  _decoder);
+            switch (i)
             {
 
                 case 0:
-                    Boolean batchable = (Boolean) l.get(10);
-                    o.setBatchable(batchable == null ? false : batchable);
+                    o.setHandle((UnsignedInteger) elementValue);
+                    break;
+
                 case 1:
-                    Boolean aborted = (Boolean) l.get(9);
-                    o.setAborted(aborted == null ? false : aborted);
+                    o.setDeliveryId((UnsignedInteger) elementValue);
+                    break;
+
                 case 2:
-                    Boolean resume = (Boolean) l.get(8);
-                    o.setResume(resume == null ? false : resume);
+                    o.setDeliveryTag((Binary) elementValue);
+                    break;
                 case 3:
-                    o.setState( (DeliveryState) l.get( 7 ) );
+                    o.setMessageFormat((UnsignedInteger) elementValue);
+                    break;
                 case 4:
-                    UnsignedByte receiverSettleMode = (UnsignedByte) l.get(6);
-                    o.setRcvSettleMode(receiverSettleMode == null ? null : ReceiverSettleMode.values()[receiverSettleMode.intValue()]);
+                    o.setSettled((Boolean) elementValue);
+                    break;
                 case 5:
-                    Boolean more = (Boolean) l.get(5);
-                    o.setMore(more == null ? false : more );
+                    Boolean more = (Boolean) elementValue;
+                    o.setMore(more == null ? false : more);
+                    break;
                 case 6:
-                    o.setSettled( (Boolean) l.get( 4 ) );
+                    UnsignedByte receiverSettleMode = (UnsignedByte) elementValue;
+                    o.setRcvSettleMode(receiverSettleMode == null ? null : ReceiverSettleMode.values()[receiverSettleMode.intValue()]);
+                    break;
                 case 7:
-                    o.setMessageFormat( (UnsignedInteger) l.get( 3 ) );
+                    o.setState((DeliveryState) elementValue);
+                    break;
                 case 8:
-                    o.setDeliveryTag( (Binary) l.get( 2 ) );
+                    Boolean resume = (Boolean) elementValue;
+                    o.setResume(resume == null ? false : resume);
+                    break;
                 case 9:
-                    o.setDeliveryId( (UnsignedInteger) l.get( 1 ) );
+                    Boolean aborted = (Boolean) elementValue;
+                    o.setAborted(aborted == null ? false : aborted);
+                    break;
                 case 10:
-                    o.setHandle( (UnsignedInteger) l.get( 0 ) );
+                    Boolean batchable = (Boolean) elementValue;
+                    o.setBatchable(batchable == null ? false : batchable);
+                    break;
             }
 
-
-            return o;
         }
+        return o;
+    }
 
-        public Class<Transfer> getTypeClass()
-        {
-            return Transfer.class;
-        }
-
-
-
-
-    public static void register(Decoder decoder, EncoderImpl encoder)
+    public Class<Transfer> getTypeClass()
     {
-        TransferType type = new TransferType(encoder);
-        for(Object descriptor : DESCRIPTORS)
+        return Transfer.class;
+    }
+
+
+    public static void register(DecoderImpl decoder, EncoderImpl encoder)
+    {
+        TransferType type = new TransferType(decoder, encoder);
+        for (Object descriptor : DESCRIPTORS)
         {
             decoder.register(descriptor, type);
         }
@@ -204,4 +225,3 @@ public final class TransferType extends AbstractDescribedType<Transfer,List> imp
     }
 
 }
-  

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/Transport.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/Transport.java
@@ -23,6 +23,8 @@ package org.apache.qpid.proton.engine;
 import java.nio.ByteBuffer;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.codec.DecoderImpl;
+import org.apache.qpid.proton.codec.EncoderImpl;
 import org.apache.qpid.proton.engine.impl.TransportImpl;
 
 
@@ -71,6 +73,16 @@ public interface Transport extends Endpoint
     {
         public static Transport create() {
             return new TransportImpl();
+        }
+
+        /** This constructor may serve you if you intend to customize the encoder and decoder with special types.
+         *  if your intent is to use with just regular types use {@link #create()}.
+         * @param encoder a custom encoder for your transport.
+         * @param decoder a custom decoder for your transport.
+         * @return
+         *  */
+        public static Transport create(EncoderImpl encoder, DecoderImpl decoder) {
+            return new TransportImpl(TransportImpl.DEFAULT_MAX_FRAME_SIZE, encoder, decoder);
         }
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ByteBufferUtils.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ByteBufferUtils.java
@@ -107,4 +107,61 @@ public class ByteBufferUtils
         return newBuffer;
     }
 
+
+
+    /**
+     * Format the ByteBuffer string representation into a programmer's understandable format
+     */
+    public static String formatGroup(String str, int groupSize, int lineBreak)
+    {
+       StringBuffer buffer = new StringBuffer();
+
+       int line = 1;
+       buffer.append("/*  1 */ \"");
+       for (int i = 0; i < str.length(); i += groupSize)
+       {
+          buffer.append(str.substring(i, i + Math.min(str.length() - i, groupSize)));
+
+          if ((i + groupSize) % lineBreak == 0)
+          {
+             buffer.append("\" +\n/* ");
+             line++;
+             if (line < 10)
+             {
+                buffer.append(" ");
+             }
+             buffer.append(Integer.toString(line) + " */ \"");
+          }
+          else if ((i + groupSize) % groupSize == 0 && str.length() - i > groupSize)
+          {
+             buffer.append("\" + \"");
+          }
+       }
+
+       buffer.append("\";");
+
+       return buffer.toString();
+
+    }
+
+    protected static final char[] hexArray = "0123456789ABCDEF".toCharArray();
+
+    /**
+     * Creates a String representation of the byte stream
+     * @param bytes
+     * @return
+     */
+    public static String bytesToHex(byte[] bytes)
+    {
+       char[] hexChars = new char[bytes.length * 2];
+       for (int j = 0; j < bytes.length; j++)
+       {
+          int v = bytes[j] & 0xFF;
+          hexChars[j * 2] = hexArray[v >>> 4];
+          hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+       }
+       return new String(hexChars);
+    }
+
+
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameParser.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameParser.java
@@ -33,6 +33,7 @@ import org.apache.qpid.proton.amqp.transport.EmptyFrame;
 import org.apache.qpid.proton.amqp.transport.FrameBody;
 import org.apache.qpid.proton.codec.ByteBufferDecoder;
 import org.apache.qpid.proton.codec.DecodeException;
+import org.apache.qpid.proton.codec.ReadableBuffer;
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
 import org.apache.qpid.proton.framing.TransportFrame;
@@ -384,9 +385,7 @@ class FrameParser implements TransportInput
 
                         if (frameBodySize > 0)
                         {
-                            _decoder.setByteBuffer(in);
-                            val = _decoder.readObject();
-                            _decoder.setByteBuffer(null);
+                            val = _decoder.readObject(new ReadableBuffer.ByteBufferReader(in));
 
                             if(in.hasRemaining())
                             {

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameWriter.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameWriter.java
@@ -60,7 +60,6 @@ class FrameWriter
         _encoder = encoder;
         _bbuf = ByteBuffer.allocate(1024);
         _buffer = new WritableBuffer.ByteBufferWrapper(_bbuf);
-        _encoder.setByteBuffer(_buffer);
         _maxFrameSize = maxFrameSize;
         _frameType = frameType;
         _protocolTracer = protocolTracer;
@@ -79,7 +78,6 @@ class FrameWriter
         _buffer = new WritableBuffer.ByteBufferWrapper(_bbuf);
         old.flip();
         _bbuf.put(old);
-        _encoder.setByteBuffer(_buffer);
     }
 
     void writeHeader(byte[] header)
@@ -103,7 +101,7 @@ class FrameWriter
             try
             {
                 _buffer.position(_frameStart + 8);
-                if (frameBody != null) _encoder.writeObject(frameBody);
+                if (frameBody != null) _encoder.writeObject(_buffer, frameBody);
                 break;
             }
             catch (BufferOverflowException e)

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslFrameParser.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslFrameParser.java
@@ -27,6 +27,7 @@ import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.security.SaslFrameBody;
 import org.apache.qpid.proton.codec.ByteBufferDecoder;
 import org.apache.qpid.proton.codec.DecodeException;
+import org.apache.qpid.proton.codec.ReadableBuffer;
 import org.apache.qpid.proton.engine.TransportException;
 
 class SaslFrameParser
@@ -203,8 +204,7 @@ class SaslFrameParser
 
                     try
                     {
-                        _decoder.setByteBuffer(input);
-                        Object val = _decoder.readObject();
+                        Object val = _decoder.readObject(new ReadableBuffer.ByteBufferReader(input));
 
                         Binary payload;
 

--- a/proton-j/src/test/java/org/apache/qpid/proton/codec/StringTypeTest.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/codec/StringTypeTest.java
@@ -116,11 +116,9 @@ public class StringTypeTest
         {
             bb.clear();
             final AmqpValue inputValue = new AmqpValue(input);
-            encoder.setByteBuffer(bb);
-            encoder.writeObject(inputValue);
+            encoder.writeObject(new WritableBuffer.ByteBufferWrapper(bb), inputValue);
             bb.clear();
-            decoder.setByteBuffer(bb);
-            final AmqpValue outputValue = (AmqpValue) decoder.readObject();
+            final AmqpValue outputValue = (AmqpValue) decoder.readObject(new ReadableBuffer.ByteBufferReader(bb));
             assertEquals("Failed to round trip String correctly: ", input, outputValue.getValue());
         }
     }

--- a/proton-j/src/test/java/org/apache/qpid/proton/engine/impl/AmqpFramer.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/engine/impl/AmqpFramer.java
@@ -80,14 +80,14 @@ public class AmqpFramer
         ByteBuffer buffer = ByteBuffer.allocate(1024);
 
         buffer.position(8); // leave hole for frame header
-        _encoder.setByteBuffer(new WritableBuffer.ByteBufferWrapper(buffer));
+        WritableBuffer writableBuffer = new WritableBuffer.ByteBufferWrapper(buffer);
 
         // write extended header - maybe empty
         buffer.put(extendedHeader);
         // write frame body
         if (frameBody != null)
         {
-            _encoder.writeObject(frameBody);
+            _encoder.writeObject(writableBuffer, frameBody);
         }
 
         int frameSize = buffer.position();


### PR DESCRIPTION
- Avoiding multiple instances. The encoder and decoder can be used as singletons.
- There's still an option to instantiate your own encoder / decoder
- stateless Decoder/Encoder (can always reuse the same instance now)
- Implementing WritableBuffer and ReadableBuffers fully, so you could use NettyBuffers integrated.
