### PR TITLE
src/ssl/openssl: add libressl compatibility

### DIFF
--- a/c/src/ssl/openssl.c
+++ b/c/src/ssl/openssl.c
@@ -522,7 +522,7 @@ pn_ssl_domain_t *pn_ssl_domain( pn_ssl_mode_t mode )
   // Mitigate the CRIME vulnerability
   SSL_CTX_set_options(domain->ctx, SSL_OP_NO_COMPRESSION);
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
   domain->default_seclevel = SSL_CTX_get_security_level(domain->ctx);
 #endif
 
@@ -709,7 +709,7 @@ int pn_ssl_domain_set_peer_authentication(pn_ssl_domain_t *domain,
    case PN_SSL_VERIFY_PEER:
    case PN_SSL_VERIFY_PEER_NAME:
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
     SSL_CTX_set_security_level(domain->ctx, domain->default_seclevel);
 #endif
 
@@ -749,7 +749,7 @@ int pn_ssl_domain_set_peer_authentication(pn_ssl_domain_t *domain,
     break;
 
    case PN_SSL_ANONYMOUS_PEER:   // hippie free love mode... :)
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
     // Must use lowest OpenSSL security level to enable anonymous ciphers.
     SSL_CTX_set_security_level(domain->ctx, 0);
 #endif


### PR DESCRIPTION
Similar to https://github.com/FreeRDP/FreeRDP/issues/5049
libressl has `#define OPENSSL_VERSION_NUMBER ` defined the same as
openssl 1.1.x which results in SSL_CTX_set_security_level() getting used.

This patch prevents SSL_CTX_<get/set>_security_level() from being used with
libressl.

Signed-off-by: Matthew Weber <matthew.weber@rockwellcollins.com>