### PR TITLE
NO-JIRA: [c] Fix typo in sizeof (wrong, bigger, type used)

### DIFF
--- a/c/src/proactor/libuv.c
+++ b/c/src/proactor/libuv.c
@@ -656,7 +656,7 @@ static void leader_listen_lh(pn_listener_t *l) {
     for (struct addrinfo *ai = l->addr.getaddrinfo.addrinfo; ai; ai = ai->ai_next) {
       ++len;
     }
-    l->addrs = (pn_netaddr_t*)calloc(len, sizeof(lsocket_t));
+    l->addrs = (pn_netaddr_t*)calloc(len, sizeof(pn_netaddr_t));
 
     /* Find the working addresses */
     for (struct addrinfo *ai = l->addr.getaddrinfo.addrinfo; ai; ai = ai->ai_next) {


### PR DESCRIPTION
This is a clang-analyzer warning, and it does look suspicious. Consider this more like a suspected bug report (diff makes it easier to explain than verbal description) than a fix.

> Result of 'calloc' is converted to a pointer of type 'pn_netaddr_t', which is incompatible with sizeof operand type 'lsocket_t'

CC @alanconway @astitcher 