### PR TITLE
PROTON-1434: add test blacklist to tox tests

### DIFF
--- a/proton-c/tox.ini.in
+++ b/proton-c/tox.ini.in
@@ -16,7 +16,7 @@ passenv =
     VALGRIND
     CLASSPATH
 commands =
-    @CMAKE_SOURCE_DIR@/tests/python/proton-test {posargs}
+    @CMAKE_SOURCE_DIR@/tests/python/proton-test '{posargs:--ignore-file=@CMAKE_SOURCE_DIR@/tests/python/tox-blacklist}'
 deps =
     unittest2
 

--- a/tests/python/tox-blacklist
+++ b/tests/python/tox-blacklist
@@ -1,0 +1,13 @@
+# Running *all* the python tests under tox is redundant as this is
+# already done by the python-test suite.
+# This file contains a list of the longer running tests that can be
+# skipped in order to speed up the tox test run
+
+proton_tests.soak.*
+proton_tests.engine.ServerTest.testIdleTimeout
+proton_tests.engine.ServerTest.testKeepalive
+proton_tests.messenger.IdleTimeoutTest.testIdleTimeout
+proton_tests.messenger.MessengerTest.testCreditBlockingRebalance
+proton_tests.messenger.NBMessengerTest.testCreditReplenish
+proton_tests.messenger.NBMessengerTest.testRecvBeforeSubscribe
+


### PR DESCRIPTION
Helps speed up the time spent running the tox tests