### PR TITLE
PROTON-2040 [cpp] Allow connection options to be updated for reconnect

### DIFF
--- a/cpp/include/proton/connection.hpp
+++ b/cpp/include/proton/connection.hpp
@@ -181,6 +181,10 @@ PN_CPP_CLASS_EXTERN connection : public internal::object<pn_connection_t>, publi
     /// @see reconnect_options, messaging_handler
     PN_CPP_EXTERN bool reconnected() const;
 
+    /// **Unsettled API** - update the connection options prior to an automatic reconnect.
+    /// Note this will over-write existing options like connection_options::update()
+    PN_CPP_EXTERN void reconnect_update(const connection_options&);
+
     /// @cond INTERNAL
   friend class internal::factory<connection>;
   friend class container;

--- a/cpp/src/connection.cpp
+++ b/cpp/src/connection.cpp
@@ -56,7 +56,7 @@ void connection::open() {
 }
 
 void connection::open(const connection_options &opts) {
-    opts.apply_unbound(*this);
+    if (uninitialized()) opts.apply_unbound(*this);
     pn_connection_open(pn_object());
 }
 
@@ -197,5 +197,10 @@ bool connection::reconnected() const {
     reconnect_context* rc = cc.reconnect_context_.get();
     return (rc && rc->reconnected_);
 }
+
+void connection::reconnect_update(const connection_options &opts) {
+    opts.apply_unbound(*this);
+}
+
 
 } // namespace proton

--- a/cpp/src/connection_options.cpp
+++ b/cpp/src/connection_options.cpp
@@ -79,11 +79,6 @@ class connection_options::impl {
      */
     void apply_unbound(connection& c) {
         pn_connection_t *pnc = unwrap(c);
-
-        // Only apply connection options if uninit.
-        bool uninit = c.uninitialized();
-        if (!uninit) return;
-
         if (reconnect.set)
             connection_context::get(pnc).reconnect_context_.reset(new reconnect_context(reconnect.value));
         if (container_id.set)

--- a/cpp/src/reconnect_test.cpp
+++ b/cpp/src/reconnect_test.cpp
@@ -316,12 +316,73 @@ int test_auth_fail_reconnect() {
     return 0;
 }
 
-int main(int argc, char** argv) {
+// Verify we can change connection options for reconnect on_transport_error()
+class test_reconnect_update : public proton::messaging_handler {
+public:
+    test_reconnect_update()
+            : errors_(0), container_(*this, "test_reconnect_update") {}
+
+    proton::reconnect_options ropts() {
+        // Fast as we can to avoid needless test slowness.
+        return proton::reconnect_options().delay(proton::duration::MILLISECOND);
+    }
+
+    proton::connection_options copts() { return proton::connection_options(); }
+
+    void on_container_start(proton::container &c) PN_CPP_OVERRIDE {
+        // Never actually connects, keeps re-trying to bogus hostnames with
+        // changing options.
+        c.connect("nosuchhost0", copts().reconnect(ropts()).virtual_host("vhost0").user("user0"));
+    }
+
+    void on_transport_error(proton::transport &t) PN_CPP_OVERRIDE {
+        switch (++errors_) {
+        case 1:
+            ASSERT_SUBSTRING("nosuchhost0", t.error().what()); // First failure
+            break;
+        case 2: {
+            ASSERT_SUBSTRING("nosuchhost0",t.error().what()); // Second failure
+            std::vector<std::string> urls;
+            urls.push_back("nosuchhost1");
+            // Update the failover list
+            t.connection().reconnect_update(copts().reconnect(ropts().failover_urls(urls)));
+            // Verify changing reconnect_options does not affect other options.
+            ASSERT_EQUAL("user0", t.connection().user());
+            break;
+        }
+        case 3:
+            ASSERT_SUBSTRING("nosuchhost0", t.error().what()); // Re-try original
+            break;
+        case 4:
+            ASSERT_SUBSTRING("nosuchhost1", t.error().what()); // Using failover host
+            // Change a non-reconnect option should not affect reconnect
+            t.connection().reconnect_update(copts().user("user1"));
+            break;
+        case 5:
+            ASSERT_SUBSTRING("nosuchhost0", t.error().what()); // Back to original
+            ASSERT_EQUAL("user1", t.connection().user());
+            break;
+        case 6:
+            ASSERT_SUBSTRING("nosuchhost1", t.error().what()); // Still have failover
+            break;
+        default:
+            t.connection().container().stop();
+        }
+    }
+
+    void run() { container_.run(); }
+
+private:
+    int errors_;
+    proton::container container_;
+};
+
+int main(int argc, char **argv) {
     int failed = 0;
     RUN_ARGV_TEST(failed, test_failover_simple());
     RUN_ARGV_TEST(failed, test_stop_reconnect());
     RUN_ARGV_TEST(failed, test_auth_fail_reconnect());
     RUN_ARGV_TEST(failed, test_reconnecting_close().run());
+    RUN_ARGV_TEST(failed, test_reconnect_update().run());
     return failed;
 }
-


### PR DESCRIPTION
Added connection::reconnect_update(const connection_options&) which can be
called during on_transport_error() to change the failover list and other
connection options before the next automatic reconnect.