### PR TITLE
NO-JIRA: [c] Fix Coverity warning of buffer overrun in pn_proactor_addr

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -505,7 +505,7 @@ endif(MSVC)
 
 if (qpid-proton-proactor)
   set(HAS_PROACTOR True)
-  add_library (qpid-proton-proactor SHARED ${qpid-proton-proactor})
+  add_library (qpid-proton-proactor SHARED ${qpid-proton-proactor} ${qpid-proton-platform})
   target_link_libraries (qpid-proton-proactor  LINK_PUBLIC qpid-proton-core)
   target_link_libraries (qpid-proton-proactor  LINK_PRIVATE ${PLATFORM_LIBS} ${PROACTOR_LIBS})
   set_target_properties (qpid-proton-proactor
@@ -515,7 +515,7 @@ if (qpid-proton-proactor)
     LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
   )
   if (BUILD_STATIC_LIBS)
-    add_library (qpid-proton-proactor-static STATIC ${qpid-proton-proactor})
+    add_library (qpid-proton-proactor-static STATIC ${qpid-proton-proactor} ${qpid-proton-platform})
   endif(BUILD_STATIC_LIBS)
 endif()
 

--- a/c/src/proactor/proactor-internal.c
+++ b/c/src/proactor/proactor-internal.c
@@ -21,6 +21,9 @@
 /* Common platform-independent implementation for proactor libraries */
 
 #include "proactor-internal.h"
+
+#include "platform/platform.h"
+
 #include <proton/error.h>
 #include <proton/listener.h>
 #include <proton/netaddr.h>
@@ -39,14 +42,7 @@ static const char *AMQPS_PORT_NAME = "amqps";
 const char *PNI_IO_CONDITION = "proton:io";
 
 int pn_proactor_addr(char *buf, size_t len, const char *host, const char *port) {
-  /* Don't use snprintf, Windows is not C99 compliant and snprintf is broken. */
-  if (buf && len > 0) {
-    buf[0] = '\0';
-    if (host) strncat(buf, host, len);
-    strncat(buf, ":", len);
-    if (port) strncat(buf, port, len);
-  }
-  return (host ? strlen(host) : 0) + (port ? strlen(port) : 0) + 1;
+  return pni_snprintf(buf, len, "%s:%s", host ? host : "", port ? port : "");
 }
 
 int pni_parse_addr(const char *addr, char *buf, size_t len, const char **host, const char **port)

--- a/c/tests/proactor_test.cpp
+++ b/c/tests/proactor_test.cpp
@@ -567,6 +567,9 @@ TEST_CASE("proactor_ssl") {
 
 TEST_CASE("proactor_addr") {
   /* Test the address formatter */
+  CHECK(1 == pn_proactor_addr(NULL, 0, "", ""));
+  CHECK(7 == pn_proactor_addr(NULL, 0, "foo", "bar"));
+  
   char addr[PN_MAX_ADDR];
   pn_proactor_addr(addr, sizeof(addr), "foo", "bar");
   CHECK_THAT("foo:bar", Equals(addr));


### PR DESCRIPTION
```
Error: OVERRUN (CWE-119):
qpid-proton-0.27.0/c/tests/proactor_test.cpp:613: overrun-buffer-arg: Overrunning array "sl" of 1024 bytes by passing it to a function which accesses it at byte offset 1024 using argument "1024UL".
#  611|
#  612|     pn_transport_t *st = pn_connection_transport(s);
#  613|->   pn_netaddr_str(pn_transport_local_addr(st), sl, sizeof(sl));
#  614|     CHECK_THAT(cr, Equals(sl)); /* client remote == server local */
```