### PR TITLE
WIP: option<T> version of connection_options getters

### DIFF
--- a/cpp/include/proton/connection_options.hpp
+++ b/cpp/include/proton/connection_options.hpp
@@ -27,6 +27,7 @@
 #include "./internal/config.hpp"
 #include "./internal/export.hpp"
 #include "./internal/pn_unique_ptr.hpp"
+#include "./option.hpp"
 #include "./symbol.hpp"
 #include "./types_fwd.hpp"
 
@@ -171,6 +172,27 @@ class connection_options {
     /// **Unsettled API** - Set reconnect and failover options.
     PN_CPP_EXTERN connection_options& reconnect(const reconnect_options &);
 
+    /// Get option values, see corresponding set function for details
+    /// {@
+    PN_CPP_EXTERN option<messaging_handler*> handler() const;
+    PN_CPP_EXTERN option<uint32_t> max_frame_size() const;
+    PN_CPP_EXTERN option<uint16_t> max_sessions() const;
+    PN_CPP_EXTERN option<duration> idle_timeout() const;
+    PN_CPP_EXTERN option<std::string> container_id() const;
+    PN_CPP_EXTERN option<std::string> virtual_host() const;
+    PN_CPP_EXTERN option<std::string> user() const;
+    PN_CPP_EXTERN option<class ssl_client_options >ssl_client_options() const;
+    PN_CPP_EXTERN option<class ssl_server_options >ssl_server_options() const;
+    PN_CPP_EXTERN option<bool> sasl_enabled() const;
+    PN_CPP_EXTERN option<bool> sasl_allow_insecure_mechs() const;
+    PN_CPP_EXTERN option<std::string> sasl_allowed_mechs() const;
+    PN_CPP_EXTERN option<std::vector<symbol> > offered_capabilities() const;
+    PN_CPP_EXTERN option<std::vector<symbol> > desired_capabilities() const;
+    PN_CPP_EXTERN option<std::string> sasl_config_name() const;
+    PN_CPP_EXTERN option<std::string> sasl_config_path() const;
+    PN_CPP_EXTERN option<reconnect_options> reconnect() const;
+    /// @}
+
     /// Update option values from values set in other.
     PN_CPP_EXTERN connection_options& update(const connection_options& other);
 
@@ -178,7 +200,6 @@ class connection_options {
     void apply_unbound(connection&) const;
     void apply_unbound_client(pn_transport_t*) const;
     void apply_unbound_server(pn_transport_t*) const;
-    messaging_handler* handler() const;
 
     class impl;
     internal::pn_unique_ptr<impl> impl_;

--- a/cpp/include/proton/delivery_mode.hpp
+++ b/cpp/include/proton/delivery_mode.hpp
@@ -30,7 +30,8 @@ namespace proton {
 /// The message delivery policy to establish when opening a link.
 /// This structure imitates the newer C++11 "enum class" so that
 /// The enumeration constants are in the delivery_mode namespace.
-struct delivery_mode {
+class delivery_mode {
+  public:
     /// Delivery modes
     enum modes {
         /// No set policy.  The application must settle messages
@@ -47,7 +48,7 @@ struct delivery_mode {
     };
 
     /// @cond INTERNAL
-    
+
     delivery_mode() : modes_(NONE) {}
     delivery_mode(modes m) : modes_(m) {}
     operator modes() { return modes_; }

--- a/cpp/include/proton/option.hpp
+++ b/cpp/include/proton/option.hpp
@@ -1,0 +1,63 @@
+#ifndef PROTON_OPTION_HPP
+#define PROTON_OPTION_HPP
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdexcept>
+
+namespace proton {
+
+/// An option may or may not hold a value.
+template <class T> class option {
+    bool is_set_;
+    T value_;
+
+  public:
+    /// An empty option - this->is_set() == false
+    option() : is_set_(false), value_() {}
+
+    /// An option containing x
+    option(const T& x) : is_set_(true), value_(x) {}
+
+    /// Set option value to x
+    option& operator=(const T& x) { value_ = x;  is_set_ = true; return *this; }
+
+    /// Copy value from another option if it is set, no op otherwise
+    void update(const option<T>& x) { if (x.is_set()) *this = x.get(); }
+
+    /// @return true if the option has a value
+    bool is_set() const { return is_set_; }
+
+    /// @return !is_set()
+    bool empty() const { return !is_set_; }
+
+    /// @return the option value if is_set()
+    /// @throw std::logic_error if !is_set()
+    T get() const {
+        if (!is_set()) throw std::logic_error("proton::option is not set");
+        return value_;
+    }
+
+    /// @return the option value if is_set() or x if not
+    T get(const T& x) const { return is_set_ ? value_ : x; }
+};
+
+}
+#endif // PROTON_OPTION_HPP

--- a/cpp/include/proton/receiver_options.hpp
+++ b/cpp/include/proton/receiver_options.hpp
@@ -26,6 +26,7 @@
 #include "./internal/export.hpp"
 #include "./internal/pn_unique_ptr.hpp"
 #include "./delivery_mode.hpp"
+#include "./option.hpp"
 #include <string>
 
 /// @file
@@ -76,7 +77,7 @@ class receiver_options {
 
     /// Set the delivery mode on the receiver.  The default is
     /// delivery_mode::AT_LEAST_ONCE.
-    PN_CPP_EXTERN receiver_options& delivery_mode(delivery_mode);
+    PN_CPP_EXTERN receiver_options& delivery_mode(class delivery_mode);
 
     /// Enable or disable automatic acceptance of messages that aren't
     /// otherwise released, rejected, or modified.  It is enabled by
@@ -100,11 +101,19 @@ class receiver_options {
     /// Set the link name. If not set a unique name is generated.
     PN_CPP_EXTERN receiver_options& name(const std::string& name);
 
+    /// Get option values, see corresponding set function for details
+    /// {@
+    PN_CPP_EXTERN option<messaging_handler*> handler() const;
+    PN_CPP_EXTERN option<class delivery_mode> delivery_mode() const;
+    PN_CPP_EXTERN option<bool> auto_accept() const;
+    PN_CPP_EXTERN option<class source_options> source() const;
+    PN_CPP_EXTERN option<class target_options> target() const;
+    PN_CPP_EXTERN option<int> credit_window() const;
+    PN_CPP_EXTERN option<std::string> name() const;
+    /// @}
 
   private:
     void apply(receiver &) const;
-    const std::string* get_name() const; // Pointer to name if set, else 0
-
     class impl;
     internal::pn_unique_ptr<impl> impl_;
 

--- a/cpp/include/proton/reconnect_options.hpp
+++ b/cpp/include/proton/reconnect_options.hpp
@@ -26,6 +26,7 @@
 #include "./internal/pn_unique_ptr.hpp"
 #include "./duration.hpp"
 #include "./source.hpp"
+#include "./option.hpp"
 
 #include <string>
 #include <vector>
@@ -78,6 +79,15 @@ class reconnect_options {
     /// Alternative connection URLs used for failover.  There are none
     /// by default.
     PN_CPP_EXTERN reconnect_options& failover_urls(const std::vector<std::string>& conn_urls);
+
+    /// Get option values, see corresponding set function for details
+    /// {@
+    PN_CPP_EXTERN option<duration> delay() const;
+    PN_CPP_EXTERN option<float> delay_multiplier() const;
+    PN_CPP_EXTERN option<duration> max_delay() const;
+    PN_CPP_EXTERN option<int> max_attempts() const;
+    PN_CPP_EXTERN option<std::vector<std::string> > failover_urls() const;
+    /// @}
 
   private:
     class impl;

--- a/cpp/include/proton/sender_options.hpp
+++ b/cpp/include/proton/sender_options.hpp
@@ -26,6 +26,7 @@
 #include "./internal/export.hpp"
 #include "./internal/pn_unique_ptr.hpp"
 #include "./delivery_mode.hpp"
+#include "./option.hpp"
 #include <string>
 
 /// @file
@@ -91,10 +92,18 @@ class sender_options {
     /// Set the link name. If not set a unique name is generated.
     PN_CPP_EXTERN sender_options& name(const std::string& name);
 
+    /// Get option values, see corresponding set function for details
+    /// {@
+    PN_CPP_EXTERN option<messaging_handler*> handler() const;
+    PN_CPP_EXTERN option<class delivery_mode> delivery_mode() const;
+    PN_CPP_EXTERN option<bool> auto_settle() const;
+    PN_CPP_EXTERN option<class source_options> source() const;
+    PN_CPP_EXTERN option<class target_options> target() const;
+    PN_CPP_EXTERN option<std::string> name() const;
+    /// @}
+
   private:
     void apply(sender&) const;
-    const std::string* get_name() const; // Pointer to name if set, else 0
-
     class impl;
     internal::pn_unique_ptr<impl> impl_;
 

--- a/cpp/include/proton/session_options.hpp
+++ b/cpp/include/proton/session_options.hpp
@@ -25,6 +25,7 @@
 #include "./fwd.hpp"
 #include "./internal/export.hpp"
 #include "./internal/pn_unique_ptr.hpp"
+#include "./option.hpp"
 
 /// @file
 /// @copybrief proton::session_options
@@ -54,6 +55,11 @@ class session_options {
     PN_CPP_EXTERN session_options& handler(class messaging_handler &);
 
     // Other useful session configuration TBD.
+
+    /// Get option values, see corresponding set function for details
+    /// {@
+    PN_CPP_EXTERN option<messaging_handler*> handler() const;
+    /// @}
 
     /// @cond INTERNAL
   private:

--- a/cpp/include/proton/source_options.hpp
+++ b/cpp/include/proton/source_options.hpp
@@ -25,6 +25,7 @@
 #include "./internal/export.hpp"
 #include "./internal/pn_unique_ptr.hpp"
 #include "./duration.hpp"
+#include "./option.hpp"
 #include "./source.hpp"
 
 #include <string>
@@ -91,6 +92,19 @@ class source_options {
 
     /// Extension capabilities that are supported/requested
     PN_CPP_EXTERN source_options& capabilities(const std::vector<symbol>&);
+
+    /// Get option values, see corresponding set function for details
+    /// {@
+    PN_CPP_EXTERN option<std::string> address() const;
+    PN_CPP_EXTERN option<bool> dynamic() const;
+    PN_CPP_EXTERN option<bool> anonymous() const;
+    PN_CPP_EXTERN option<enum source::distribution_mode> distribution_mode() const;
+    PN_CPP_EXTERN option<enum source::durability_mode> durability_mode() const;
+    PN_CPP_EXTERN option<duration> timeout() const;
+    PN_CPP_EXTERN option<enum source::expiry_policy> expiry_policy() const;
+    PN_CPP_EXTERN option<source::filter_map> filters() const;
+    PN_CPP_EXTERN option<std::vector<symbol> > capabilities() const;
+    /// @}
 
   private:
     void apply(source&) const;

--- a/cpp/include/proton/target_options.hpp
+++ b/cpp/include/proton/target_options.hpp
@@ -25,6 +25,7 @@
 #include "./internal/export.hpp"
 #include "./internal/pn_unique_ptr.hpp"
 #include "./duration.hpp"
+#include "./option.hpp"
 #include "./target.hpp"
 
 #include <string>
@@ -82,6 +83,17 @@ class target_options {
 
     /// Extension capabilities that are supported/requested
     PN_CPP_EXTERN target_options& capabilities(const std::vector<symbol>&);
+
+    /// Get option values, see corresponding set function for details
+    /// {@
+    PN_CPP_EXTERN option<std::string> address() const;
+    PN_CPP_EXTERN option<bool> dynamic() const;
+    PN_CPP_EXTERN option<bool> anonymous() const;
+    PN_CPP_EXTERN option<enum target::durability_mode> durability_mode() const;
+    PN_CPP_EXTERN option<duration> timeout() const;
+    PN_CPP_EXTERN option<enum target::expiry_policy> expiry_policy() const;
+    PN_CPP_EXTERN option<std::vector<symbol> > capabilities() const;
+    /// @}
 
   private:
     void apply(target&) const;

--- a/cpp/src/connect_config.cpp
+++ b/cpp/src/connect_config.cpp
@@ -156,7 +156,7 @@ std::string parse(std::istream& is, connection_options& opts) {
         raise(msg() << "'scheme' must be \"amqp\" or \"amqps\"");
     }
 
-    string host = get_string(root, "host", "");
+    string host = get_string(root, "host", "localhost");
     opts.virtual_host(host.c_str());
 
     Value port = root.get("port", scheme);

--- a/cpp/src/connection_driver.cpp
+++ b/cpp/src/connection_driver.cpp
@@ -69,7 +69,7 @@ void connection_driver::configure(const connection_options& opts, bool server) {
         opts.apply_unbound_client(driver_.transport);
     }
     pn_connection_driver_bind(&driver_);
-    handler_ =  opts.handler();
+    handler_ =  opts.handler().get(0);
 }
 
 void connection_driver::connect(const connection_options& opts) {

--- a/cpp/src/connection_options.cpp
+++ b/cpp/src/connection_options.cpp
@@ -40,15 +40,6 @@
 
 namespace proton {
 
-template <class T> struct option {
-    T value;
-    bool set;
-
-    option() : value(), set(false) {}
-    option& operator=(const T& x) { value = x;  set = true; return *this; }
-    void update(const option<T>& x) { if (x.set) *this = x.value; }
-};
-
 class connection_options::impl {
   public:
     option<messaging_handler*> handler;
@@ -84,29 +75,29 @@ class connection_options::impl {
         bool uninit = c.uninitialized();
         if (!uninit) return;
 
-        if (reconnect.set)
-            connection_context::get(pnc).reconnect_context_.reset(new reconnect_context(reconnect.value));
-        if (container_id.set)
-            pn_connection_set_container(pnc, container_id.value.c_str());
-        if (virtual_host.set)
-            pn_connection_set_hostname(pnc, virtual_host.value.c_str());
-        if (user.set)
-            pn_connection_set_user(pnc, user.value.c_str());
-        if (password.set)
-            pn_connection_set_password(pnc, password.value.c_str());
-        if (offered_capabilities.set)
-            value(pn_connection_offered_capabilities(pnc)) = offered_capabilities.value;
-        if (desired_capabilities.set)
-            value(pn_connection_desired_capabilities(pnc)) = desired_capabilities.value;
+        if (reconnect.is_set())
+            connection_context::get(pnc).reconnect_context_.reset(new reconnect_context(reconnect.get()));
+        if (container_id.is_set())
+            pn_connection_set_container(pnc, container_id.get().c_str());
+        if (virtual_host.is_set())
+            pn_connection_set_hostname(pnc, virtual_host.get().c_str());
+        if (user.is_set())
+            pn_connection_set_user(pnc, user.get().c_str());
+        if (password.is_set())
+            pn_connection_set_password(pnc, password.get().c_str());
+        if (offered_capabilities.is_set())
+            value(pn_connection_offered_capabilities(pnc)) = offered_capabilities.get();
+        if (desired_capabilities.is_set())
+            value(pn_connection_desired_capabilities(pnc)) = desired_capabilities.get();
     }
 
     void apply_transport(pn_transport_t* pnt) {
-        if (max_frame_size.set)
-            pn_transport_set_max_frame(pnt, max_frame_size.value);
-        if (max_sessions.set)
-            pn_transport_set_channel_max(pnt, max_sessions.value);
-        if (idle_timeout.set)
-            pn_transport_set_idle_timeout(pnt, idle_timeout.value.milliseconds());
+        if (max_frame_size.is_set())
+            pn_transport_set_max_frame(pnt, max_frame_size.get());
+        if (max_sessions.is_set())
+            pn_transport_set_channel_max(pnt, max_sessions.get());
+        if (idle_timeout.is_set())
+            pn_transport_set_idle_timeout(pnt, idle_timeout.get().milliseconds());
     }
 
     void apply_sasl(pn_transport_t* pnt) {
@@ -115,17 +106,17 @@ class connection_options::impl {
         if (!pnt) return;
 
         // Skip entirely if SASL explicitly disabled
-        if (!sasl_enabled.set || sasl_enabled.value) {
-            if (sasl_enabled.set)  // Explicitly set, not just default behaviour.
+        if (!sasl_enabled.is_set() || sasl_enabled.get()) {
+            if (sasl_enabled.is_set())  // Explicitly set, not just default behaviour.
                 pn_sasl(pnt);      // Force a sasl instance.  Lazily create one otherwise.
-            if (sasl_allow_insecure_mechs.set)
-                pn_sasl_set_allow_insecure_mechs(pn_sasl(pnt), sasl_allow_insecure_mechs.value);
-            if (sasl_allowed_mechs.set)
-                pn_sasl_allowed_mechs(pn_sasl(pnt), sasl_allowed_mechs.value.c_str());
-            if (sasl_config_name.set)
-                pn_sasl_config_name(pn_sasl(pnt), sasl_config_name.value.c_str());
-            if (sasl_config_path.set)
-                pn_sasl_config_path(pn_sasl(pnt), sasl_config_path.value.c_str());
+            if (sasl_allow_insecure_mechs.is_set())
+                pn_sasl_set_allow_insecure_mechs(pn_sasl(pnt), sasl_allow_insecure_mechs.get());
+            if (sasl_allowed_mechs.is_set())
+                pn_sasl_allowed_mechs(pn_sasl(pnt), sasl_allowed_mechs.get().c_str());
+            if (sasl_config_name.is_set())
+                pn_sasl_config_name(pn_sasl(pnt), sasl_config_name.get().c_str());
+            if (sasl_config_path.is_set())
+                pn_sasl_config_path(pn_sasl(pnt), sasl_config_path.get().c_str());
         }
 
     }
@@ -135,17 +126,17 @@ class connection_options::impl {
         // and if there is a pipelined open frame.
         if (!pnt) return;
 
-        if (client && ssl_client_options.set) {
+        if (client && ssl_client_options.is_set()) {
             // A side effect of pn_ssl() is to set the ssl peer
             // hostname to the connection hostname, which has
             // already been adjusted for the virtual_host option.
             pn_ssl_t *ssl = pn_ssl(pnt);
-            if (pn_ssl_init(ssl, ssl_client_options.value.pn_domain(), NULL))
+            if (pn_ssl_init(ssl, ssl_client_options.get().pn_domain(), NULL))
                 throw error(MSG("client SSL/TLS initialization error"));
-        } else if (!client && ssl_server_options.set) {
-                pn_ssl_t *ssl = pn_ssl(pnt);
-                if (pn_ssl_init(ssl, ssl_server_options.value.pn_domain(), NULL))
-                    throw error(MSG("server SSL/TLS initialization error"));
+        } else if (!client && ssl_server_options.is_set()) {
+            pn_ssl_t *ssl = pn_ssl(pnt);
+            if (pn_ssl_init(ssl, ssl_server_options.get().pn_domain(), NULL))
+                throw error(MSG("server SSL/TLS initialization error"));
         }
 
     }
@@ -212,10 +203,26 @@ connection_options& connection_options::sasl_allowed_mechs(const std::string &s)
 connection_options& connection_options::sasl_config_name(const std::string &n) { impl_->sasl_config_name = n; return *this; }
 connection_options& connection_options::sasl_config_path(const std::string &p) { impl_->sasl_config_path = p; return *this; }
 
+option<messaging_handler*> connection_options::handler() const { return impl_->handler; }
+option<uint32_t> connection_options::max_frame_size() const { return impl_->max_frame_size; }
+option<uint16_t> connection_options::max_sessions() const { return impl_->max_sessions; }
+option<duration> connection_options::idle_timeout() const { return impl_->idle_timeout; }
+option<std::string> connection_options::container_id() const { return impl_->container_id; }
+option<std::string> connection_options::virtual_host() const { return impl_->virtual_host; }
+option<std::string> connection_options::user() const { return impl_->user; }
+option<class ssl_client_options> connection_options::ssl_client_options() const { return impl_->ssl_client_options; }
+option<class ssl_server_options> connection_options::ssl_server_options() const { return impl_->ssl_server_options; }
+option<bool> connection_options::sasl_enabled() const { return impl_->sasl_enabled; }
+option<bool> connection_options::sasl_allow_insecure_mechs() const { return impl_->sasl_allow_insecure_mechs; }
+option<std::string> connection_options::sasl_allowed_mechs() const { return impl_->sasl_allowed_mechs; }
+option<std::vector<symbol> > connection_options::offered_capabilities() const { return impl_->offered_capabilities; }
+option<std::vector<symbol> > connection_options::desired_capabilities() const { return impl_->desired_capabilities; }
+option<std::string> connection_options::sasl_config_name() const { return impl_->sasl_config_name; }
+option<std::string> connection_options::sasl_config_path() const { return impl_->sasl_config_path; }
+option<reconnect_options> connection_options::reconnect() const { return impl_->reconnect; }
+
 void connection_options::apply_unbound(connection& c) const { impl_->apply_unbound(c); }
 void connection_options::apply_unbound_client(pn_transport_t *t) const { impl_->apply_sasl(t); impl_->apply_ssl(t, true); impl_->apply_transport(t); }
 void connection_options::apply_unbound_server(pn_transport_t *t) const { impl_->apply_sasl(t); impl_->apply_ssl(t, false); impl_->apply_transport(t); }
-
-messaging_handler* connection_options::handler() const { return impl_->handler.value; }
 
 } // namespace proton

--- a/cpp/src/proactor_container_impl.cpp
+++ b/cpp/src/proactor_container_impl.cpp
@@ -181,7 +181,7 @@ pn_connection_t* container::impl::make_connection_lh(
 
     connection_options opts = client_connection_options_; // Defaults
     opts.update(user_opts);
-    messaging_handler* mh = opts.handler();
+    messaging_handler* mh = opts.handler().get(0);
 
     pn_connection_t *pnc = pn_connection();
     connection_context& cc(connection_context::get(pnc));
@@ -592,7 +592,7 @@ container::impl::dispatch_result container::impl::dispatch(pn_event_t* event) {
         connection_context& cc = connection_context::get(c);
         cc.container = &container_;
         cc.listener_context_ = lc;
-        cc.handler = opts.handler();
+        cc.handler = opts.handler().get(0);
         cc.work_queue_ = new container::impl::connection_work_queue(*container_.impl_, c);
         pn_transport_t* pnt = pn_transport();
         pn_transport_set_server(pnt);

--- a/cpp/src/reconnect_options.cpp
+++ b/cpp/src/reconnect_options.cpp
@@ -41,4 +41,10 @@ reconnect_options& reconnect_options::max_delay(duration d) { impl_->max_delay =
 reconnect_options& reconnect_options::max_attempts(int i) { impl_->max_attempts = i; return *this; }
 reconnect_options& reconnect_options::failover_urls(const std::vector<std::string>& urls) { impl_->failover_urls = urls; return *this; }
 
+option<duration> reconnect_options::delay() const { return impl_->delay; }
+option<float> reconnect_options::delay_multiplier() const { return impl_->delay_multiplier; }
+option<duration> reconnect_options::max_delay() const { return impl_->max_delay; }
+option<int> reconnect_options::max_attempts() const { return impl_->max_attempts; }
+option<std::vector<std::string> > reconnect_options::failover_urls() const { return impl_->failover_urls; }
+
 } // namespace proton

--- a/cpp/src/sender_options.cpp
+++ b/cpp/src/sender_options.cpp
@@ -31,15 +31,6 @@
 
 namespace proton {
 
-template <class T> struct option {
-    T value;
-    bool set;
-
-    option() : value(), set(false) {}
-    option& operator=(const T& x) { value = x;  set = true; return *this; }
-    void update(const option<T>& x) { if (x.set) *this = x.value; }
-};
-
 class sender_options::impl {
     static link_context& get_context(sender l) {
         return link_context::get(unwrap(l));
@@ -63,22 +54,22 @@ class sender_options::impl {
     option<messaging_handler*> handler;
     option<proton::delivery_mode> delivery_mode;
     option<bool> auto_settle;
-    option<source_options> source;
-    option<target_options> target;
+    option<class source_options> source;
+    option<class target_options> target;
     option<std::string> name;
 
     void apply(sender& s) {
         if (s.uninitialized()) {
-            if (delivery_mode.set) set_delivery_mode(s, delivery_mode.value);
-            if (handler.set && handler.value) container::impl::set_handler(s, handler.value);
-            if (auto_settle.set) get_context(s).auto_settle = auto_settle.value;
-            if (source.set) {
+            if (delivery_mode.is_set()) set_delivery_mode(s, delivery_mode.get());
+            if (handler.is_set() && handler.get()) container::impl::set_handler(s, handler.get());
+            if (auto_settle.is_set()) get_context(s).auto_settle = auto_settle.get();
+            if (source.is_set()) {
                 proton::source local_s(make_wrapper<proton::source>(pn_link_source(unwrap(s))));
-                source.value.apply(local_s);
+                source.get().apply(local_s);
             }
-            if (target.set) {
+            if (target.is_set()) {
                 proton::target local_t(make_wrapper<proton::target>(pn_link_target(unwrap(s))));
-                target.value.apply(local_t);
+                target.get().apply(local_t);
             }
         }
     }
@@ -110,13 +101,17 @@ void sender_options::update(const sender_options& x) { impl_->update(*x.impl_); 
 sender_options& sender_options::handler(class messaging_handler &h) { impl_->handler = &h; return *this; }
 sender_options& sender_options::delivery_mode(proton::delivery_mode m) {impl_->delivery_mode = m; return *this; }
 sender_options& sender_options::auto_settle(bool b) {impl_->auto_settle = b; return *this; }
-sender_options& sender_options::source(const source_options &s) {impl_->source = s; return *this; }
-sender_options& sender_options::target(const target_options &s) {impl_->target = s; return *this; }
+sender_options& sender_options::source(const class source_options &s) {impl_->source = s; return *this; }
+sender_options& sender_options::target(const class target_options &s) {impl_->target = s; return *this; }
 sender_options& sender_options::name(const std::string &s) {impl_->name = s; return *this; }
 
 void sender_options::apply(sender& s) const { impl_->apply(s); }
 
-const std::string* sender_options::get_name() const {
-    return impl_->name.set ? &impl_->name.value : 0;
-}
+option<messaging_handler*> sender_options::handler() const { return impl_->handler; }
+option<class delivery_mode> sender_options::delivery_mode() const { return impl_->delivery_mode; }
+option<bool> sender_options::auto_settle() const { return impl_->auto_settle; }
+option<class source_options> sender_options::source() const { return impl_->source; }
+option<class target_options> sender_options::target() const { return impl_->target; }
+option<std::string> sender_options::name() const { return impl_->name; }
+
 } // namespace proton

--- a/cpp/src/session.cpp
+++ b/cpp/src/session.cpp
@@ -77,7 +77,8 @@ sender session::open_sender(const std::string &addr) {
 }
 
 sender session::open_sender(const std::string &addr, const sender_options &so) {
-    std::string name = so.get_name() ? *so.get_name() : next_link_name(connection());
+    option<std::string> name_opt = so.name();
+    std::string name = name_opt.is_set() ? name_opt.get() : next_link_name(connection());
     pn_link_t *lnk = pn_sender(pn_object(), name.c_str());
     pn_terminus_set_address(pn_link_target(lnk), addr.c_str());
     sender snd(make_wrapper<sender>(lnk));
@@ -91,7 +92,8 @@ receiver session::open_receiver(const std::string &addr) {
 
 receiver session::open_receiver(const std::string &addr, const receiver_options &ro)
 {
-    std::string name = ro.get_name() ? *ro.get_name() : next_link_name(connection());
+    option<std::string> name_opt = ro.name();
+    std::string name = name_opt.is_set() ? name_opt.get() : next_link_name(connection());
     pn_link_t *lnk = pn_receiver(pn_object(), name.c_str());
     pn_terminus_set_address(pn_link_source(lnk), addr.c_str());
     receiver rcv(make_wrapper<receiver>(lnk));

--- a/cpp/src/session_options.cpp
+++ b/cpp/src/session_options.cpp
@@ -32,22 +32,13 @@
 
 namespace proton {
 
-template <class T> struct option {
-    T value;
-    bool set;
-
-    option() : value(), set(false) {}
-    option& operator=(const T& x) { value = x;  set = true; return *this; }
-    void update(const option<T>& x) { if (x.set) *this = x.value; }
-};
-
 class session_options::impl {
   public:
     option<messaging_handler *> handler;
 
     void apply(session& s) {
         if (s.uninitialized()) {
-            if (handler.set && handler.value) container::impl::set_handler(s, handler.value);
+            if (handler.is_set() && handler.get()) container::impl::set_handler(s, handler.get());
         }
     }
 
@@ -68,7 +59,7 @@ session_options& session_options::handler(class messaging_handler &h) { impl_->h
 
 void session_options::apply(session& s) const { impl_->apply(s); }
 
-
+option<messaging_handler*> session_options::handler() const { return impl_->handler; }
 
 
 } // namespace proton


### PR DESCRIPTION
This is the template approach to option getters - memory safe.
Needs to be extended to all the _options classes, but I want agreement on the approach and option<T> clss before I complete the job. @astitcher @cliffjansen 