### PR TITLE
PROTON-1369: Add deprecation warnings to the C++ binding

### DIFF
--- a/proton-c/bindings/cpp/include/proton/default_container.hpp
+++ b/proton-c/bindings/cpp/include/proton/default_container.hpp
@@ -22,6 +22,8 @@
  *
  */
 
+#include "./internal/export.hpp"
+
 /// @file
 /// @copybrief proton::default_container
 


### PR DESCRIPTION
Changes

 - Add warnings for default_container.hpp, function.hpp, url.hpp, and some methods in value.hpp
 - Removed some deprecated type conversion functions that were never published as API
 - Convert examples that used the URL class to instead split the connection URL and address into two args
 - Some minor example improvements

Notes and questions

 - This approach requires users define PN_CPP_USE_DEPRECATED_API if they want to carry on without moving to the preferred APIs.
    - The alternative is #pragma message (just a warning), but that's not as portable as #error.  #warning is regrettably non-standard.
 - I'm using #define PN_CPP_USE_DEPRECATED_API/#undef for internal uses - what's the other approach?  I remember a recommendation to use an ORed set of internal variables, but I unfortunately lost the details.
 - I wasn't able to find the cmake support for deprecation macros.
