### PR TITLE
PROTON-1532: Allow insecure mechanism in SASL

### DIFF
--- a/proton-c/bindings/ruby/lib/core/connection.rb
+++ b/proton-c/bindings/ruby/lib/core/connection.rb
@@ -35,6 +35,18 @@ module Qpid::Proton
     #
     proton_accessor :hostname
 
+    # @!attribute user
+    #
+    # @return [String] The AMQP user for the connection.
+    #
+    proton_accessor :user
+
+    # @!attribute password
+    #
+    # @return [String] The AMQP password for the connection.
+    #
+    proton_writer   :password
+
     # @private
     proton_reader :attachments
 

--- a/proton-c/bindings/ruby/lib/core/sasl.rb
+++ b/proton-c/bindings/ruby/lib/core/sasl.rb
@@ -50,6 +50,18 @@ module Qpid::Proton
     # Authentication failed due to bad credentials.
     AUTH = Cproton::PN_SASL_AUTH
 
+    # @private
+    include Util::SwigHelper
+
+    # @private
+    PROTON_METHOD_PREFIX = "pn_sasl"
+
+    # @!attribute allow_insecure_mechs
+    #
+    # @return [Boolean] Attribute to allow use of clear text authentication.
+    #
+    proton_accessor :allow_insecure_mechs
+
     # Constructs a new instance for the given transport.
     #
     # @param transport [Transport] The transport.


### PR DESCRIPTION
This commit extends SASL with the additional allow_insecure_mechs allowing users to override the defailt (false) authentication and use the plain mechanism. It also extends the Connection class to expose user and password that is used by the plain mechanism.

Finally, this patch modifies the connect method which now avoids the use of the plain method which is not defined on SASL. The code now more resembles the Python version.

This addresses the issue reported in [PROTON-1532](https://issues.apache.org/jira/browse/PROTON-1532) where I was trying to connect to an ActiveMQ using plain username/password authentication. Previous code used method `plain` which does not exist.