### PR TITLE
Replace user-defined macro WIN32 by compiler-defined _WIN32

### DIFF
--- a/c/include/proton/import_export.h
+++ b/c/include/proton/import_export.h
@@ -33,7 +33,7 @@
   PN_IMPORT         - Import declaration
 */
 
-#if defined(WIN32) && !defined(PROTON_DECLARE_STATIC)
+#if defined(_WIN32) && !defined(PROTON_DECLARE_STATIC)
 /* Import and Export definitions for Windows: */
 #  define PN_EXPORT __declspec(dllexport)
 #  define PN_IMPORT __declspec(dllimport)
@@ -66,7 +66,7 @@
 #endif
 
 #if ! defined(PN_USE_DEPRECATED_API)
-#  if defined(WIN32)
+#  if defined(_WIN32)
 #    define PN_DEPRECATED(message) __declspec(deprecated(message))
 #  elif defined __GNUC__
 #    if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40500

--- a/cpp/examples/ssl.cpp
+++ b/cpp/examples/ssl.cpp
@@ -184,7 +184,7 @@ int main(int argc, char **argv) {
 
 bool using_OpenSSL() {
     // Current defaults.
-#if defined(WIN32)
+#if defined(_WIN32)
     return false;
 #else
     return true;

--- a/cpp/examples/ssl_client_cert.cpp
+++ b/cpp/examples/ssl_client_cert.cpp
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
 
 bool using_OpenSSL() {
     // Current defaults.
-#if defined(WIN32)
+#if defined(_WIN32)
     return false;
 #else
     return true;

--- a/cpp/include/proton/internal/export.hpp
+++ b/cpp/include/proton/internal/export.hpp
@@ -25,7 +25,7 @@
 /// @cond INTERNAL
 
 /// import/export macros
-#if defined(WIN32) && !defined(PN_CPP_DECLARE_STATIC)
+#if defined(_WIN32) && !defined(PN_CPP_DECLARE_STATIC)
   //
   // Import and Export definitions for Windows:
   //
@@ -62,7 +62,7 @@
 #else
 #  if defined(PN_COMPILER_CXX_ATTRIBUTE_DEPRECATED) && PN_COMPILER_CXX_ATTRIBUTE_DEPRECATED
 #    define PN_CPP_DEPRECATED(message) [[deprecated(message)]]
-#  elif defined(WIN32)
+#  elif defined(_WIN32)
 #    define PN_CPP_DEPRECATED(message) __declspec(deprecated(message))
 #  elif (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40500
 #    define PN_CPP_DEPRECATED(message) __attribute__((deprecated))

--- a/cpp/src/uuid.cpp
+++ b/cpp/src/uuid.cpp
@@ -27,7 +27,7 @@
 #include <sstream>
 #include <iomanip>
 
-#ifdef WIN32
+#if defined(_WIN32)
 #include <process.h>
 #define GETPID _getpid
 #else


### PR DESCRIPTION
On Windows, if qpid-proton is used by another build system (still compiling with VC) than a Visual Studio project, `/D WIN32` is not automatically set on the command line.

Today both `WIN32` and `_WIN32` can be found in the source code.

The idea here are:
* removing this uncertainty by using `_WIN32` that is automatically set by the compiler
* having a better uniformity across the source code.