### PR TITLE
NO-JIRA: Removed python upgrade for xcode7.3 travis build to fix pip issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DBUILD_RUBY=NO'
     before_install:
     - brew update
-    - brew upgrade cmake python openssl
+    - brew upgrade cmake openssl
     - brew install libuv swig
 
   - os: osx


### PR DESCRIPTION
Tried a few different updates to rectify the [travis xcode7.3 build failure](https://travis-ci.org/apache/qpid-proton/jobs/436640885) with this having the least impact. Originally we needed this to get a working python version but now we don't and the upgrade to 3.7.0 breaks pip for the moment.