### PR TITLE
PROTON-1342: CI on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,30 @@
 # under the License
 #
 
-os: linux
 sudo: false
 language: cpp
 compiler:
 - gcc
 - clang
-env:
-- QPID_PROTON_CMAKE_ARGS=
-- QPID_PROTON_CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Coverage
+
 matrix:
-  exclude:
-  - compiler: clang
-    env: QPID_PROTON_CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Coverage
+  include:
+  - os: linux
+    env:
+    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Coverage'
+
+  - os: osx
+    osx_image: xcode7.3
+    env:
+    - QPID_PROTON_CMAKE_ARGS='-DPROACTOR=libuv -DSASL_IMPL=none -DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11'
+
+  - os: osx
+    osx_image: xcode9
+    env:
+    - QPID_PROTON_CMAKE_ARGS='-DPROACTOR=libuv -DSASL_IMPL=none -DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13'
+
+# Note addons is apt specific at the moment and will not be applied for osx.
+# See before_install brew commands below
 addons:
   apt:
     packages:
@@ -46,6 +57,11 @@ addons:
     - php5
     - golang
     - lcov
+
+before_install:
+- eval "${MATRIX_EVAL}"
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libuv openssl; fi
 
 install:
 - pip install --user --upgrade pip

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Qpid Proton - AMQP messaging toolkit
 ====================================
 
-Linux Build | Windows Build
-------------|--------------
-[![Linux Build Status](https://travis-ci.org/apache/qpid-proton.svg?branch=master)](https://travis-ci.org/apache/qpid-proton) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/apache/qpid-proton?branch=master&svg=true)](https://ci.appveyor.com/project/ke4qqq/qpid-proton/branch/master)
+Linux Build | Windows Build | OSX Build
+------------|---------------|----------
+[![Linux Build Status](https://travis-ci.org/apache/qpid-proton.svg?branch=master)](https://travis-ci.org/apache/qpid-proton) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/apache/qpid-proton?branch=master&svg=true)](https://ci.appveyor.com/project/ke4qqq/qpid-proton/branch/master) | [![OSX Build Status](https://api.travis-ci.org/RoddieKieley/qpid-proton.svg?branch=PROTON-522)](https://travis-ci.org/roddiekieley/qpid-proton/branch/PROTON-522)
 
 Qpid Proton is a high-performance, lightweight messaging library. It can be
 used in the widest range of messaging applications, including brokers, client


### PR DESCRIPTION
This contains the travis yaml updates to configure CI to run osx type os's as well as matrix'd variants for 10.11-10.13 and Xcode 7.3.1 - Xcode 9 respectively. 

IMPORTANT: This alone will simply result in failed builds for os: osx, and requires the work in PROTON-522 for working os: osx builds. PR to follow.

NOTE: This PR also contains an updated README.md that shows the status of the OSX builds on PROTON-522 at the moment.  Please edit as required.

Feedback welcome!