### PR TITLE
[PROTON-1352] Trivial casting from UnsignedByte to SenderSettleMode and ReceiverSettleMode

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/amqp/transport/ReceiverSettleMode.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/amqp/transport/ReceiverSettleMode.java
@@ -27,11 +27,28 @@ import org.apache.qpid.proton.amqp.UnsignedByte;
 
 public enum ReceiverSettleMode
 {
-    FIRST, SECOND;
+    FIRST(0),
+    SECOND(1);
 
-    public UnsignedByte getValue()
-    {
-        return UnsignedByte.valueOf((byte)ordinal());
+    private UnsignedByte value;
+
+    private ReceiverSettleMode(int value) {
+        this.value = UnsignedByte.valueOf((byte)value);
     }
 
+    public static ReceiverSettleMode valueOf(UnsignedByte value) {
+
+        switch (value.intValue()) {
+            case 0:
+                return ReceiverSettleMode.FIRST;
+            case 1:
+                return ReceiverSettleMode.SECOND;
+            default:
+                throw new IllegalArgumentException("The value can be only 0 (for FIRST) and 1 (for SECOND)");
+        }
+    }
+
+    public UnsignedByte getValue() {
+        return this.value;
+    }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/amqp/transport/SenderSettleMode.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/amqp/transport/SenderSettleMode.java
@@ -27,11 +27,32 @@ import org.apache.qpid.proton.amqp.UnsignedByte;
 
 public enum SenderSettleMode
 {
-    UNSETTLED, SETTLED, MIXED;
+    UNSETTLED(0),
+    SETTLED(1),
+    MIXED(2);
 
-    public UnsignedByte getValue()
-    {
-        return UnsignedByte.valueOf((byte)ordinal());
+    private UnsignedByte value;
+
+    private SenderSettleMode(int value) {
+        this.value = UnsignedByte.valueOf((byte)value);
     }
 
+    public static SenderSettleMode valueOf(UnsignedByte value) {
+
+        switch (value.intValue()) {
+
+            case 0:
+                return SenderSettleMode.UNSETTLED;
+            case 1:
+                return SenderSettleMode.SETTLED;
+            case 2:
+                return SenderSettleMode.MIXED;
+            default:
+                throw new IllegalArgumentException("The value can be only 0 (for UNSETTLED), 1 (for SETTLED) and 2 (for MIXED)");
+        }
+    }
+
+    public UnsignedByte getValue() {
+        return this.value;
+    }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/message/impl/MessageImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/message/impl/MessageImpl.java
@@ -769,6 +769,10 @@ public class MessageImpl implements ProtonJMessage
             sb.append("properties=");
             sb.append(_properties);
         }
+        if (_messageAnnotations != null) {
+            sb.append("message_annotations=");
+            sb.append(_messageAnnotations);
+        }
         if (_body != null) {
             sb.append("body=");
             sb.append(_body);

--- a/proton-j/src/test/java/org/apache/qpid/proton/amqp/transport/ReceiverSettleModeTest.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/amqp/transport/ReceiverSettleModeTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.proton.amqp.transport;
+
+import org.apache.qpid.proton.amqp.UnsignedByte;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ReceiverSettleModeTest {
+
+    @Test
+    public void testEquality() {
+
+        ReceiverSettleMode first = ReceiverSettleMode.FIRST;
+        ReceiverSettleMode second = ReceiverSettleMode.SECOND;
+
+        assertEquals(first, ReceiverSettleMode.valueOf(UnsignedByte.valueOf((byte)0)));
+        assertEquals(second, ReceiverSettleMode.valueOf(UnsignedByte.valueOf((byte)1)));
+
+        assertEquals(first.getValue(), UnsignedByte.valueOf((byte)0));
+        assertEquals(second.getValue(), UnsignedByte.valueOf((byte)1));
+    }
+
+    @Test
+    public void testNotEquality() {
+
+        ReceiverSettleMode first = ReceiverSettleMode.FIRST;
+        ReceiverSettleMode second = ReceiverSettleMode.SECOND;
+
+        assertNotEquals(first, ReceiverSettleMode.valueOf(UnsignedByte.valueOf((byte)1)));
+        assertNotEquals(second, ReceiverSettleMode.valueOf(UnsignedByte.valueOf((byte)0)));
+
+        assertNotEquals(first.getValue(), UnsignedByte.valueOf((byte)1));
+        assertNotEquals(second.getValue(), UnsignedByte.valueOf((byte)0));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalArgument() {
+
+        ReceiverSettleMode.valueOf(UnsignedByte.valueOf((byte)2));
+    }
+}

--- a/proton-j/src/test/java/org/apache/qpid/proton/amqp/transport/SenderSettleModeTest.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/amqp/transport/SenderSettleModeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.proton.amqp.transport;
+
+import org.apache.qpid.proton.amqp.UnsignedByte;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class SenderSettleModeTest {
+
+    @Test
+    public void testEquality() {
+
+        SenderSettleMode unsettled = SenderSettleMode.UNSETTLED;
+        SenderSettleMode settled = SenderSettleMode.SETTLED;
+        SenderSettleMode mixed = SenderSettleMode.MIXED;
+
+        assertEquals(unsettled, SenderSettleMode.valueOf(UnsignedByte.valueOf((byte)0)));
+        assertEquals(settled, SenderSettleMode.valueOf(UnsignedByte.valueOf((byte)1)));
+        assertEquals(mixed, SenderSettleMode.valueOf(UnsignedByte.valueOf((byte)2)));
+
+        assertEquals(unsettled.getValue(), UnsignedByte.valueOf((byte)0));
+        assertEquals(settled.getValue(), UnsignedByte.valueOf((byte)1));
+        assertEquals(mixed.getValue(), UnsignedByte.valueOf((byte)2));
+    }
+
+    @Test
+    public void testNotEquality() {
+
+        SenderSettleMode unsettled = SenderSettleMode.UNSETTLED;
+        SenderSettleMode settled = SenderSettleMode.SETTLED;
+        SenderSettleMode mixed = SenderSettleMode.MIXED;
+
+        assertNotEquals(unsettled, SenderSettleMode.valueOf(UnsignedByte.valueOf((byte)2)));
+        assertNotEquals(settled, SenderSettleMode.valueOf(UnsignedByte.valueOf((byte)0)));
+        assertNotEquals(mixed, SenderSettleMode.valueOf(UnsignedByte.valueOf((byte)1)));
+
+        assertNotEquals(unsettled.getValue(), UnsignedByte.valueOf((byte)2));
+        assertNotEquals(settled.getValue(), UnsignedByte.valueOf((byte)0));
+        assertNotEquals(mixed.getValue(), UnsignedByte.valueOf((byte)1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalArgument() {
+
+        SenderSettleMode.valueOf(UnsignedByte.valueOf((byte)3));
+    }
+}


### PR DESCRIPTION
Refactored ReceiverSettleMode and SenderSettleMode for having trivial casting from/to UnsignedByte
Added message annotations to the String visualization of AMQP message