### PR TITLE
PROTON-1711: SSL_IMPL none SASL_IMPL none build attempts to build c-s…

### DIFF
--- a/proton-c/src/tests/CMakeLists.txt
+++ b/proton-c/src/tests/CMakeLists.txt
@@ -40,7 +40,10 @@ pn_add_c_test (c-event-tests event.c)
 pn_add_c_test (c-data-tests data.c)
 pn_add_c_test (c-condition-tests condition.c)
 pn_add_c_test (c-connection-driver-tests connection_driver.c)
-pn_add_c_test (c-ssl-tests ssl.c)
+if(NOT SSL_IMPL STREQUAL none)
+    pn_add_c_test (c-ssl-tests ssl.c)
+endif()
+
 
 pn_add_c_test (c-parse-url-tests parse-url.c)
 target_link_libraries (c-parse-url-tests qpid-proton)


### PR DESCRIPTION
…sl-tests and fails

Added simple check to only build c-ssl-tests if SSL_IMPL was not none.

NOTE: This simple change also exposes the fact that the python binding does not build with SSL_IMPL none and all other configuration variables default at the moment. I disabled the python binding for a successful build as I didn't need it at the moment.

Should be addressed here or via separate issue?