### PR TITLE
Adds cmake libatomic check to examplex/cpp

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -58,6 +58,24 @@ foreach(example
   add_executable(${example} ${example}.cpp)
 endforeach()
 
+INCLUDE(CheckCXXSourceCompiles)
+
+# Sometimes linking against libatomic is required for atomic ops, if
+# the platform doesn't support lock-free atomics.
+function(check_cxx_atomics varname)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  check_cxx_source_compiles("
+#include <cstdint>
+#include <atomic>
+std::atomic<uintptr_t> x;
+std::atomic<uintmax_t> y;
+int main() {
+  return x + y;
+}
+" ${varname})
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endfunction(check_cxx_atomics)
+
 if(HAS_CPP11)
   # Single-threaded examples that require C++11
   foreach(example
@@ -72,6 +90,20 @@ if(HAS_CPP11)
         broker)
       add_executable(mt_${example} mt/${example}.cpp ${container_src})
       target_link_libraries(mt_${example} pthread)
+      check_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
+      if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+        check_library_exists(atomic __atomic_fetch_add_8 "" HAS_LIBATOMIC)
+        if(HAS_LIBATOMIC)
+          target_link_libraries(mt_${example} atomic)
+          list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+          check_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+          if(NOT HAVE_CXX_ATOMICS_WITH_LIB)
+            message(FATAL_ERROR "Host compiler must support std::atomic!")
+          endif()
+        else()
+          message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
+        endif()
+      endif()
     endforeach()
     add_cpp_test(cpp-example-mt ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/example_test.py -v MtBrokerTest)
   endif()


### PR DESCRIPTION
qpid-proton FTBFS on Debian for mips and mipsel with following error:
```
/usr/bin/c++   -g -O2 -fdebug-prefix-map=/«PKGBUILDDIR»=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2    -Wl,-z,relro CMakeFiles/mt_broker.dir/mt/broker.cpp.o CMakeFiles/mt_broker.dir/mt/epoll_container.cpp.o  -o mt_broker -rdynamic ../../proton-c/bindings/cpp/libqpid-proton-cpp.so.8.0.0 -lpthread ../../proton-c/libqpid-proton.so.8.0.0 -lssl -lcrypto -Wl,-rpath,/«PKGBUILDDIR»/obj-mips-linux-gnu/proton-c/bindings/cpp:/«PKGBUILDDIR»/obj-mips-linux-gnu/proton-c 
CMakeFiles/mt_broker.dir/mt/epoll_container.cpp.o: In function `std::__atomic_base<unsigned long long>::operator++()':
/usr/include/c++/6/bits/atomic_base.h:296: undefined reference to `__atomic_fetch_add_8'
/usr/include/c++/6/bits/atomic_base.h:296: undefined reference to `__atomic_fetch_add_8'
CMakeFiles/mt_broker.dir/mt/broker.cpp.o: In function `std::__atomic_base<unsigned long long>::fetch_add(unsigned long long, std::memory_order)':
/usr/include/c++/6/bits/atomic_base.h:514: undefined reference to `__atomic_fetch_add_8'
/usr/include/c++/6/bits/atomic_base.h:514: undefined reference to `__atomic_fetch_add_8'
collect2: error: ld returned 1 exit status
examples/cpp/CMakeFiles/mt_broker.dir/build.make:127: recipe for target 'examples/cpp/mt_broker' failed
make[4]: *** [examples/cpp/mt_broker] Error 1
```
Full logs:
https://buildd.debian.org/status/fetch.php?pkg=qpid-proton&arch=mips&ver=0.14.0-2&stamp=1477932759
https://buildd.debian.org/status/fetch.php?pkg=qpid-proton&arch=mipsel&ver=0.14.0-2&stamp=1477941420

I added a check to figure out whether we need to link with libatomic.
This fixes the examples for 32-bit MIPS CPUs where the 8-byte atomic operations call into the libatomic library.