### PR TITLE
PROTON-2126 Fix Appveyor CI build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,22 +2,44 @@ version: '{branch}.{build}'
 configuration: RelWithDebInfo
 environment:
   matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      CMAKE_GENERATOR: Visual Studio 16 2019
+      PYTHON: "C:\\Python37-x64"
+      VCPKG_INTEGRATION: '-DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake -A x64'
+      VCPKG_DEFAULT_TRIPLET: x64-windows
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      CMAKE_GENERATOR: Visual Studio 15
+      CMAKE_GENERATOR: Visual Studio 15 2017
+      PYTHON: "C:\\Python27"
       VCPKG_INTEGRATION: '-DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake'
-    - CMAKE_GENERATOR: Visual Studio 12
-    - CMAKE_GENERATOR: Visual Studio 10
+      VCPKG_DEFAULT_TRIPLET: x86-windows
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CMAKE_GENERATOR: Visual Studio 14 2015
+      PYTHON: "C:\\Python27"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CMAKE_GENERATOR: Visual Studio 12 2013
+      PYTHON: "C:\\Python27"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CMAKE_GENERATOR: Visual Studio 11 2012
+      PYTHON: "C:\\Python27"
+init:
+# Microsoft Visual C++ 9.0 is required. Get it from http://aka.ms/vcpython27
+# https://github.com/SiLab-Bonn/silab_utils/blob/ee92c0c73e4af7ace256ae2e09d734ed4a82e28d/appveyor.yml
+- ps: Start-FileDownload 'http://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi' C:\VCForPython27.msi
+- cmd: msiexec /i C:\VCForPython27.msi /quiet /qn
 install:
 - cinst -y swig
+# https://www.appveyor.com/docs/lang/cpp/#vc-packaging-tool
 - cd C:\Tools\vcpkg
 - git pull
 - .\bootstrap-vcpkg.bat
 - cd %APPVEYOR_BUILD_FOLDER%
-- vcpkg install jsoncpp:x86-windows
-- vcpkg install jsoncpp:x64-windows
+- vcpkg install jsoncpp
 - vcpkg integrate install
-- pip install --user --upgrade pip
-- pip install --user setuptools tox
+# https://pythonhosted.org/CodeChat/appveyor.yml.html
+- "%PYTHON%\\python.exe -m pip install --upgrade pip"
+- "%PYTHON%\\python.exe -m pip install --upgrade setuptools"
+- "%PYTHON%\\python.exe -m pip install --upgrade wheel"
+- "%PYTHON%\\python.exe -m pip install --upgrade tox"
 cache:
 - C:\ProgramData\chocolatey\bin -> .appveyor.yml
 - C:\ProgramData\chocolatey\lib -> .appveyor.yml
@@ -25,7 +47,7 @@ cache:
 before_build:
 - mkdir BLD
 - cd BLD
-- cmake %VCPKG_INTEGRATION% -G "%CMAKE_GENERATOR%" %QPID_PROTON_CMAKE_ARGS% ..
+- cmake %VCPKG_INTEGRATION% -G "%CMAKE_GENERATOR%" -DPYTHON_EXECUTABLE=%PYTHON%\\python.exe ..
 - cd ..
 build:
   project: BLD/Proton.sln

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -159,12 +159,17 @@ class Configure(build_ext):
         # implementations will be used.
         sources.append(os.path.join(proton_src, 'sasl', 'sasl.c'))
         sources.append(os.path.join(proton_src, 'sasl', 'default_sasl.c'))
-        if cc.has_function('sasl_client_done', includes=['sasl/sasl.h'],
-                           libraries=['sasl2']):
+        # Skip the SASL detection on Windows.
+        # MSbuild scans output of Exec tasks and fails the build if it notices error-like
+        # strings there. This is a known issue with CMake and msbuild, see
+        # * https://github.com/Microsoft/msbuild/issues/2424
+        # * https://cmake.org/pipermail/cmake-developers/2015-October/026775.html
+        if cc.compiler_type!='msvc' and cc.has_function(
+                'sasl_client_done', includes=['sasl/sasl.h'], libraries=['sasl2']):
             libraries.append('sasl2')
             sources.append(os.path.join(proton_src, 'sasl', 'cyrus_sasl.c'))
         else:
-            log.warn("Cyrus SASL not installed - only the ANONYMOUS and"
+            log.warn("Cyrus SASL not installed or on Windows - only the ANONYMOUS and"
                      " PLAIN mechanisms will be supported!")
             sources.append(os.path.join(proton_src, 'sasl', 'cyrus_stub.c'))
 
@@ -175,9 +180,9 @@ class Configure(build_ext):
             targets = []
             target_base = os.path.join(self.build_temp, 'srcs')
             try:
-                os.mkdir(target_base)
-            except FileExistsError:
-	            pass
+                os.makedirs(target_base)
+            except OSError:  # FileExistsError in 3.7
+                pass
 
             for f in sources:
                 # We know each file ends in '.c' as we filtered on that above so just add 'pp' to end


### PR DESCRIPTION
Previously, the build would fail when installing setuptools and tox:

```
pip install --user setuptools tox
Traceback (most recent call last):
  File "c:\python27\lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "c:\python27\lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "C:\Python27\Scripts\pip.exe\__main__.py", line 9, in <module>
TypeError: 'module' object is not callable
Command exited with code 1
```

* Use pip systemwide, not with --user flag
* Use explicit Appveyor image versions in build matrix
* Install VC 9.0, because Python 2.7 needs it

https://www.appveyor.com/docs/windows-images-software/

https://wiki.python.org/moin/WindowsCompilers#Microsoft_Visual_C.2B-.2B-_9.0_standalone:_Visual_C.2B-.2B-_Compiler_for_Python_2.7_.28x86.2C_x64.29

* Don't try detecting sasl on Windows, because MSBuild would fail the py wheel build
* Build also with Python 3.7 x64 to check that is possible
* Fix bad indent in setup.py.in
* Use os.makedirs in setup.py.in, to avoid failue:

```
Error [WinError 3]
	The system cannot find the path specified: 'build\\temp.win-amd64-3.7\\Release\\srcs'
	py_pkg_wheel
	C:\Users\Administrator\qpid-proton\build\python\CUSTOMBUILD	1
```

* Install wheel with pip