### PR TITLE
PROTON-2185 cpp/CMakeLists.txt: fix qpid-proton-cpp linking

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -179,7 +179,7 @@ if(BUILD_STATIC_LIBS)
   add_library(qpid-proton-cpp-static STATIC ${qpid-proton-cpp-source})
 endif(BUILD_STATIC_LIBS)
 
-target_link_libraries (qpid-proton-cpp LINK_PRIVATE ${PLATFORM_LIBS} qpid-proton-core qpid-proton-proactor ${CONNECT_CONFIG_LIBS})
+target_link_libraries (qpid-proton-cpp LINK_PRIVATE ${PLATFORM_LIBS} ${CONNECT_CONFIG_LIBS} LINK_PUBLIC qpid-proton-core qpid-proton-proactor)
 
 set_target_properties (
   qpid-proton-cpp


### PR DESCRIPTION
gpid-proton-cpp must use LINK_PUBLIC to link with qpid-proton-core and
qpid-proton-proactor otherwise build will fail if those libraries are
not yet installed on the system:

[ 81%] Linking CXX executable value_test
/home/fabrice/buildroot/output/host/lib/gcc/arm-buildroot-linux-uclibcgnueabihf/8.3.0/../../../../arm-buildroot-linux-uclibcgnueabihf/bin/ld: warning: libqpid-proton-proactor.so.1, needed by libqpid-proton-cpp.so.12.6.0, not found (try using -rpath or -rpath-link)
/home/fabrice/buildroot/output/host/lib/gcc/arm-buildroot-linux-uclibcgnueabihf/8.3.0/../../../../arm-buildroot-linux-uclibcgnueabihf/bin/ld: warning: libqpid-proton-core.so.10, needed by libqpid-proton-cpp.so.12.6.0, not found (try using -rpath or -rpath-link)
/home/fabrice/buildroot/output/host/lib/gcc/arm-buildroot-linux-uclibcgnueabihf/8.3.0/../../../../arm-buildroot-linux-uclibcgnueabihf/bin/ld: libqpid-proton-cpp.so.12.6.0: undefined reference to `pn_data_put_described'

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>