### PR TITLE
NO-JIRA: [c] missing break in send-ssl.c example

### DIFF
--- a/c/examples/send-ssl.c
+++ b/c/examples/send-ssl.c
@@ -134,6 +134,7 @@ static bool handle(app_data_t* app, pn_event_t* event) {
        printf("secure connection: %s\n", name);
        fflush(stdout);
      }
+     break;
    }
 
    case PN_LINK_FLOW: {


### PR DESCRIPTION
    CID 214944 (#1 of 1): Missing break in switch (MISSING_BREAK)unterminated_case: The case for value
    PN_CONNECTION_REMOTE_OPEN is not terminated by a 'break' statement.

This looks genuinely wrong. Either there is `break` missing, or there should be some `/* fallthrough */` comment to signal this is intentional.