### PR TITLE
PROTON-2109: [Python] Correct default JSON schema to amqps

### DIFF
--- a/python/proton/_reactor.py
+++ b/python/proton/_reactor.py
@@ -1214,7 +1214,7 @@ class Container(Reactor):
         """
         if not url and not urls and not address:
             config = _get_default_config()
-            scheme = config.get('scheme', 'amqp')
+            scheme = config.get('scheme', 'amqps')
             _url = "%s://%s:%s" % (scheme, config.get('host', 'localhost'), config.get('port', _get_default_port_for_scheme(scheme)))
             _ssl_domain = None
             _kwargs = kwargs

--- a/python/tests/proton_tests/connect.py
+++ b/python/tests/proton_tests/connect.py
@@ -32,7 +32,7 @@ def write_connect_conf(obj):
         json.dump(obj, outfile)
 
 class Server(MessagingHandler):
-    def __init__(self, expected_user=None, scheme='amqp'):
+    def __init__(self, expected_user=None, scheme='amqps'):
         super(Server, self).__init__()
         self.port = free_tcp_port()
         self.scheme = scheme


### PR DESCRIPTION
According to the [documentation](https://github.com/apache/qpid-proton/blob/master/docs/connect-config.md), default port should be `amqps`.