### PR TITLE
IOException doesn't necessarily catch java.nio.channels.UnresolvedAdd…

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/reactor/impl/IOHandler.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/reactor/impl/IOHandler.java
@@ -154,7 +154,7 @@ public class IOHandler extends BaseHandler {
             socketChannel.configureBlocking(false);
             socketChannel.connect(new InetSocketAddress(hostname, port));
             socket = socketChannel.socket();
-        } catch(IOException ioException) {
+        } catch(Exception ioException) {
             ErrorCondition condition = new ErrorCondition();
             condition.setCondition(Symbol.getSymbol("proton:io"));
             condition.setDescription(ioException.getMessage());


### PR DESCRIPTION
IOException doesn't necessarily catch java.nio.channels.UnresolvedAddressException which is thrown when server is unavailable. This will cause reactor to fail and require a client restart. changing to Exception and close transport, so client can recover from failure even if 1 server is down without stopping reactor