### PR TITLE
NO-JIRA: [c] Fix "Logically dead code" warning caused by excessive NULL checks

### DIFF
--- a/c/tools/reactor-recv.c
+++ b/c/tools/reactor-recv.c
@@ -94,19 +94,17 @@ typedef struct {
   pn_link_t *reply_link;
 } connection_context_t;
 
-
+/**
+ * @return buffer of sufficient size, or NULL
+ */
 static char *ensure_buffer(char *buf, size_t needed, size_t *actual)
 {
-  char* new_buf;
   // Make room for the largest message seen so far, plus extra for slight changes in metadata content
   if (needed + 1024 <= *actual)
     return buf;
   needed += 2048;
-  new_buf = (char *) realloc(buf, needed);
-  if (new_buf != NULL) {
-    buf = new_buf;
-    *actual = buf ? needed : 0;
-  }
+  buf = (char *) realloc(buf, needed);
+  *actual = buf ? needed : 0;
   return buf;
 }
 


### PR DESCRIPTION
dead_error_line: Execution cannot reach the expression 0UL inside this statement: *actual = (buf ? needed : 0...