### PR TITLE
PROTON-2040: Alternative suggestion for updating connection options:

### DIFF
--- a/c/src/core/connection_driver.c
+++ b/c/src/core/connection_driver.c
@@ -77,12 +77,13 @@ int pn_connection_driver_bind(pn_connection_driver_t *d) {
 
 pn_connection_t *pn_connection_driver_release_connection(pn_connection_driver_t *d) {
   if (d->transport) {           /* Make sure transport is closed and unbound */
-      pn_connection_driver_close(d);
-      pn_transport_unbind(d->transport);
+    pn_connection_driver_close(d);
+    pn_transport_unbind(d->transport);
   }
   pn_connection_t *c = d->connection;
   if (c) {
     d->connection = NULL;
+    pn_connection_reset(c);
     pn_connection_collect(c, NULL); /* Disconnect from the collector */
   }
   return c;

--- a/cpp/include/proton/connection.hpp
+++ b/cpp/include/proton/connection.hpp
@@ -175,11 +175,24 @@ PN_CPP_CLASS_EXTERN connection : public internal::object<pn_connection_t>, publi
     /// execute code safely in the event-handler thread.
     PN_CPP_EXTERN void wake() const;
 
-    /// **Unsettled API** - true if this connection has been automatically
+    /// **Unsettled API** - True if this connection has been automatically
     /// re-connected.
     ///
     /// @see reconnect_options, messaging_handler
     PN_CPP_EXTERN bool reconnected() const;
+
+    /// **Unsettled API** - Update the connection options for this connection
+    ///
+    /// This method can be used to update the connection options used with this
+    /// connection. Usually the connection options are only used during the initial
+    /// connection attempt so this ability is only useful when automatically
+    /// reconnect is enabled and you wish to change the connection options before
+    /// the next reconnect attempt. This would usually be in the handler for the
+    /// `on_transport_error` event @see messaging_handler.
+    ///
+    /// @note Connection options supplied in the parameter will be merged with the
+    /// existing parameters as if `connection_options::update()` was used.
+    PN_CPP_EXTERN void update_options(const connection_options&);
 
     /// @cond INTERNAL
   friend class internal::factory<connection>;

--- a/cpp/src/connection.cpp
+++ b/cpp/src/connection.cpp
@@ -198,4 +198,9 @@ bool connection::reconnected() const {
     return (rc && rc->reconnected_);
 }
 
+void connection::update_options(const connection_options& options) {
+    connection_context& cc = connection_context::get(pn_object());
+    cc.connection_options_->update(options);
+}
+
 } // namespace proton

--- a/cpp/src/connection_options.cpp
+++ b/cpp/src/connection_options.cpp
@@ -84,8 +84,12 @@ class connection_options::impl {
         bool uninit = c.uninitialized();
         if (!uninit) return;
 
-        if (reconnect.set)
+        if (reconnect.set) {
+            // Transfer reconnect options from connection options to reconnect contexts
+            // to stop the reconnect context being reset every retry unless there are new options
             connection_context::get(pnc).reconnect_context_.reset(new reconnect_context(reconnect.value));
+            reconnect.set = false;
+        }
         if (container_id.set)
             pn_connection_set_container(pnc, container_id.value.c_str());
         if (virtual_host.set)

--- a/cpp/src/proactor_container_impl.cpp
+++ b/cpp/src/proactor_container_impl.cpp
@@ -194,7 +194,7 @@ pn_connection_t* container::impl::make_connection_lh(
     cc.connection_options_.reset(new connection_options(opts));
 
     setup_connection_lh(url, pnc);
-    make_wrapper(pnc).open(opts);
+    make_wrapper(pnc).open(*cc.connection_options_);
 
     return pnc;                 // 1 refcount from pn_connection()
 }


### PR DESCRIPTION
- Renamed connection method - update_options()
  * This is the actual function of the method - to update any connection
    options. so that updating eg SSL/SASL options will take affect too.
- Corrected implementation
  * The previous implementation did not actually update the stored
    connection options, rather applying them immediately. This did
    accidentally update the reconnection options and the connection
    based options, but not the transport based ones.