### PR TITLE
[Go binding] Replaced c handler based flowcontroller with native go

### DIFF
--- a/proton-c/bindings/go/src/qpid.apache.org/proton/engine.go
+++ b/proton-c/bindings/go/src/qpid.apache.org/proton/engine.go
@@ -385,12 +385,6 @@ func (eng *Engine) Run() error {
 	_ = eng.conn.Close() // Close conn, force read/write goroutines to exit (they will Inject)
 	wait.Wait()          // Wait for goroutines
 
-	for _, h := range eng.handlers {
-		switch h := h.(type) {
-		case cHandler:
-			C.pn_handler_free(h.pn)
-		}
-	}
 	C.pn_connection_engine_final(&eng.engine)
 	return eng.err.Get()
 }


### PR DESCRIPTION
- The go binding now has no dependency on the proton-c reactor code

@alanconway - could you take a look at this an tell me what you think.