### PR TITLE
NO-JIRA: [cpp] add constants for standard AMQP condition names

### DIFF
--- a/cpp/include/proton/error_condition.hpp
+++ b/cpp/include/proton/error_condition.hpp
@@ -36,13 +36,29 @@ struct pn_condition_t;
 
 namespace proton {
 
-/// Describes an endpoint error state.
+/// Standard AMQP error condition names.
+const std::string INTERNAL_ERROR;
+const std::string NOT_FOUND;
+const std::string UNAUTHORIZED_ACCESS;
+const std::string DECODE_ERROR;
+const std::string RESOURCE_LIMIT_EXCEEDED;
+const std::string NOT_ALLOWED;
+const std::string INVALID_FIELD;
+const std::string NOT_IMPLEMENTED;
+const std::string RESOURCE_LOCKED;
+const std::string PRECONDITION_FAILED;
+const std::string RESOURCE_DELETED;
+const std::string ILLEGAL_STATE;
+const std::string FRAME_SIZE_TOO_SMALL;
+
+/// Describes an endpoint error stte.
 class error_condition {
     /// @cond INTERNAL
     error_condition(pn_condition_t* c);
     /// @endcond
 
   public:
+
     /// Create an empty error condition.
     error_condition() {}
 

--- a/cpp/src/error_condition.cpp
+++ b/cpp/src/error_condition.cpp
@@ -99,4 +99,18 @@ std::ostream& operator<<(std::ostream& o, const error_condition& err) {
     return o << err.what();
 }
 
+const std::string INTERNAL_ERROR = "amqp:internal-error";
+const std::string NOT_FOUND = "amqp:not-found";
+const std::string UNAUTHORIZED_ACCESS = "amqp:unauthorized-access";
+const std::string DECODE_ERROR = "amqp:decode-error";
+const std::string RESOURCE_LIMIT_EXCEEDED = "amqp:resource-limit-exceeded";
+const std::string NOT_ALLOWED = "amqp:not-allowed";
+const std::string INVALID_FIELD = "amqp:invalid-field";
+const std::string NOT_IMPLEMENTED = "amqp:not-implemented";
+const std::string RESOURCE_LOCKED = "amqp:resource-locked";
+const std::string PRECONDITION_FAILED = "amqp:precondition-failed";
+const std::string RESOURCE_DELETED = "amqp:resource-deleted";
+const std::string ILLEGAL_STATE = "amqp:illegal-state";
+const std::string FRAME_SIZE_TOO_SMALL = "amqp:frame-size-too-small";
+
 }


### PR DESCRIPTION
Convenience for folks who want to generate standard-ish errors from servers. 