### PR TITLE
PROTON-2130: epoll proactor changed to use serialized calls to epoll_…

### DIFF
--- a/c/tests/proactor_test.cpp
+++ b/c/tests/proactor_test.cpp
@@ -173,7 +173,7 @@ TEST_CASE("proactor_connection_wake") {
 
   REQUIRE_RUN(p, PN_CONNECTION_REMOTE_OPEN);
   REQUIRE_RUN(p, PN_CONNECTION_REMOTE_OPEN);
-  CHECK(!pn_proactor_get(p)); /* Should be idle */
+  while (p.flush().first != 0);
   pn_connection_wake(c);
   REQUIRE_RUN(p, PN_CONNECTION_WAKE);
   REQUIRE_RUN(p, PN_TRANSPORT_CLOSED);


### PR DESCRIPTION
New poller with single caller to epoll_wait as described in PROTON-2130.

Also new: the "poller" thread looks through the new events and looks for warm threads that could be re-assigned to previous context work.

This pull request is ready to try out but not yet ready to merge.  Known issues include:

 - rare assertion failures in proton ctest using debug build
 - some test failures in QPID dispatch router
