### PR TITLE
NO-JIRA: [c] link fuzzing binaries using CXX linker

### DIFF
--- a/c/tests/fuzz/CMakeLists.txt
+++ b/c/tests/fuzz/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library (StandaloneFuzzTargetMain STATIC StandaloneFuzzTargetMain.c Standalo
 macro (pn_add_fuzz_test test)
   add_executable (${test} ${ARGN})
   target_link_libraries (${test} qpid-proton-core ${FUZZING_LIBRARY})
+  # link fuzzer binaries with libstdc++ since -lFuzzingEngine is a C++ library
+  set_target_properties(${test} PROPERTIES LINKER_LANGUAGE CXX)
 
   if (FUZZ_REGRESSION_TESTS)
     # StandaloneFuzzTargetMain cannot walk directory trees


### PR DESCRIPTION
This should allow for removal of patch file https://github.com/google/oss-fuzz/blob/1909d92b8bb068dd7aa94bdf22da4028ada385ea/projects/qpid-proton/c_tests_fuzz_CMakeLists.patch