### PR TITLE
PROTON-1312: fix memory leak on BlockingConnection.close()

### DIFF
--- a/proton-c/bindings/python/proton/__init__.py
+++ b/proton-c/bindings/python/proton/__init__.py
@@ -2581,6 +2581,9 @@ and SASL layers to identify the peer.
     """
     self._update_cond()
     pn_connection_close(self._impl)
+    if hasattr(self, '_session_policy'):
+      # break circular ref
+      del self._session_policy
 
   @property
   def state(self):

--- a/proton-c/bindings/python/proton/reactor.py
+++ b/proton-c/bindings/python/proton/reactor.py
@@ -494,12 +494,7 @@ class SessionPerConnection(object):
     def session(self, connection):
         if not self._default_session:
             self._default_session = _create_session(connection)
-            self._default_session.context = self
         return self._default_session
-
-    def on_session_remote_close(self, event):
-        event.connection.close()
-        self._default_session = None
 
 class GlobalOverrides(object):
     """

--- a/proton-c/bindings/python/proton/utils.py
+++ b/proton-c/bindings/python/proton/utils.py
@@ -132,10 +132,12 @@ class BlockingReceiver(BlockingLink):
             raise LinkException("Failed to open receiver %s, source does not match" % self.link.name)
         if credit: receiver.flow(credit)
         self.fetcher = fetcher
+        self.container = connection.container
 
     def __del__(self):
         self.fetcher = None
-        self.link.handler = None
+        self.link.handler = None  # fails if reactor finalizes first
+        self.container = None
 
     def receive(self, timeout=False):
         if not self.fetcher:
@@ -222,12 +224,19 @@ class BlockingConnection(Handler):
             self, self.container.create_receiver(self.conn, address, name=name, dynamic=dynamic, handler=handler or fetcher, options=options), fetcher, credit=prefetch)
 
     def close(self):
+        if not self.conn:
+            return
         self.conn.close()
         try:
             self.wait(lambda: not (self.conn.state & Endpoint.REMOTE_ACTIVE),
                       msg="Closing connection")
         finally:
+            self.conn.free()
+            # For cleanup, reactor needs to process PN_CONNECTION_FINAL
+            # and all events with embedded contexts must be drained.
+            self.run() # will not block any more
             self.conn = None
+            self.container.global_handler = None # break circular ref: container to cadapter.on_error
             self.container = None
 
     def _is_closed(self):
@@ -236,6 +245,8 @@ class BlockingConnection(Handler):
     def run(self):
         """ Hand control over to the event loop (e.g. if waiting indefinitely for incoming messages) """
         while self.container.process(): pass
+        self.container.stop()
+        self.container.process()
 
     def wait(self, condition, timeout=False, msg=None):
         """Call process until condition() is true"""


### PR DESCRIPTION
Instrumenting the C code shows that Python BlockingConnections never
free their underlying connections, sessions and links, and frequently
the reactor too.

The BlockingConnection stops processing its dedicated reactor abruptly
on close preventing normal shutdown and cleanup operations from taking
place. Plus there are some circular references that keep some
structures alive.

The reactor C code keeps a connection and its children alive until
after the PN_CONNECTION_FINAL has completed dispatch processing.  The
BlockingConnection must continue processing the container at least
that far.  However, any unprocessed event can can contain a relevant
refcounted context so the safe route is to drain all remaining events
(including the PN_REACTOR_FINAL).

The SessionPerConnection class keeps the session alive by assigning a
context that is never used perhaps for some previous use in a handler.
This class is not currently used as a handler and its
on_session_remote_close is never called.  Removing the context
eliminates one needless refcount.

self.conn.free() is required to trigger a pn_connection_release() on
the blocking connection.
