### PR TITLE
PROTON-2030 Use CLOCK_MONOTONIC in proactors for pn_transport_tick

### DIFF
--- a/c/include/proton/proactor.h
+++ b/c/include/proton/proactor.h
@@ -299,6 +299,8 @@ PNP_EXTERN pn_proactor_t *pn_connection_proactor(pn_connection_t *connection);
 PNP_EXTERN pn_proactor_t *pn_event_proactor(pn_event_t *event);
 
 /**
+ * @deprecated Use ::pn_proactor_now_64()
+ *
  * Get the real elapsed time since an arbitrary point in the past in milliseconds.
  *
  * This may be used as a portable way to get a process-local timestamp for the
@@ -311,6 +313,20 @@ PNP_EXTERN pn_proactor_t *pn_event_proactor(pn_event_t *event);
  * @note Thread-safe
  */
 PNP_EXTERN pn_millis_t pn_proactor_now(void);
+
+/**
+ * Get the real elapsed time since an arbitrary point in the past in milliseconds.
+ *
+ * This may be used as a portable way to get a process-local timestamp for the
+ * current time. It is monotonically increasing and will never go backwards.
+ *
+ * Note: this is not a suitable value for an AMQP timestamp to be sent as part
+ * of a message.  Such a timestamp should use the real time in milliseconds
+ * since the epoch.
+ *
+ * @note Thread-safe
+ */
+PNP_EXTERN int64_t pn_proactor_now_64(void);
 
 /**
  * @}

--- a/c/include/proton/transport.h
+++ b/c/include/proton/transport.h
@@ -681,7 +681,7 @@ PN_EXTERN bool pn_transport_closed(pn_transport_t *transport);
  *
  * @param[in] transport the transport to process.
  * @param[in] now A monotonically-increasing time value in milliseconds.
- *   Does not need to be wall-clock time or a valid AMQP timestamp, but must increase montonically.
+ *   Does not need to be wall-clock time or a valid AMQP timestamp, but must increase monotonically.
  *
  * @return If non-zero, then the monotonic expiration time of the next pending
  * timer event for the transport.  The caller must invoke pn_transport_tick

--- a/c/src/core/engine-internal.h
+++ b/c/src/core/engine-internal.h
@@ -103,7 +103,7 @@ typedef struct pn_io_layer_t {
   ssize_t (*process_input)(struct pn_transport_t *transport, unsigned int layer, const char *, size_t);
   ssize_t (*process_output)(struct pn_transport_t *transport, unsigned int layer, char *, size_t);
   void (*handle_error)(struct pn_transport_t* transport, unsigned int layer);
-  pn_timestamp_t (*process_tick)(struct pn_transport_t *transport, unsigned int layer, pn_timestamp_t);
+  int64_t (*process_tick)(struct pn_transport_t *transport, unsigned int layer, int64_t);
   size_t (*buffered_output)(struct pn_transport_t *transport);  // how much output is held
 } pn_io_layer_t;
 

--- a/c/src/core/transport.c
+++ b/c/src/core/transport.c
@@ -152,7 +152,7 @@ static ssize_t pn_input_read_amqp(pn_transport_t *transport, unsigned int layer,
 static ssize_t pn_output_write_amqp_header(pn_transport_t *transport, unsigned int layer, char *bytes, size_t available);
 static ssize_t pn_output_write_amqp(pn_transport_t *transport, unsigned int layer, char *bytes, size_t available);
 static void pn_error_amqp(pn_transport_t *transport, unsigned int layer);
-static pn_timestamp_t pn_tick_amqp(pn_transport_t *transport, unsigned int layer, pn_timestamp_t now);
+static int64_t pn_tick_amqp(pn_transport_t *transport, unsigned int layer, int64_t now);
 
 static ssize_t pn_io_layer_input_autodetect(pn_transport_t *transport, unsigned int layer, const char *bytes, size_t available);
 static ssize_t pn_io_layer_output_null(pn_transport_t *transport, unsigned int layer, char *bytes, size_t available);
@@ -2632,7 +2632,7 @@ static ssize_t pn_input_read_amqp(pn_transport_t* transport, unsigned int layer,
 }
 
 /* process AMQP related timer events */
-static pn_timestamp_t pn_tick_amqp(pn_transport_t* transport, unsigned int layer, pn_timestamp_t now)
+static int64_t pn_tick_amqp(pn_transport_t* transport, unsigned int layer, int64_t now)
 {
   pn_timestamp_t timeout = 0;
 
@@ -2917,7 +2917,7 @@ pn_millis_t pn_transport_get_remote_idle_timeout(pn_transport_t *transport)
 
 int64_t pn_transport_tick(pn_transport_t *transport, int64_t now)
 {
-  pn_timestamp_t r = 0;
+  int64_t r = 0;
   for (int i = 0; i<PN_IO_LAYER_CT; ++i) {
     if (transport->io_layers[i] && transport->io_layers[i]->process_tick)
       r = pn_timestamp_min(r, transport->io_layers[i]->process_tick(transport, i, now));

--- a/c/src/proactor/epoll.c
+++ b/c/src/proactor/epoll.c
@@ -1419,10 +1419,10 @@ static void pconnection_tick(pconnection_t *pc) {
   pn_transport_t *t = pc->driver.transport;
   if (pn_transport_get_idle_timeout(t) || pn_transport_get_remote_idle_timeout(t)) {
     ptimer_set(&pc->timer, 0);
-    int64_t now = pn_proactor_now_64();
-    int64_t next = pn_transport_tick(t, now);
+    uint64_t now = pn_proactor_now_64();
+    uint64_t next = pn_transport_tick(t, now);
     if (next) {
-      ptimer_set(&pc->timer, (uint64_t) next - now);
+      ptimer_set(&pc->timer, next - now);
     }
   }
 }

--- a/c/src/proactor/libuv.c
+++ b/c/src/proactor/libuv.c
@@ -1339,5 +1339,9 @@ const pn_netaddr_t *pn_listener_addr(pn_listener_t *l) {
 }
 
 pn_millis_t pn_proactor_now(void) {
+  return (pn_millis_t) pn_proactor_now_64();
+}
+
+int64_t pn_proactor_now_64(void) {
   return uv_hrtime() / 1000000; // uv_hrtime returns time in nanoseconds
 }

--- a/c/src/proactor/win_iocp.c
+++ b/c/src/proactor/win_iocp.c
@@ -2132,8 +2132,8 @@ static void pconnection_tick(pconnection_t *pc) {
     if(!stop_timer(pc->context.proactor->timer_queue, &pc->tick_timer)) {
       // TODO: handle error
     }
-    int64_t now = pn_proactor_now_64();
-    int64_t next = pn_transport_tick(t, now);
+    uint64_t now = pn_proactor_now_64();
+    uint64_t next = pn_transport_tick(t, now);
     if (next) {
       if (!start_timer(pc->context.proactor->timer_queue, &pc->tick_timer, tick_timer_cb, pc, next - now)) {
         // TODO: handle error


### PR DESCRIPTION
- deprecates pn_proactor_now in favour of new pn_proactor_now_64
- replaces use of pn_i_now2 with pn_proactor_now_64
- uses GetTickCount64() in iocp proactor, instead of GetSystemTimeAsFileTime