### PR TITLE
[cpp] Fix update method missing 'name' variable

### DIFF
--- a/proton-c/bindings/cpp/src/receiver_options.cpp
+++ b/proton-c/bindings/cpp/src/receiver_options.cpp
@@ -101,6 +101,7 @@ class receiver_options::impl {
         dynamic_address.update(x.dynamic_address);
         source.update(x.source);
         target.update(x.target);
+        name.update(x.name);
     }
 
 };

--- a/proton-c/bindings/cpp/src/sender_options.cpp
+++ b/proton-c/bindings/cpp/src/sender_options.cpp
@@ -89,6 +89,7 @@ class sender_options::impl {
         auto_settle.update(x.auto_settle);
         source.update(x.source);
         target.update(x.target);
+        name.update(x.name);
     }
 
 };


### PR DESCRIPTION
The `name` property in the sender and receiver is not being updated correctly when passed to the `open_sender` and `open_receiver`.

Here is a simple example demonstrating the problem:
```cpp
#include <proton/sender_options.hpp>
#include <proton/receiver_options.hpp>
#include <proton/container.hpp>

#include <iostream>

int main()
{
    proton::container c;

    proton::sender_options so;
    proton::receiver_options ro;

    so.name("qpid");
    ro.name("qpid");

    proton::sender sender = c.open_sender("", so);
    proton::receiver receiver = c.open_receiver("", ro);

    std::cout << sender.name() << std::endl;
    std::cout << receiver.name() << std::endl;
}
```
The output is currently a random uuid, but it should be "qpid" in both cases.