### PR TITLE
Fix mapping of LONG for Ruby 2.4+

### DIFF
--- a/proton-c/bindings/ruby/lib/codec/mapping.rb
+++ b/proton-c/bindings/ruby/lib/codec/mapping.rb
@@ -96,7 +96,7 @@ module Qpid::Proton::Codec
   INT        = Mapping.new(Cproton::PN_INT, "int")
   CHAR       = Mapping.new(Cproton::PN_CHAR, "char")
   ULONG      = Mapping.new(Cproton::PN_ULONG, "ulong")
-  LONG       = Mapping.new(Cproton::PN_LONG, "long", [Fixnum, Bignum])
+  LONG       = Mapping.new(Cproton::PN_LONG, "long", RUBY_VERSION < "2.4" ? [Fixnum, Bignum] : [Integer])
   TIMESTAMP  = Mapping.new(Cproton::PN_TIMESTAMP, "timestamp", [Date, Time])
   FLOAT      = Mapping.new(Cproton::PN_FLOAT, "float")
   DOUBLE     = Mapping.new(Cproton::PN_DOUBLE, "double", [Float])


### PR DESCRIPTION
```
(Ruby 2.4.1) > irb
> RUBY_VERSION < "2.4" ? [Fixnum, Bignum] : [Integer]
=> [Integer]

(Ruby 2.3.3) > irb
> RUBY_VERSION < "2.4" ? [Fixnum, Bignum] : [Integer]
=> [Fixnum, Bignum]
```