### PR TITLE
PROTON-2147 on xcode10.1, openssl is in opt/openssl@11/, not in opt/openssl/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
   - os: osx
     osx_image: xcode10.1
     env:
-    - PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'
+    - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
     - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 -DBUILD_RUBY=NO -DBUILD_PYTHON=OFF -DBUILD_GO=ON'
     before_install:
@@ -54,7 +54,7 @@ matrix:
     - brew install libuv swig jsoncpp
 
 # Note addons is apt specific at the moment and will not be applied for osx.
-# See before_install brew commands below
+# See before_install brew commands above
 addons:
   apt:
     packages:
@@ -84,4 +84,3 @@ before_script:
 
 script:
 - cmake --build . --target install -- -j$(nproc) && ctest -V ${QPID_PROTON_CTEST_ARGS}
-


### PR DESCRIPTION
This is the minimal change that seems to resolve this.

I have another PR which uses the addons:homebrew:packages feature in .travis.yml, but making any larger change to dependencies on macOS seems to be a tarpit full of issues so far to me.