### PR TITLE
PROTON-1959 [cpp] Binary compatible reconnect

### DIFF
--- a/cpp/docs/pages.dox
+++ b/cpp/docs/pages.dox
@@ -1,9 +1,6 @@
-/// Order the pages in the documentations side-panel by declaring them here
-
 /// @page overview_page Overview
 /// @page tutorial_page Tutorial
 /// @page connect-config Connection Configuration
 /// @page types_page AMQP and C++ types
 /// @page mt_page Multi-threading
 /// @page io_page IO integration
-///

--- a/cpp/src/handler.cpp
+++ b/cpp/src/handler.cpp
@@ -56,8 +56,6 @@ void messaging_handler::on_connection_open(connection &c) {
         pn_connection_open(unwrap(c));
     }
 }
-void messaging_handler::on_connection_reconnecting(connection &) {}
-void messaging_handler::on_connection_start(connection &) {}
 void messaging_handler::on_connection_wake(connection&) {}
 
 void messaging_handler::on_session_close(session &) {}

--- a/cpp/src/messaging_adapter.cpp
+++ b/cpp/src/messaging_adapter.cpp
@@ -231,9 +231,6 @@ void on_connection_remote_close(messaging_handler& handler, pn_event_t* event) {
 
 void on_connection_bound(messaging_handler& handler, pn_event_t* event) {
     connection c(make_wrapper(pn_event_connection(event)));
-    if (!c.reconnected()) {     // Call on_connection_start() on first connect
-        handler.on_connection_start(c);
-    }
 }
 
 void on_connection_remote_open(messaging_handler& handler, pn_event_t* event) {

--- a/cpp/src/reconnect_test.cpp
+++ b/cpp/src/reconnect_test.cpp
@@ -131,7 +131,7 @@ class server_connection_handler : public proton::messaging_handler {
 class tester : public proton::messaging_handler, public waiter {
   public:
     tester() : waiter(3), container_(*this, "reconnect_client"),
-               start_count(0), open_count(0), reconnecting_count(0),
+               start_count(0), open_count(0),
                link_open_count(0), transport_error_count(0), transport_close_count(0) {}
 
     void on_container_start(proton::container &c) PN_CPP_OVERRIDE {
@@ -151,23 +151,16 @@ class tester : public proton::messaging_handler, public waiter {
         container_.connect(s1->url(), proton::connection_options().reconnect(proton::reconnect_options().failover_urls(urls)));
     }
 
-    void on_connection_start(proton::connection& c) PN_CPP_OVERRIDE {
-        start_count++;
-        c.open_sender("messages");
-        ASSERT(!c.reconnected());
-    }
-
     void on_connection_open(proton::connection& c) PN_CPP_OVERRIDE {
-        ASSERT(bool(open_count) == c.reconnected());
+        if (!c.reconnected()) {
+            start_count++;
+            c.open_sender("messages");
+        }
+        ASSERT_EQUAL(bool(open_count), c.reconnected());
         open_count++;
     }
 
-    void on_connection_reconnecting(proton::connection& c) PN_CPP_OVERRIDE {
-        reconnecting_count++;
-    }
-
     void on_sender_open(proton::sender &s) PN_CPP_OVERRIDE {
-        ASSERT(bool(link_open_count) == s.connection().reconnected());
         link_open_count++;
     }
 
@@ -180,6 +173,7 @@ class tester : public proton::messaging_handler, public waiter {
     }
 
     void on_transport_error(proton::transport& t) PN_CPP_OVERRIDE {
+        ASSERT_EQUAL(bool(transport_error_count), t.connection().reconnected());
         transport_error_count++;
     }
 
@@ -191,11 +185,10 @@ class tester : public proton::messaging_handler, public waiter {
         container_.run();
         ASSERT_EQUAL(1, start_count);
         ASSERT_EQUAL(3, open_count);
-        ASSERT(2 < reconnecting_count);
+        // Could be > 3, unpredicatble number reconnects while listener comes up.
+        ASSERT(2 < transport_error_count);
         // Last reconnect fails before opening links
         ASSERT(link_open_count > 1);
-        // All transport errors should have been hidden
-        ASSERT_EQUAL(0, transport_error_count);
         // One final transport close, not an error
         ASSERT_EQUAL(1, transport_close_count);
     }
@@ -205,7 +198,7 @@ class tester : public proton::messaging_handler, public waiter {
     proton::internal::pn_unique_ptr<server_connection_handler> s2;
     proton::internal::pn_unique_ptr<server_connection_handler> s3;
     proton::container container_;
-    int start_count, open_count, reconnecting_count, link_open_count, transport_error_count, transport_close_count;
+    int start_count, open_count, link_open_count, transport_error_count, transport_close_count;
 };
 
 int test_failover_simple() {
@@ -284,11 +277,11 @@ class authfail_reconnect_tester : public proton::messaging_handler, public waite
     bool errored_;
 };
 
-// Verify we can stop reconnecting by calling close() in on_connection_reconnecting()
+// Verify we can stop reconnecting by calling close() in on_transport_error()
 class test_reconnecting_close : public proton::messaging_handler, public waiter {
   public:
     test_reconnecting_close() : waiter(1), container_(*this, "test_reconnecting_close"),
-                                reconnecting_called(false) {}
+                                transport_error_called(false) {}
 
     void on_container_start(proton::container &c) PN_CPP_OVERRIDE {
         s1.reset(new server_connection_handler(c, 0, *this));
@@ -298,17 +291,13 @@ class test_reconnecting_close : public proton::messaging_handler, public waiter 
         container_.connect(s1->url(), proton::connection_options().reconnect(proton::reconnect_options()));
     }
 
-    void on_connection_reconnecting(proton::connection& c) PN_CPP_OVERRIDE {
-        reconnecting_called = true;
-        c.close();                        // Abort reconnection
+    void on_transport_error(proton::transport& t) PN_CPP_OVERRIDE {
+        transport_error_called = true;
+        t.connection().close();                        // Abort reconnection
     }
 
     void on_connection_close(proton::connection& c) PN_CPP_OVERRIDE {
         ASSERT(0);              // Not expecting any clean close
-    }
-
-    void on_transport_error(proton::transport& t) PN_CPP_OVERRIDE {
-        // Expected, don't throw
     }
 
     void run() {
@@ -318,7 +307,7 @@ class test_reconnecting_close : public proton::messaging_handler, public waiter 
   private:
     proton::container container_;
     std::string err_;
-    bool reconnecting_called;
+    bool transport_error_called;
     proton::internal::pn_unique_ptr<server_connection_handler> s1;
 };
 


### PR DESCRIPTION
The previous commit f53c7683d7e90363 added virtual functions to messaging_handler
which is a binary incompatible change.

Modify & update doc to work with existing messaging_handler functions.
Use existing pn_connection_open() and pn_transport_error() events instead of creating new ones.