### PR TITLE
NO-JIRA: revert temporary workaround for PROTON-1453

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ before_script:
 - export PATH=${HOME}/.local/bin:${PATH}
 - mkdir Build
 - cd Build
-- cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/install -DTOX_ENVLIST="py26,py27,py35"
+- cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/install
 script:
 - cmake --build . --target install && ctest -V


### PR DESCRIPTION
Looks like the fix for PROTON-1453 resolves the problems travis hit for the tox tests.  This change reverts just the change where the travis config filtered out py33 and py34.