### PR TITLE
PROTON-1463 GO-Bindings Added AMQP Address Method

### DIFF
--- a/examples/go/electron/receive.go
+++ b/examples/go/electron/receive.go
@@ -75,7 +75,9 @@ func main() {
 			c, err := container.Dial("tcp", url.Host)
 			fatalIf(err)
 			connections <- c // Save connection so we can Close() when main() ends
-			r, err := c.Receiver(electron.Source(url.Path))
+                        addr, err := amqp.Address(url)
+                        fatalIf(err)
+			r, err := c.Receiver(electron.Source(addr))
 			fatalIf(err)
 			// Loop receiving messages and sending them to the main() goroutine
 			for {

--- a/examples/go/electron/send.go
+++ b/examples/go/electron/send.go
@@ -74,7 +74,9 @@ func main() {
 			c, err := container.Dial("tcp", url.Host)
 			fatalIf(err)
 			connections <- c // Save connection so we can Close() when main() ends
-			s, err := c.Sender(electron.Target(url.Path))
+			addr, err := amqp.Address(url)
+			fatalIf(err)
+			s, err := c.Sender(electron.Target(addr))
 			fatalIf(err)
 			// Loop sending messages.
 			for i := int64(0); i < *count; i++ {

--- a/proton-c/bindings/go/src/qpid.apache.org/amqp/url.go
+++ b/proton-c/bindings/go/src/qpid.apache.org/amqp/url.go
@@ -102,3 +102,15 @@ func ParseURL(s string) (u *url.URL, err error) {
 	}
 	return u, err
 }
+
+// Provides the AMQP address from the provided URL
+// Example: localhost:5672/addr where 'addr' is the address
+// Ultimately removes the unecessary slash from url.Path
+func Address(u *url.URL) (address string, err error){
+       //a .Path will at least contain a '/' if set else empty
+       if len(u.Path) <= 1 {
+         return "", errors.New("URL not expected length.")
+       }
+
+       return u.Path[1:], nil //remove prepended '/'
+       }


### PR DESCRIPTION
Original examples used url.Path variable to return the amqp address.  The address returned added an unnecessary prepended slash character.  Added a amqp.Address() method to filter the slash character out.  

Original problem running example:  ./receiver.go localhost:5672/example
Receiver listened on the '/example' address instead of 'example'

Also adjusted the receiver and sender examples to use url.Address() instead of passing url.Path.