### PR TITLE
PROTON-1940: [c] normalize encoding of multiple="true" fields

### DIFF
--- a/c/src/core/transport.c
+++ b/c/src/core/transport.c
@@ -1858,13 +1858,13 @@ static int pni_process_conn_setup(pn_transport_t *transport, pn_endpoint_t *endp
       pn_connection_t *connection = (pn_connection_t *) endpoint;
       const char *cid = pn_string_get(connection->container);
       pni_calculate_channel_max(transport);
-      int err = pn_post_frame(transport, AMQP_FRAME_TYPE, 0, "DL[SS?I?H?InnCCC]", OPEN,
+      int err = pn_post_frame(transport, AMQP_FRAME_TYPE, 0, "DL[SS?I?H?InnMMC]", OPEN,
                               cid ? cid : "",
                               pn_string_get(connection->hostname),
                               // TODO: This is messy, because we also have to allow local_max_frame_ to be 0 to mean unlimited
                               // otherwise flow control goes wrong
                               transport->local_max_frame!=0 && transport->local_max_frame!=OPEN_MAX_FRAME_SIZE_DEFAULT,
-                                transport->local_max_frame,
+                              transport->local_max_frame,
                               transport->channel_max!=OPEN_CHANNEL_MAX_DEFAULT, transport->channel_max,
                               (bool)idle_timeout, idle_timeout,
                               connection->offered_capabilities,
@@ -2024,12 +2024,13 @@ static int pni_process_link_setup(pn_transport_t *transport, pn_endpoint_t *endp
         if (err) return err;
       } else {
         int err = pn_post_frame(transport, AMQP_FRAME_TYPE, ssn_state->local_channel,
-                                "DL[SIoBB?DL[SIsIoC?sCnCC]?DL[SIsIoCC]nnIL]", ATTACH,
+                                "DL[SIoBB?DL[SIsIoC?sCnMM]?DL[SIsIoCM]nnIL]", ATTACH,
                                 pn_string_get(link->name),
                                 state->local_handle,
                                 endpoint->type == RECEIVER,
                                 link->snd_settle_mode,
                                 link->rcv_settle_mode,
+
                                 (bool) link->source.type, SOURCE,
                                 pn_string_get(link->source.address),
                                 link->source.durability,
@@ -2041,6 +2042,7 @@ static int pni_process_link_setup(pn_transport_t *transport, pn_endpoint_t *endp
                                 link->source.filter,
                                 link->source.outcomes,
                                 link->source.capabilities,
+
                                 (bool) link->target.type, TARGET,
                                 pn_string_get(link->target.address),
                                 link->target.durability,
@@ -2049,6 +2051,7 @@ static int pni_process_link_setup(pn_transport_t *transport, pn_endpoint_t *endp
                                 link->target.dynamic,
                                 link->target.properties,
                                 link->target.capabilities,
+
                                 0, link->max_message_size);
         if (err) return err;
       }

--- a/c/tests/data.c
+++ b/c/tests/data.c
@@ -21,8 +21,10 @@
 
 #undef NDEBUG                   /* Make sure that assert() is enabled even in a release build. */
 
-#include <proton/codec.h>
+#include "test_tools.h"
 #include "core/data.h"
+
+#include <proton/codec.h>
 #include <assert.h>
 #include <stdio.h>
 
@@ -44,6 +46,59 @@ static void test_grow(void)
   pn_data_free(data);
 }
 
+static void test_multiple(test_t *t) {
+  pn_data_t *data = pn_data(1);
+  pn_data_t *src = pn_data(1);
+
+  /* NULL data pointer */
+  pn_data_fill(data, "M", NULL);
+  TEST_INSPECT(t, "null", data);
+
+  /* Empty data object */
+  pn_data_clear(data);
+  pn_data_fill(data, "M", src);
+  TEST_INSPECT(t, "null", data);
+
+  /* Empty array */
+  pn_data_clear(data);
+  pn_data_clear(src);
+  pn_data_put_array(src, false, PN_SYMBOL);
+  pn_data_fill(data, "M", src);
+  TEST_INSPECT(t, "null", data);
+
+  /* Single-element array */
+  pn_data_clear(data);
+  pn_data_clear(src);
+  pn_data_put_array(src, false, PN_SYMBOL);
+  pn_data_enter(src);
+  pn_data_put_symbol(src, PN_BYTES_LITERAL(foo));
+  pn_data_fill(data, "M", src);
+  TEST_INSPECT(t, ":foo", data);
+
+  /* Multi-element array */
+  pn_data_clear(data);
+  pn_data_clear(src);
+  pn_data_put_array(src, false, PN_SYMBOL);
+  pn_data_enter(src);
+  pn_data_put_symbol(src, PN_BYTES_LITERAL(foo));
+  pn_data_put_symbol(src, PN_BYTES_LITERAL(bar));
+  pn_data_fill(data, "M", src);
+  TEST_INSPECT(t, "@PN_SYMBOL[:foo, :bar]", data);
+
+  /* Non-array */
+  pn_data_clear(data);
+  pn_data_clear(src);
+  pn_data_put_symbol(src, PN_BYTES_LITERAL(baz));
+  pn_data_fill(data, "M", src);
+  TEST_INSPECT(t, ":baz", data);
+
+  pn_data_free(data);
+  pn_data_free(src);
+}
+
 int main(int argc, char **argv) {
+  int failed = 0;
   test_grow();
+  RUN_ARGV_TEST(failed, t, test_multiple(&t));
+  return failed;
 }

--- a/c/tests/test_tools.h
+++ b/c/tests/test_tools.h
@@ -160,6 +160,13 @@ bool test_str_equal_(test_t *t, const char* want, const char* got, const char *f
 }
 #define TEST_STR_EQUAL(TEST, WANT, GOT) test_str_equal_((TEST), (WANT), (GOT), __FILE__, __LINE__)
 
+#define TEST_INSPECT(TEST, WANT, GOT) do {              \
+    pn_string_t *s = pn_string(NULL);                   \
+    TEST_ASSERT(0 == pn_inspect(GOT, s));               \
+    TEST_STR_EQUAL((TEST), (WANT), pn_string_get(s));   \
+    pn_free(s);                                         \
+  } while (0)
+
 #define TEST_STR_IN(TEST, WANT, GOT)                                    \
   test_check_((TEST), strstr((GOT), (WANT)), NULL, __FILE__, __LINE__, "'%s' not in '%s'", (WANT), (GOT))
 

--- a/python/tests/proton_tests/engine.py
+++ b/python/tests/proton_tests/engine.py
@@ -690,7 +690,7 @@ class LinkTest(Test):
                                             capabilities=["one", "two", "three"]),
                              TerminusConfig(address="source",
                                             timeout=7,
-                                            capabilities=[]))
+                                            capabilities=None))
   def test_distribution_mode(self):
     self._test_source_target(TerminusConfig(address="source",
                                             dist_mode=Terminus.DIST_MODE_COPY),


### PR DESCRIPTION
AMQP spec allows several ways to encode a "multiple" field, we allow all in
incoming data or pn_data_t values created in the user, but when writing
to the wire we always encode:

- empty array as null
- single value array as a single value
- multiple values - encoded as array

This is the most compact encoding and seems to be best for interop, as some AMQP
clients (.NET) have trouble with an empty array in a multiple value field.