### PR TITLE
[Ruby code Example] fix Messenger package

### DIFF
--- a/examples/ruby/messenger/README.md
+++ b/examples/ruby/messenger/README.md
@@ -111,7 +111,7 @@ Enter **non-blocking mode**!
 When working in non-blocking mode you set a flag on your messenger to put it into non-blocking mode.
 
 ```
-messenger = Qpid::Proton::Messenger.new
+messenger = Qpid::Proton::Messenger::Messenger.new
 messenger.passive = true
 ```
 

--- a/tests/smoke/recv.rb
+++ b/tests/smoke/recv.rb
@@ -2,7 +2,7 @@
 
 require 'qpid_proton.rb'
 
-messenger = Qpid::Proton::Messenger.new()
+messenger = Qpid::Proton::Messenger::Messenger.new
 messenger.incoming_window = 1
 message = Qpid::Proton::Message.new()
 

--- a/tests/smoke/send.rb
+++ b/tests/smoke/send.rb
@@ -2,7 +2,7 @@
 
 require 'qpid_proton.rb'
 
-messenger = Qpid::Proton::Messenger.new()
+messenger = Qpid::Proton::Messenger::Messenger.new
 messenger.outgoing_window = 10
 message = Qpid::Proton::Message.new()
 


### PR DESCRIPTION
Some ruby examples have the correct package for `Messenger`, while others have a truncated package.

Thanks for the great gem and packages