### PR TITLE
PROTON-1831: Incorrect open/close sequence for same link name.

### DIFF
--- a/tools/python/proctest.py
+++ b/tools/python/proctest.py
@@ -31,7 +31,7 @@ from copy import copy
 import platform
 from os.path import dirname as dirname
 
-DEFAULT_TIMEOUT=10
+DEFAULT_TIMEOUT=30              # Valgrind can be very slow.
 
 class ProcError(Exception):
     """An exception that displays failed process output"""


### PR DESCRIPTION
Fixes the server side part of PROTON-1831 - transport error if a duplicate link
name is attached instead of seg fault.

Client side problem remains: pni_process does not respect the order of individual open/close calls,
and it is possible to generate an invalid sequence that attempts a duplicate
attach when it should not. This commit includes a test that illustrates the
problem, the test runs but status is ignored for now.