### PR TITLE
PROTON-2131: Introduce new proton logging API

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -177,15 +177,6 @@ if (PN_WINAPI)
   list(APPEND PLATFORM_DEFINITIONS "PN_WINAPI")
 endif (PN_WINAPI)
 
-# Flags for example self-test build, CACHE INTERNAL for visibility
-set(C_EXAMPLE_FLAGS "${COMPILE_WARNING_FLAGS}")
-set(C_EXAMPLE_LINK_FLAGS "${SANITIZE_FLAGS}")
-
-if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCC)
-  # Ensure that examples build with c90, to deal with older c++03-as-c compilers.
-  set(C_EXAMPLE_FLAGS "${C_EXAMPLE_FLAGS} -std=iso9899:1990 -pedantic")
-endif()
-
 if (MSVC)
     set(CMAKE_DEBUG_POSTFIX "d")
     add_definitions(
@@ -194,8 +185,21 @@ if (MSVC)
         /wd4800
         /wd4996
     )
-    set (qpid-proton-platform src/compiler/msvc/snprintf.c)
 endif (MSVC)
+
+# Ensure that examples build with c90 on gcc/clang, to deal with older c++03-as-c compilers.
+set(C_EXAMPLE_FLAGS_GNU "-std=iso9899:1990 -pedantic")
+set(C_EXAMPLE_FLAGS_Clang "-std=iso9899:1990 -pedantic")
+
+# Flags for example self-test build
+set(C_EXAMPLE_FLAGS "${COMPILE_WARNING_FLAGS} ${C_EXAMPLE_FLAGS_${CMAKE_C_COMPILER_ID}}")
+set(C_EXAMPLE_LINK_FLAGS "${SANITIZE_FLAGS}")
+
+set(qpid-proton-platform_GNU src/compiler/gcc/start.c)
+set(qpid-proton-platform_Clang src/compiler/gcc/start.c)
+set(qpid-proton-platform_MSVC src/compiler/msvc/snprintf.c src/compiler/msvc/start.c)
+
+set(qpid-proton-platform ${qpid-proton-platform_${CMAKE_C_COMPILER_ID}})
 
 # for full source distribution:
 set (qpid-proton-platform-all
@@ -240,7 +244,8 @@ set (qpid-proton-core
   src/core/object/iterator.c
   src/core/object/record.c
 
-  src/core/log.c
+  src/core/init.c
+  src/core/logger.c
   src/core/util.c
   src/core/error.c
   src/core/buffer.c
@@ -267,39 +272,9 @@ set (qpid-proton-include-generated
   ${CMAKE_CURRENT_BINARY_DIR}/include/proton/version.h
   )
 
-set (qpid-proton-private-includes
-  src/messenger/store.h
-  src/messenger/subscription.h
-  src/messenger/messenger.h
-  src/messenger/transform.h
-  src/ssl/ssl-internal.h
-  src/sasl/sasl-internal.h
-  src/core/autodetect.h
-  src/core/log_private.h
-  src/core/config.h
-  src/core/encoder.h
-  src/core/dispatch_actions.h
-  src/core/engine-internal.h
-  src/core/transport.h
-  src/core/framing.h
-  src/core/buffer.h
-  src/core/util.h
-  src/core/dispatcher.h
-  src/core/data.h
-  src/core/decoder.h
-  src/core/max_align.h
-  src/core/message-internal.h
-  src/reactor/io/windows/iocp.h
-  src/reactor/selector.h
-  src/reactor/io.h
-  src/reactor/reactor.h
-  src/reactor/selectable.h
-  src/platform/platform.h
-  src/platform/platform_fmt.h
-  src/proactor/proactor-internal.h
-  )
-
 set (qpid-proton-extra
+  src/core/log.c
+
   src/extra/url.c
 
   src/reactor/reactor.c
@@ -333,7 +308,7 @@ set (qpid-proton-include
   include/proton/import_export.h
   include/proton/link.h
   include/proton/listener.h
-  include/proton/log.h
+  include/proton/logger.h
   include/proton/message.h
   include/proton/netaddr.h
   include/proton/object.h
@@ -350,6 +325,7 @@ set (qpid-proton-include
 
 set (qpid-proton-include-extra
   include/proton/handlers.h
+  include/proton/log.h
   include/proton/messenger.h
   include/proton/reactor.h
   include/proton/selectable.h

--- a/c/include/proton/logger.h
+++ b/c/include/proton/logger.h
@@ -1,0 +1,171 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**@file
+ *
+ * General proton logging facility
+ */
+
+#include <proton/import_export.h>
+#include <proton/object.h>
+
+#include <stdarg.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct pn_logger_t pn_logger_t;
+
+/**
+ * Definitions for different subsystems that can log messages
+ * Note that these are exclusive bits so that you can specify multiple
+ * subsystems to filter
+ */
+typedef enum pn_log_subsystem_t {
+    PN_SUBSYSTEM_NONE    = 0,
+    PN_SUBSYSTEM_IO      = 1,
+    PN_SUBSYSTEM_EVENT   = 2,
+    PN_SUBSYSTEM_AMQP    = 4,
+    PN_SUBSYSTEM_SSL     = 8,
+    PN_SUBSYSTEM_SASL    = 16,
+    PN_SUBSYSTEM_BINDING = 32,
+    PN_SUBSYSTEM_ALL     = 65535
+} pn_log_subsystem_t; /* We hint to the compiler it can use 16 bits for this value */
+
+/**
+ * Definitions for different severities of log messages
+ * Note that these are exclusive bits so that you can specify multiple
+ * severities to filter
+ */
+typedef enum pn_log_level_t {
+    PN_LEVEL_NONE     = 0,
+    PN_LEVEL_CRITICAL = 1,    /* Something is wrong and can't be fixed - probably a library bug */
+    PN_LEVEL_ERROR    = 2,    /* Something went wrong */
+    PN_LEVEL_WARNING  = 4,    /* Something unusual happened but not necessarily an error */
+    PN_LEVEL_INFO     = 8,    /* Something that might be interesting happened */
+    PN_LEVEL_DEBUG    = 16,   /* Something you might want to know about happened */
+    PN_LEVEL_TRACE    = 32,   /* Detail about something that happened */
+    PN_LEVEL_FRAME    = 64,   /* Protocol frame traces */
+    PN_LEVEL_RAW      = 128,  /* Raw protocol bytes */
+    PN_LEVEL_ALL      = 65535 /* Every possible severity */
+} pn_log_level_t; /* We hint to the compiler that it can use 16 bits for this value */
+
+/**
+ * Callback for sinking logger messages.
+ */
+typedef void (*pn_log_sink_t)(intptr_t sink_context, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *message);
+
+/*
+ * Return the default library logger
+ */
+PN_EXTERN pn_logger_t *pn_default_logger(void);
+
+/**
+ * Create a new logger
+ */
+PN_EXTERN pn_logger_t *pn_logger(void);
+
+/**
+ * Free an existing logger
+ */
+PN_EXTERN void pn_logger_free(pn_logger_t *logger);
+
+/**
+ * Get a human readable name for a logger severity
+ */
+PN_EXTERN const char *pn_logger_level_name(pn_log_level_t severity);
+
+/**
+ * Get a human readable name for a logger subsystem
+ */
+PN_EXTERN const char *pn_logger_subsystem_name(pn_log_subsystem_t subsystem);
+
+/**
+ * Set a logger's tracing flags.
+ *
+ * Set trace flags to control what a logger logs.
+ *
+ * The trace flags for a logger control what sort of information is
+ * logged. See pn_log_severity_t and pn_log_subsystem_t for more details.
+ *
+ * @param[in] logger the logger
+ */
+PN_EXTERN void pn_logger_set_mask(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity);
+
+/**
+ * Clear a logger's tracing flags.
+ *
+ * Clear trace flags to control what a logger logs.
+ *
+ * The trace flags for a logger control what sort of information is
+ * logged. See pn_log_severity_t and pn_log_subsystem_t for more details.
+ *
+ * @param[in] logger the logger
+ */
+PN_EXTERN void pn_logger_reset_mask(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity);
+
+/**
+ * Set the tracing function used by a logger.
+ *
+ * The tracing function is called to perform logging. Overriding this
+ * function allows embedding applications to divert the engine's
+ * logging to a place of their choice.
+ *
+ * @param[in] logger the logger
+ * @param[in] sink the tracing function
+ * @param[in] sink_context user specified context to pass into each call of the tracing callback
+ */
+PN_EXTERN void pn_logger_set_log_sink(pn_logger_t *logger, pn_log_sink_t sink, intptr_t sink_context);
+
+/**
+ * Get the tracing function used by a logger.
+ *
+ * @param[in] logger the logger
+ * @return the tracing sink function used by a logger
+ */
+PN_EXTERN pn_log_sink_t pn_logger_get_log_sink(pn_logger_t *logger);
+
+/**
+ * Get the sink context used by a logger.
+ *
+ * @param[in] logger the logger
+ * @return the sink context used by a logger
+ */
+PN_EXTERN intptr_t pn_logger_get_log_sink_context(pn_logger_t *logger);
+
+/**
+ *  * Log a printf formatted using the logger
+ *
+ * This is mainly for use in proton internals , but will allow application log messages to
+ * be processed the same way.
+ *
+ * @param[in] logger the logger
+ * @param[in] fmt the printf formatted message to be logged
+ */
+PN_EXTERN void pn_logger_logf(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c/include/proton/transport.h
+++ b/c/include/proton/transport.h
@@ -25,6 +25,7 @@
 #include <proton/import_export.h>
 #include <proton/type_compat.h>
 #include <proton/condition.h>
+#include <proton/logger.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -225,6 +226,19 @@ PN_EXTERN bool pn_transport_is_encrypted(pn_transport_t *transport);
  * @return the transport's condition object
  */
 PN_EXTERN pn_condition_t *pn_transport_condition(pn_transport_t *transport);
+
+/**
+ * Get the transport logger
+ *
+ * This can be used to control the logging information emitted by the transport
+ *
+ * The pointer returned by this operation is valid until the
+ * transport object is freed.
+ *
+ * @param[in] transport the transport object
+ * @return the transport's logger object
+ */
+PN_EXTERN pn_logger_t *pn_transport_logger(pn_transport_t *transport);
 
 /**
  * **Deprecated** - Use ::pn_transport_condition().

--- a/c/src/compiler/gcc/start.c
+++ b/c/src/compiler/gcc/start.c
@@ -1,5 +1,3 @@
-#ifndef LOG_H
-#define LOG_H
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,42 +17,16 @@
  * under the License.
  */
 
-#include <proton/import_export.h>
-#include <proton/logger.h>
-#include <proton/type_compat.h>
+#include "core/init.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * @cond INTERNAL
- */
-    
-/**
- * Enable/disable global logging.
- *
- * By default, logging is enabled by environment variable PN_TRACE_LOG.
- * Calling this function overrides the environment setting.
- */
-PN_EXTERN void pn_log_enable(bool enabled);
-
-/**
- * Set the logger.
- *
- * By default a logger that prints to stderr is installed.
- *  
- * @param logger is called with each log message if logging is enabled.
- * Passing 0 disables logging regardless of pn_log_enable() or environment settings.
- */
-PN_EXTERN void pn_log_logger(void (*logger)(const char *message));
-
-/**
- * @endcond
- */
-
-#ifdef __cplusplus
+__attribute__((constructor))
+static void init(void)
+{
+  pn_init();
 }
-#endif
 
-#endif
+__attribute__((destructor))
+static void fini(void)
+{
+  pn_fini();
+}

--- a/c/src/compiler/msvc/start.c
+++ b/c/src/compiler/msvc/start.c
@@ -1,5 +1,3 @@
-#ifndef LOG_H
-#define LOG_H
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,42 +17,33 @@
  * under the License.
  */
 
-#include <proton/import_export.h>
-#include <proton/logger.h>
-#include <proton/type_compat.h>
+#define WIN32_LEAN_AMD_MEAN
+#include <windows.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "core/init.h"
 
-/**
- * @cond INTERNAL
- */
-    
-/**
- * Enable/disable global logging.
- *
- * By default, logging is enabled by environment variable PN_TRACE_LOG.
- * Calling this function overrides the environment setting.
- */
-PN_EXTERN void pn_log_enable(bool enabled);
+BOOL WINAPI DllMain(HINSTANCE dLL, DWORD reason, LPVOID reserved)
+{
+// Perform actions based on the reason for calling.
+  switch (reason)
+  {
+  case DLL_PROCESS_ATTACH:
+    // Initialize once for each new process.
+    pn_init();
+    break;
 
-/**
- * Set the logger.
- *
- * By default a logger that prints to stderr is installed.
- *  
- * @param logger is called with each log message if logging is enabled.
- * Passing 0 disables logging regardless of pn_log_enable() or environment settings.
- */
-PN_EXTERN void pn_log_logger(void (*logger)(const char *message));
+  case DLL_THREAD_ATTACH:
+    // Do thread-specific initialization.
+    break;
 
-/**
- * @endcond
- */
+  case DLL_THREAD_DETACH:
+    // Do thread-specific cleanup.
+    break;
 
-#ifdef __cplusplus
+  case DLL_PROCESS_DETACH:
+    // Perform any necessary cleanup.
+    pn_fini();
+    break;
+  }
+  return TRUE;
 }
-#endif
-
-#endif

--- a/c/src/core/codec.c
+++ b/c/src/core/codec.c
@@ -36,7 +36,7 @@
 #include "decoder.h"
 #include "encoder.h"
 #include "data.h"
-#include "log_private.h"
+#include "logger_private.h"
 
 const char *pn_type_name(pn_type_t type)
 {
@@ -717,7 +717,7 @@ int pn_data_vfill(pn_data_t *data, const char *fmt, va_list ap)
           }
           break;
         default:
-          pn_logf("unrecognized * code: 0x%.2X '%c'", code, code);
+          PN_LOG_DEFAULT(PN_SUBSYSTEM_AMQP, PN_LEVEL_CRITICAL, "unrecognized * code: 0x%.2X '%c'", code, code);
           return PN_ARG_ERR;
         }
       }
@@ -742,7 +742,7 @@ int pn_data_vfill(pn_data_t *data, const char *fmt, va_list ap)
         break;
       }
      default:
-      pn_logf("unrecognized fill code: 0x%.2X '%c'", code, code);
+      PN_LOG_DEFAULT(PN_SUBSYSTEM_AMQP, PN_LEVEL_CRITICAL, "unrecognized fill code: 0x%.2X '%c'", code, code);
       return PN_ARG_ERR;
     }
 

--- a/c/src/core/connection_driver.c
+++ b/c/src/core/connection_driver.c
@@ -49,10 +49,10 @@ static pn_event_t *batch_next(pn_event_batch_t *batch) {
   }
   /* Log the next event that will be processed */
   pn_event_t *next = pn_collector_next(d->collector);
-  if (next && d->transport->trace & PN_TRACE_EVT) {
+  if (next && PN_SHOULD_LOG(&d->transport->logger, PN_SUBSYSTEM_EVENT, PN_LEVEL_DEBUG)) {
     pn_string_clear(d->transport->scratch);
     pn_inspect(next, d->transport->scratch);
-    pn_transport_log(d->transport, pn_string_get(d->transport->scratch));
+    pni_logger_log(&d->transport->logger, PN_SUBSYSTEM_EVENT, PN_LEVEL_DEBUG, pn_string_get(d->transport->scratch));
   }
   return next;
 }
@@ -169,18 +169,18 @@ void pn_connection_driver_errorf(pn_connection_driver_t *d, const char *name, co
 }
 
 void pn_connection_driver_log(pn_connection_driver_t *d, const char *msg) {
-  pn_transport_log(d->transport, msg);
+  pni_logger_log(&d->transport->logger, PN_SUBSYSTEM_IO, PN_LEVEL_TRACE, msg);
 }
 
 void pn_connection_driver_logf(pn_connection_driver_t *d, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  pn_transport_vlogf(d->transport, fmt, ap);
+  pni_logger_vlogf(&d->transport->logger, PN_SUBSYSTEM_IO, PN_LEVEL_TRACE, fmt, ap);
   va_end(ap);
 }
 
 void pn_connection_driver_vlogf(pn_connection_driver_t *d, const char *fmt, va_list ap) {
-  pn_transport_vlogf(d->transport, fmt, ap);
+  pni_logger_vlogf(&d->transport->logger, PN_SUBSYSTEM_IO, PN_LEVEL_TRACE, fmt, ap);
 }
 
 pn_connection_driver_t* pn_event_batch_connection_driver(pn_event_batch_t *batch) {

--- a/c/src/core/dispatcher.c
+++ b/c/src/core/dispatcher.c
@@ -21,20 +21,21 @@
 
 #include "dispatcher.h"
 
-#include "framing.h"
-#include "protocol.h"
 #include "engine-internal.h"
+#include "framing.h"
+#include "logger_private.h"
+#include "protocol.h"
 
 #include "dispatch_actions.h"
 
 int pni_bad_frame(pn_transport_t *transport, uint8_t frame_type, uint16_t channel, pn_data_t *args, const pn_bytes_t *payload) {
-  pn_transport_logf(transport, "Error dispatching frame: type: %d: Unknown performative", frame_type);
+  PN_LOG(&transport->logger, PN_SUBSYSTEM_AMQP, PN_LEVEL_ERROR, "Error dispatching frame: type: %d: Unknown performative", frame_type);
   return PN_ERR;
 }
 
 int pni_bad_frame_type(pn_transport_t *transport, uint8_t frame_type, uint16_t channel, pn_data_t *args, const pn_bytes_t *payload) {
-    pn_transport_logf(transport, "Error dispatching frame: Unknown frame type: %d", frame_type);
-    return PN_ERR;
+  PN_LOG(&transport->logger, PN_SUBSYSTEM_AMQP, PN_LEVEL_ERROR, "Error dispatching frame: Unknown frame type: %d", frame_type);
+  return PN_ERR;
 }
 
 // We could use a table based approach here if we needed to dynamically
@@ -44,7 +45,7 @@ static inline int pni_dispatch_action(pn_transport_t* transport, uint64_t lcode,
   pn_action_t *action;
   switch (frame_type) {
   case AMQP_FRAME_TYPE:
-    /* Regular AMQP fames */
+    /* Regular AMQP frames */
     switch (lcode) {
     case OPEN:            action = pn_do_open; break;
     case BEGIN:           action = pn_do_begin; break;
@@ -77,8 +78,7 @@ static inline int pni_dispatch_action(pn_transport_t* transport, uint64_t lcode,
 static int pni_dispatch_frame(pn_transport_t * transport, pn_data_t *args, pn_frame_t frame)
 {
   if (frame.size == 0) { // ignore null frames
-    if (transport->trace & PN_TRACE_FRM)
-      pn_transport_logf(transport, "%u <- (EMPTY FRAME)", frame.channel);
+    PN_LOG(&transport->logger, PN_SUBSYSTEM_AMQP, PN_LEVEL_FRAME, "%u <- (EMPTY FRAME)", frame.channel);
     return 0;
   }
 
@@ -88,7 +88,7 @@ static int pni_dispatch_frame(pn_transport_t * transport, pn_data_t *args, pn_fr
                      "Error decoding frame: %s %s\n", pn_code(dsize),
                      pn_error_text(pn_data_error(args)));
     pn_quote(transport->scratch, frame.payload, frame.size);
-    pn_transport_log(transport, pn_string_get(transport->scratch));
+    PN_LOG(&transport->logger, PN_SUBSYSTEM_AMQP, PN_LEVEL_ERROR, pn_string_get(transport->scratch));
     return dsize;
   }
 
@@ -100,11 +100,11 @@ static int pni_dispatch_frame(pn_transport_t * transport, pn_data_t *args, pn_fr
   bool scanned;
   int e = pn_data_scan(args, "D?L.", &scanned, &lcode);
   if (e) {
-    pn_transport_log(transport, "Scan error");
+    PN_LOG(&transport->logger, PN_SUBSYSTEM_AMQP, PN_LEVEL_ERROR, "Scan error");
     return e;
   }
   if (!scanned) {
-    pn_transport_log(transport, "Error dispatching frame");
+    PN_LOG(&transport->logger, PN_SUBSYSTEM_AMQP, PN_LEVEL_ERROR, "Error dispatching frame");
     return PN_ERR;
   }
   size_t payload_size = frame.size - dsize;

--- a/c/src/core/engine-internal.h
+++ b/c/src/core/engine-internal.h
@@ -28,6 +28,7 @@
 
 #include "buffer.h"
 #include "dispatcher.h"
+#include "logger_private.h"
 #include "util.h"
 
 typedef enum pn_endpoint_type_t {CONNECTION, SESSION, SENDER, RECEIVER} pn_endpoint_type_t;
@@ -124,6 +125,7 @@ typedef struct pni_sasl_t pni_sasl_t;
 typedef struct pni_ssl_t pni_ssl_t;
 
 struct pn_transport_t {
+  pn_logger_t logger;
   pn_tracer_t tracer;
   pni_sasl_t *sasl;
   pni_ssl_t *ssl;
@@ -187,8 +189,6 @@ struct pn_transport_t {
   char *input_buf;
 
   pn_record_t *context;
-
-  pn_trace_t trace;
 
   /*
    * The maximum channel number can be constrained in several ways:

--- a/c/src/core/init.c
+++ b/c/src/core/init.c
@@ -1,5 +1,3 @@
-#ifndef LOG_H
-#define LOG_H
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,42 +17,14 @@
  * under the License.
  */
 
-#include <proton/import_export.h>
-#include <proton/logger.h>
-#include <proton/type_compat.h>
+#include "core/logger_private.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * @cond INTERNAL
- */
-    
-/**
- * Enable/disable global logging.
- *
- * By default, logging is enabled by environment variable PN_TRACE_LOG.
- * Calling this function overrides the environment setting.
- */
-PN_EXTERN void pn_log_enable(bool enabled);
-
-/**
- * Set the logger.
- *
- * By default a logger that prints to stderr is installed.
- *  
- * @param logger is called with each log message if logging is enabled.
- * Passing 0 disables logging regardless of pn_log_enable() or environment settings.
- */
-PN_EXTERN void pn_log_logger(void (*logger)(const char *message));
-
-/**
- * @endcond
- */
-
-#ifdef __cplusplus
+void pn_init(void)
+{
+  pni_init_default_logger();
 }
-#endif
 
-#endif
+void pn_fini(void)
+{
+  pni_fini_default_logger();
+}

--- a/c/src/core/init.h
+++ b/c/src/core/init.h
@@ -1,6 +1,8 @@
-#ifndef LOG_H
-#define LOG_H
+#ifndef PROTON_INIT_H
+#define PROTON_INIT_H 1
+
 /*
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,44 +19,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */
-
-#include <proton/import_export.h>
-#include <proton/logger.h>
-#include <proton/type_compat.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * @cond INTERNAL
- */
-    
-/**
- * Enable/disable global logging.
  *
- * By default, logging is enabled by environment variable PN_TRACE_LOG.
- * Calling this function overrides the environment setting.
- */
-PN_EXTERN void pn_log_enable(bool enabled);
-
-/**
- * Set the logger.
- *
- * By default a logger that prints to stderr is installed.
- *  
- * @param logger is called with each log message if logging is enabled.
- * Passing 0 disables logging regardless of pn_log_enable() or environment settings.
- */
-PN_EXTERN void pn_log_logger(void (*logger)(const char *message));
-
-/**
- * @endcond
  */
 
-#ifdef __cplusplus
-}
-#endif
+void pn_init(void);
+void pn_fini(void);
 
-#endif
+#endif // init.h

--- a/c/src/core/logger.c
+++ b/c/src/core/logger.c
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <proton/logger.h>
+#include <proton/error.h>
+
+#include "logger_private.h"
+#include "util.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void pni_default_log_sink(intptr_t logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *message)
+{
+  fprintf(stderr, "[%p]:%5s:%5s:%s\n", (void *) logger, pn_logger_subsystem_name(subsystem), pn_logger_level_name(severity), message);
+  fflush(stderr);
+}
+
+static pn_logger_t the_default_logger = {
+  pni_default_log_sink,
+  (intptr_t) &the_default_logger,
+  PN_LEVEL_CRITICAL,
+  PN_SUBSYSTEM_ALL,
+  NULL
+};
+
+void pni_logger_init(pn_logger_t *logger)
+{
+  *logger = the_default_logger;
+  logger->sink_context = (intptr_t) logger;
+  logger->scratch = pn_string(NULL);
+}
+
+void pni_logger_fini(pn_logger_t *logger)
+{
+  pn_free(logger->scratch);
+  logger->scratch = NULL;
+}
+
+void pni_init_default_logger(void)
+{
+  int sev_mask = 0;
+  int sub_mask = 0;
+  /* Back compatible environment settings */
+  if (pn_env_bool("PN_TRACE_RAW")) { sev_mask |= PN_LEVEL_RAW; }
+  if (pn_env_bool("PN_TRACE_FRM")) { sev_mask |= PN_LEVEL_FRAME; }
+
+  /* These aren't used enough to make them back compatible */
+  if (pn_env_bool("PN_TRACE_DRV")) { sev_mask |= PN_LEVEL_TRACE | PN_LEVEL_DEBUG; }
+  if (pn_env_bool("PN_TRACE_EVT")) { sev_mask |= PN_LEVEL_DEBUG; }
+
+  if (pn_env_bool("PN_TRACE_LOG")) { sev_mask |= PN_LEVEL_TRACE; }
+  if (pn_env_bool("PN_DEBUG_LOG")) { sev_mask |= PN_LEVEL_DEBUG; }
+  if (pn_env_bool("PN_INFO_LOG"))  { sev_mask |= PN_LEVEL_INFO; }
+  if (pn_env_bool("PN_WARNING_LOG")) { sev_mask |= PN_LEVEL_WARNING; }
+  if (pn_env_bool("PN_ERROR_LOG")) { sev_mask |= PN_LEVEL_ERROR; }
+  the_default_logger.sev_mask = (pn_log_level_t) (the_default_logger.sev_mask | sev_mask);
+  the_default_logger.sub_mask = (pn_log_subsystem_t) (the_default_logger.sub_mask | sub_mask);
+  the_default_logger.scratch = pn_string(NULL);
+}
+
+void pni_fini_default_logger(void)
+{
+  pni_logger_fini(&the_default_logger);
+}
+
+const char *pn_logger_level_name(pn_log_level_t severity)
+{
+  if (severity==PN_LEVEL_ALL)     return "*ALL*";
+  if (severity&PN_LEVEL_CRITICAL) return "CRITICAL";
+  if (severity&PN_LEVEL_ERROR)    return "ERROR";
+  if (severity&PN_LEVEL_WARNING)  return "WARNING";
+  if (severity&PN_LEVEL_INFO)     return "INFO";
+  if (severity&PN_LEVEL_DEBUG)    return "DEBUG";
+  if (severity&PN_LEVEL_TRACE)    return "TRACE";
+  if (severity&PN_LEVEL_FRAME)    return "FRAME";
+  if (severity&PN_LEVEL_RAW)      return "RAW";
+  return "UNKNOWN";
+}
+
+const char *pn_logger_subsystem_name(pn_log_subsystem_t subsystem)
+{
+  if (subsystem==PN_SUBSYSTEM_ALL)    return "*ALL*";
+  if (subsystem&PN_SUBSYSTEM_IO)      return "IO";
+  if (subsystem&PN_SUBSYSTEM_EVENT)   return "EVENT";
+  if (subsystem&PN_SUBSYSTEM_AMQP)    return "AMQP";
+  if (subsystem&PN_SUBSYSTEM_SSL)     return "SSL";
+  if (subsystem&PN_SUBSYSTEM_SASL)    return "SASL";
+  if (subsystem&PN_SUBSYSTEM_BINDING) return "BINDING";
+  return "UNKNOWN";
+}
+
+pn_logger_t *pn_logger(void)
+{
+  pn_logger_t *l = (pn_logger_t*) malloc(sizeof(pn_logger_t));
+  pni_logger_init(l);
+  return l;
+}
+
+void pn_logger_free(pn_logger_t *logger)
+{
+  if (!logger) return;
+  pni_logger_fini(logger);
+  free(logger);
+}
+
+pn_logger_t *pn_default_logger(void)
+{
+  return &the_default_logger;
+}
+
+void pn_logger_set_mask(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity)
+{
+  logger->sev_mask = (pn_log_level_t) (logger->sev_mask | severity);
+  logger->sub_mask = (pn_log_subsystem_t) (logger->sub_mask | subsystem);
+}
+
+void pn_logger_reset_mask(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity)
+{
+  logger->sev_mask = (pn_log_level_t) (logger->sev_mask & ~severity);
+  logger->sub_mask = (pn_log_subsystem_t) (logger->sub_mask & ~subsystem);
+}
+
+void pn_logger_set_log_sink(pn_logger_t *logger, pn_log_sink_t sink, intptr_t sink_context)
+{
+  logger->sink = sink;
+  logger->sink_context = sink_context;
+}
+
+pn_log_sink_t pn_logger_get_log_sink(pn_logger_t *logger)
+{
+  return logger->sink;
+}
+
+intptr_t pn_logger_get_log_sink_context(pn_logger_t *logger)
+{
+  return logger->sink_context;
+}
+
+void pni_logger_log_data(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *msg, const char *bytes, size_t size)
+{
+  char buf[256];
+  ssize_t n = pn_quote_data(buf, 256, bytes, size);
+  if (n >= 0) {
+    pn_logger_logf(logger, subsystem, severity, "%s: %s", msg, buf);
+  } else if (n == PN_OVERFLOW) {
+    pn_logger_logf(logger, subsystem, severity, "%s: %s (truncated)", msg, buf);
+  } else {
+    pn_logger_logf(logger, subsystem, severity, "%s: cannot log data: %s", msg, pn_code(n));
+  }
+}
+
+void pni_logger_log(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *message)
+{
+  assert(logger);
+  logger->sink(logger->sink_context, subsystem, severity, message);
+}
+
+void pni_logger_vlogf(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *fmt, va_list ap)
+{
+  assert(logger);
+  pn_string_vformat(logger->scratch, fmt, ap);
+  pni_logger_log(logger, subsystem, severity, pn_string_get(logger->scratch));
+}
+
+void pn_logger_logf(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *fmt, ...)
+{
+  va_list ap;
+
+  va_start(ap, fmt);
+  pni_logger_vlogf(logger, subsystem, severity, fmt, ap);
+  va_end(ap);
+}

--- a/c/src/core/logger_private.h
+++ b/c/src/core/logger_private.h
@@ -1,0 +1,59 @@
+#ifndef LOGGER_PRIVATE_H
+#define LOGGER_PRIVATE_H
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <proton/logger.h>
+
+struct pn_logger_t {
+    pn_log_sink_t       sink;
+    intptr_t            sink_context;
+    pn_log_level_t   sev_mask;
+    pn_log_subsystem_t  sub_mask;
+    pn_string_t        *scratch;
+};
+
+void pni_init_default_logger(void);
+void pni_fini_default_logger(void);
+
+void pni_logger_init(pn_logger_t*);
+void pni_logger_fini(pn_logger_t*);
+
+void pni_logger_log(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *message);
+void pni_logger_vlogf(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *fmt, va_list ap);
+void pni_logger_log_data(pn_logger_t *logger, pn_log_subsystem_t subsystem, pn_log_level_t severity, const char *msg, const char *bytes, size_t size);
+
+#define PN_SHOULD_LOG(logger, subsys, sev) \
+    (((sev) & PN_LEVEL_CRITICAL) || (((logger)->sub_mask & (subsys)) && ((logger)->sev_mask & (sev))))
+
+#define PN_LOG(logger, subsys, sev, ...) \
+    do { \
+        if (PN_SHOULD_LOG(logger, subsys, sev)) \
+            pn_logger_logf(logger, (pn_log_subsystem_t) (subsys), (pn_log_level_t) (sev), __VA_ARGS__); \
+    } while(0)
+
+#define PN_LOG_DEFAULT(subsys, sev, ...) PN_LOG(pn_default_logger(), subsys, sev, __VA_ARGS__)
+
+#define PN_LOG_DATA(logger, subsys, sev, ...) \
+    do { \
+        if (PN_SHOULD_LOG(logger, subsys, sev)) \
+            pni_logger_log_data(logger, (pn_log_subsystem_t) (subsys), (pn_log_level_t) (sev), __VA_ARGS__); \
+    } while(0)
+
+#endif

--- a/c/src/proactor/epoll.c
+++ b/c/src/proactor/epoll.c
@@ -26,8 +26,8 @@
 /* Avoid GNU extensions, in particular the incompatible alternative strerror_r() */
 #undef _GNU_SOURCE
 
-#include "../core/log_private.h"
-#include "./proactor-internal.h"
+#include "core/logger_private.h"
+#include "proactor-internal.h"
 
 #include <proton/condition.h>
 #include <proton/connection_driver.h>
@@ -684,7 +684,7 @@ static inline bool proactor_has_event(pn_proactor_t *p) {
 
 static pn_event_t *log_event(void* p, pn_event_t *e) {
   if (e) {
-    pn_logf("[%p]:(%s)", (void*)p, pn_event_type_name(pn_event_type(e)));
+    PN_LOG_DEFAULT(PN_SUBSYSTEM_EVENT, PN_LEVEL_DEBUG, "[%p]:(%s)", (void*)p, pn_event_type_name(pn_event_type(e)));
   }
   return e;
 }
@@ -1387,7 +1387,7 @@ void pn_proactor_connect2(pn_proactor_t *p, pn_connection_t *c, pn_transport_t *
   assert(pc); // TODO: memory safety
   const char *err = pconnection_setup(pc, p, c, t, false, addr);
   if (err) {    /* TODO aconway 2017-09-13: errors must be reported as events */
-    pn_logf("pn_proactor_connect failure: %s", err);
+    PN_LOG_DEFAULT(PN_SUBSYSTEM_EVENT, PN_LEVEL_ERROR, "pn_proactor_connect failure: %s", err);
     return;
   }
   // TODO: check case of proactor shutting down
@@ -1796,7 +1796,7 @@ void pn_listener_accept2(pn_listener_t *l, pn_connection_t *c, pn_transport_t *t
   assert(pc); // TODO: memory safety
   const char *err = pconnection_setup(pc, pn_listener_proactor(l), c, t, true, "");
   if (err) {
-    pn_logf("pn_listener_accept failure: %s", err);
+    PN_LOG_DEFAULT(PN_SUBSYSTEM_EVENT, PN_LEVEL_ERROR, "pn_listener_accept failure: %s", err);
     return;
   }
   // TODO: fuller sanity check on input args

--- a/c/src/proactor/libuv.c
+++ b/c/src/proactor/libuv.c
@@ -24,7 +24,7 @@
 #define _POSIX_C_SOURCE 200809L
 #endif
 
-#include "../core/log_private.h"
+#include "core/logger_private.h"
 #include "proactor-internal.h"
 
 #include <proton/condition.h>
@@ -821,7 +821,7 @@ static pn_event_batch_t *proactor_batch_lh(pn_proactor_t *p, pn_event_type_t t) 
 
 static pn_event_t *log_event(void* p, pn_event_t *e) {
   if (e) {
-    pn_logf("[%p]:(%s)", (void*)p, pn_event_type_name(pn_event_type(e)));
+    PN_LOG_DEFAULT(PN_SUBSYSTEM_EVENT, PN_LEVEL_DEBUG, "[%p]:(%s)", (void*)p, pn_event_type_name(pn_event_type(e)));
   }
   return e;
 }

--- a/c/src/proactor/win_iocp.c
+++ b/c/src/proactor/win_iocp.c
@@ -44,7 +44,8 @@
 #include <iostream>
 #include <sstream>
 
-#include "./netaddr-internal.h" /* Include after socket/inet headers */
+#include "netaddr-internal.h" /* Include after socket/inet headers */
+#include "core/logger_private.h"
 
 /*
  * Proactor for Windows using IO completion ports.
@@ -1556,8 +1557,8 @@ iocp_t *pni_iocp()
 // Proton Proactor support
 // ======================================================================
 
-#include "../core/log_private.h"
-#include "./proactor-internal.h"
+#include "core/logger_private.h"
+#include "proactor-internal.h"
 
 class csguard {
   public:
@@ -2031,7 +2032,7 @@ static inline bool proactor_has_event(pn_proactor_t *p) {
 
 static pn_event_t *log_event(void* p, pn_event_t *e) {
   if (e) {
-    pn_logf("[%p]:(%s)", (void*)p, pn_event_type_name(pn_event_type(e)));
+    PN_LOG_DEFAULT(PN_SUBSYSTEM_EVENT, PN_LEVEL_DEBUG, "[%p]:(%s)", (void*)p, pn_event_type_name(pn_event_type(e)));
   }
   return e;
 }
@@ -2531,7 +2532,7 @@ static pn_event_batch_t *proactor_completion_loop(struct pn_proactor_t* p, bool 
     if (!good_op && !overlapped) {
       // Should never happen.  shutdown?
       // We aren't expecting a timeout, closed completion port, or other error here.
-      pn_logf("%s", errno_str("Windows Proton proactor internal failure\n", false).c_str());
+      PN_LOG_DEFAULT(PN_SUBSYSTEM_EVENT, PN_LEVEL_CRITICAL, "%s", errno_str("Windows Proton proactor internal failure\n", false).c_str());
       abort();
     }
 
@@ -2727,7 +2728,7 @@ void pn_proactor_connect2(pn_proactor_t *p, pn_connection_t *c, pn_transport_t *
   assert(pc); // TODO: memory safety
   const char *err = pconnection_setup(pc, p, c, t, false, addr);
   if (err) {
-    pn_logf("pn_proactor_connect failure: %s", err);
+    PN_LOG_DEFAULT(PN_SUBSYSTEM_EVENT, PN_LEVEL_ERROR, "pn_proactor_connect failure: %s", err);
     return;
   }
   // TODO: check case of proactor shutting down
@@ -3185,7 +3186,7 @@ void pn_listener_accept2(pn_listener_t *l, pn_connection_t *c, pn_transport_t *t
     assert(pc);  // TODO: memory safety
     const char *err_str = pconnection_setup(pc, p, c, t, true, "");
     if (err_str) {
-      pn_logf("pn_listener_accept failure: %s", err_str);
+      PN_LOG_DEFAULT(PN_SUBSYSTEM_EVENT, PN_LEVEL_ERROR, "pn_listener_accept failure: %s", err_str);
       return;
     }
     proactor_add(&pc->context);

--- a/c/src/sasl/cyrus_sasl.c
+++ b/c/src/sasl/cyrus_sasl.c
@@ -22,7 +22,7 @@
 #define _GNU_SOURCE
 #endif
 
-#include "core/log_private.h"
+#include "core/logger_private.h"
 
 #include "proton/sasl.h"
 #include "proton/sasl-plugin.h"
@@ -132,7 +132,7 @@ static void pni_cyrus_interact(pn_transport_t *transport, sasl_interact_t *inter
       break;
     }
     default:
-      pn_logf("(%s): %s - %s", i->challenge, i->prompt, i->defresult);
+      pnx_sasl_logf(transport, "(%s): %s - %s", i->challenge, i->prompt, i->defresult);
     }
   }
 }

--- a/c/tests/fuzz/fuzz-connection-driver.c
+++ b/c/tests/fuzz/fuzz-connection-driver.c
@@ -26,7 +26,7 @@
 
 #include "proton/connection_driver.h"
 #include "proton/engine.h"
-#include "proton/log.h"
+#include "proton/logger.h"
 #include "proton/message.h"
 
 #include "libFuzzingEngine.h"
@@ -56,7 +56,7 @@ const bool VERBOSE = false;
 const bool ERRORS = false;
 
 // I could not get rid of the error messages on stderr in any other way
-void devnull(pn_transport_t *transport, const char *message) {}
+void devnull(intptr_t context, pn_log_subsystem_t sub,  pn_log_level_t sev, const char *message) {}
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   if (VERBOSE)
@@ -71,10 +71,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     exit(1);
   }
 
-  pn_log_enable(false);
-  pn_log_logger(NULL);
-  pn_transport_trace(driver.transport, PN_TRACE_OFF);
-  pn_transport_set_tracer(driver.transport, devnull);
+  pn_logger_set_log_sink(pn_default_logger(), devnull, 0);
 
   uint8_t *data = (uint8_t *)Data;
   size_t size = Size;

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -133,7 +133,14 @@ class Configure(build_ext):
         macros += [('PROTON_DECLARE_STATIC', None)]
 
         if self.compiler_type=='msvc':
-            sources.append(os.path.join(proton_src, 'compiler' , 'msvc', 'snprintf.c'))
+            sources += [
+                os.path.join(proton_src, 'compiler', 'msvc', 'snprintf.c'),
+                os.path.join(proton_src, 'compiler', 'msvc', 'start.c')
+            ]
+        elif self.compiler_type=='unix':
+            sources += [
+                os.path.join(proton_src, 'compiler' , 'gcc', 'start.c')
+            ]
 
         # Check whether openssl is installed by poking
         # pkg-config for a minimum version 0. If it's installed, it should

--- a/python/tests/proton_tests/transport.py
+++ b/python/tests/proton_tests/transport.py
@@ -392,4 +392,4 @@ class LogTest(Test):
     t.log("one")
     t.log("two")
     t.log("three")
-    assert messages == [(t, "one"), (t, "two"), (t, "three")], messages
+    assert messages == [(t, "TRACE: one"), (t, "TRACE: two"), (t, "TRACE: three")], messages


### PR DESCRIPTION
See [PROTON-2131](https://issues.apache.org/jira/browse/PROTON-2131) for some of the problems this API seeks to solve.

This change
- Introduces a new type ```pn_logger_t``` which represents a logger
  - The library has a default logger this can be retrieved using ```pn_default_logger()```
    All new loggers will inherit their properties from the default logger at the point they are created. The default logger will also be used for any messages logged outside the context of an AMQP connection.
  - In the current proton code every ```pn_transport_t``` object also has a logger, which will be initialised from the default logger when the transport is created. All messages logged in the context of an AMQP connection will be logged to the connection's transport's logger.
    The transport's logger can be retreived using ```pn_transport_logger()```.

- Converted all uses in the Proton core library to use the new API
- Currently no higher language API bindings (Python/Ruby/C++)
- This introduces some portable library infrastructure to globally initialise/
  shutdown the library independent of it's clients.

