### PR TITLE
PROTON-1326: update python setup.py to avoid using incompatible opens…

### DIFF
--- a/proton-c/bindings/python/setup.py.in
+++ b/proton-c/bindings/python/setup.py.in
@@ -164,12 +164,15 @@ class Configure(build_ext):
         # Check whether openssl is installed by poking
         # pkg-config for a minimum version 0. If it's installed, it should
         # return True and we'll use it. Otherwise, we'll use the stub.
-        if misc.pkg_config_version_installed('openssl', atleast='0'):
+
+        # PROTON-1326 - the 0.17.x release is not forward compatible with
+        # openssl >= 1.1.0
+        if misc.pkg_config_installed('openssl < 1.1.0'):
             libraries += ['ssl', 'crypto']
             sources.append(os.path.join(proton_src, 'ssl', 'openssl.c'))
         else:
             sources.append(os.path.join(proton_src, 'ssl', 'ssl_stub.c'))
-            log.warn("OpenSSL not installed - disabling SSL support!")
+            log.warn("OpenSSL not installed or incompatible version - disabling SSL support!")
 
         # create a temp compiler to check for optional compile-time features
         cc = new_compiler(compiler=self.compiler_type)
@@ -237,7 +240,7 @@ class Configure(build_ext):
         """Check to see if the proper version of the Proton development library
         and headers are already installed
         """
-        return misc.pkg_config_version_installed('libqpid-proton', version)
+        return misc.pkg_config_installed('libqpid-proton = %s' % version)
 
     def use_installed_proton(self):
         """The Proton development headers and library are installed, update the

--- a/proton-c/bindings/python/setuputils/misc.py
+++ b/proton-c/bindings/python/setuputils/misc.py
@@ -39,26 +39,17 @@ def _call_pkg_config(args):
     return None
 
 
-
-def pkg_config_version_installed(package, version=None, atleast=None):
-    """Check if version of a package is is installed
+def pkg_config_installed(package):
+    """Check if a package is installed
 
     This function returns True/False depending on whether
-    the package is found and is the correct version.
+    the package is found.
 
-    :param version: The exact version of the package required
-    :param atleast: True if installed package is at least this version
+    :param package: name of the package, may include version constraints
+    compatible with pkg-config --exists syntax. e.g.:
+    "openssl >= 1.0.0 openssl < 1.1.0"
     """
-
-    if version is None and atleast is None:
-        log.fatal('package version string required')
-    elif version and atleast:
-        log.fatal('Specify either version or atleast, not both')
-
-    check = 'exact' if version else 'atleast'
-    p = _call_pkg_config(['--%s-version=%s' % (check,
-                                               version or atleast),
-                          package])
+    p = _call_pkg_config(['--exists', package])
     if p:
         out,err = p.communicate()
         if p.returncode:


### PR DESCRIPTION
…sl 1.1.0

Proposing this patch against 0.17.x to fix a problem in the python-qpid-proton pypi packages.

I don't think this requires another 0.17.x release since the change only relates to python packaging.  I simply need to rebuild the python packages on pypi with this fix.