### PR TITLE
Memory usage tracking for proton-c

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -245,6 +245,7 @@ set (qpid-proton-core
   src/core/object/record.c
 
   src/core/init.c
+  src/core/memory.c
   src/core/logger.c
   src/core/util.c
   src/core/error.c

--- a/c/include/proton/cid.h
+++ b/c/include/proton/cid.h
@@ -40,8 +40,8 @@ typedef enum {
   CID_pn_collector,
   CID_pn_event,
 
-  CID_pn_encoder,   /* Unused */
-  CID_pn_decoder,   /* Unused */
+  CID_pn_buffer,
+  CID_pn_error,
   CID_pn_data,
 
   CID_pn_connection,
@@ -62,6 +62,7 @@ typedef enum {
   CID_pn_selectable,
 
   CID_pn_url,
+  CID_pn_strdup,
 
   CID_pn_listener,
   CID_pn_proactor,

--- a/c/include/proton/logger.h
+++ b/c/include/proton/logger.h
@@ -92,12 +92,13 @@ typedef struct pn_logger_t pn_logger_t;
  */
 typedef enum pn_log_subsystem_t {
     PN_SUBSYSTEM_NONE    = 0,    /**< No subsystem */
-    PN_SUBSYSTEM_IO      = 1,    /**< Low level Input/Output */
-    PN_SUBSYSTEM_EVENT   = 2,    /**< Events */
-    PN_SUBSYSTEM_AMQP    = 4,    /**< AMQP protocol processing */
-    PN_SUBSYSTEM_SSL     = 8,    /**< TLS/SSL protocol processing */
-    PN_SUBSYSTEM_SASL    = 16,   /**< SASL protocol processing */
-    PN_SUBSYSTEM_BINDING = 32,   /**< Language binding */
+    PN_SUBSYSTEM_MEMORY  = 1,    /**< Memory usage */
+    PN_SUBSYSTEM_IO      = 2,    /**< Low level Input/Output */
+    PN_SUBSYSTEM_EVENT   = 4,    /**< Events */
+    PN_SUBSYSTEM_AMQP    = 8,    /**< AMQP protocol processing */
+    PN_SUBSYSTEM_SSL     = 16,   /**< TLS/SSL protocol processing */
+    PN_SUBSYSTEM_SASL    = 32,   /**< SASL protocol processing */
+    PN_SUBSYSTEM_BINDING = 64,   /**< Language binding */
     PN_SUBSYSTEM_ALL     = 65535 /**< Every subsystem */
 } pn_log_subsystem_t; /* We hint to the compiler it can use 16 bits for this value */
 

--- a/c/src/core/engine.c
+++ b/c/src/core/engine.c
@@ -20,18 +20,20 @@
  */
 
 #include "engine-internal.h"
+
 #include "framing.h"
-#include <stdlib.h>
-#include <string.h>
+#include "memory.h"
+#include "platform/platform.h"
+#include "platform/platform_fmt.h"
 #include "protocol.h"
+#include "transport.h"
 
 #include <assert.h>
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 
-#include "platform/platform.h"
-#include "platform/platform_fmt.h"
-#include "transport.h"
 
 static void pni_session_bound(pn_session_t *ssn);
 static void pni_link_bound(pn_link_t *link);
@@ -209,7 +211,7 @@ void pn_condition_init(pn_condition_t *condition)
 }
 
 pn_condition_t *pn_condition() {
-  pn_condition_t *c = (pn_condition_t*)malloc(sizeof(pn_condition_t));
+  pn_condition_t *c = (pn_condition_t*)pni_mem_allocate(PN_VOID, sizeof(pn_condition_t));
   pn_condition_init(c);
   return c;
 }
@@ -225,7 +227,7 @@ void pn_condition_free(pn_condition_t *c) {
   if (c) {
     pn_condition_clear(c);
     pn_condition_tini(c);
-    free(c);
+    pni_mem_deallocate(PN_VOID, c);
   }
 }
 

--- a/c/src/core/error.c
+++ b/c/src/core/error.c
@@ -19,11 +19,14 @@
  *
  */
 
+#include <proton/error.h>
+#include <proton/object.h>
+
+#include "memory.h"
 #include "platform/platform.h"
 #include "util.h"
 
 #include <proton/connection.h>
-#include <proton/error.h>
 #include <proton/link.h>
 #include <proton/session.h>
 
@@ -36,9 +39,11 @@ struct pn_error_t {
   int code;
 };
 
+PN_STRUCT_CLASSDEF(pn_error)
+
 pn_error_t *pn_error()
 {
-  pn_error_t *error = (pn_error_t *) malloc(sizeof(pn_error_t));
+  pn_error_t *error = (pn_error_t *) pni_mem_allocate(PN_CLASSCLASS(pn_error), sizeof(pn_error_t));
   if (error != NULL) {
     error->code = 0;
     error->text = NULL;
@@ -49,8 +54,8 @@ pn_error_t *pn_error()
 void pn_error_free(pn_error_t *error)
 {
   if (error) {
-    free(error->text);
-    free(error);
+    pni_mem_subdeallocate(PN_CLASSCLASS(pn_error), error, error->text);
+    pni_mem_deallocate(PN_CLASSCLASS(pn_error), error);
   }
 }
 
@@ -58,7 +63,7 @@ void pn_error_clear(pn_error_t *error)
 {
   if (error) {
     error->code = 0;
-    free(error->text);
+    pni_mem_subdeallocate(PN_CLASSCLASS(pn_error), error, error->text);
     error->text = NULL;
   }
 }

--- a/c/src/core/memory.c
+++ b/c/src/core/memory.c
@@ -1,0 +1,278 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "core/memory.h"
+
+#ifdef PN_MEMDEBUG
+#include "logger_private.h"
+
+#include "proton/object.h"
+#include "proton/cid.h"
+
+#include <stdlib.h>
+
+#include <signal.h>
+
+// Non portable actual size of allocated block
+// malloc_usable_size() for glibc
+// _msize() for MSCRT
+// malloc_size() for BSDs
+#ifdef __GLIBC__
+#include <malloc.h>
+#define msize malloc_usable_size
+#elif defined(_WIN32)
+#include <malloc.h>
+#define msize _msize
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+#include <malloc/malloc.h>
+#define msize malloc_size
+#else
+#define msize(x) (0)
+#endif
+
+static struct stats {
+  const char* name;
+  size_t count_alloc;
+  size_t count_dealloc;
+  size_t requested;
+  size_t alloc;
+  size_t dealloc;
+  size_t count_suballoc;
+  size_t count_subrealloc;
+  size_t count_subdealloc;
+  size_t subrequested;
+  size_t suballoc;
+  size_t subdealloc;
+} stats[CID_pn_listener_socket+1] = {{0}}; // Just happens to be the last CID
+
+static bool debug_memory = false;
+
+// Hidden export
+PN_EXTERN void pn_mem_dump_stats(void);
+
+// Dump out memory use
+void pn_mem_dump_stats(void)
+{
+  pn_logger_t *logger = pn_default_logger();
+
+  size_t total_alloc = 0;
+  size_t total_dealloc = 0;
+  size_t count_alloc = 0;
+  size_t count_dealloc = 0;
+
+  if (PN_SHOULD_LOG(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_DEBUG)) {
+    pn_logger_logf(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_DEBUG, "Memory allocation stats:");
+    pn_logger_logf(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_DEBUG, "%15s:          %5s %5s %5s %9s %9s",
+                   "class", "alloc", "free", "rallc", "bytes alloc", "bytes free"
+    );
+  }
+  for (int i = 1; i<=CID_pn_listener_socket; i++) {
+    struct stats *entry = &stats[i];
+    count_alloc += entry->count_alloc+entry->count_suballoc;
+    count_dealloc += entry->count_dealloc+entry->count_subdealloc;
+    total_alloc += entry->alloc+entry->suballoc;
+    total_dealloc += entry->dealloc+entry->subdealloc;
+    if (entry->name && PN_SHOULD_LOG(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_DEBUG)) {
+      pn_logger_logf(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_DEBUG, "%15s:   direct %5d %5d       %9d %9d",
+                     entry->name,
+                     entry->count_alloc, entry->count_dealloc,
+                     entry->alloc, entry->dealloc
+      );
+      pn_logger_logf(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_DEBUG, "%15s: indirect %5d %5d %5d %9d %9d",
+                     entry->name,
+                     entry->count_suballoc, entry->count_subdealloc, entry->count_subrealloc,
+                     entry->suballoc, entry->subdealloc
+      );
+    }
+  }
+
+  if (!PN_SHOULD_LOG(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_INFO)) return;
+
+  pn_logger_logf(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_INFO, "%15s:        %7d %5d       %9d %9d",
+                 "Totals", count_alloc, count_dealloc, total_alloc, total_dealloc
+  );
+}
+
+#ifdef _WIN32
+void pni_mem_setup_logging(void)
+{
+}
+#else
+static void pn_mem_dump_stats_int(int i)
+{
+  pn_logger_t *logger = pn_default_logger();
+  pn_logger_t save = *logger;
+
+  pn_logger_set_mask(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_DEBUG | PN_LEVEL_INFO);
+
+  pn_mem_dump_stats();
+
+  *logger = save;
+}
+
+void pni_mem_setup_logging(void)
+{
+  debug_memory = true;
+  signal(SIGUSR1, pn_mem_dump_stats_int);
+}
+#endif
+
+void pni_init_memory(void)
+{
+}
+
+void pni_fini_memory(void)
+{
+  pn_logger_t *logger = pn_default_logger();
+  pn_logger_t save = *logger;
+
+  if (debug_memory)
+    pn_logger_set_mask(logger, PN_SUBSYSTEM_MEMORY, PN_LEVEL_DEBUG | PN_LEVEL_INFO);
+
+  pn_mem_dump_stats();
+
+  *logger = save;
+}
+
+static inline struct stats *pni_track_common(const pn_class_t *clazz, void *o, size_t *size)
+{
+  struct stats *entry = &stats[pn_class_id(clazz)];
+  if (!entry->name) {entry->name = pn_class_name(clazz);}
+  *size = msize(o);
+  return entry;
+}
+
+static void pni_track_alloc(const pn_class_t *clazz, void *o, size_t requested)
+{
+  size_t size;
+  struct stats *entry = pni_track_common(clazz, o, &size);
+
+  entry->count_alloc++;
+  entry->alloc += size;
+  entry->requested += requested;
+}
+
+static void pni_track_dealloc(const pn_class_t *clazz, void *o)
+{
+  size_t size;
+  struct stats *entry = pni_track_common(clazz, o, &size);
+
+  entry->count_dealloc++;
+  entry->dealloc += size;
+}
+
+static void pni_track_suballoc(const pn_class_t *clazz, void *o, size_t requested)
+{
+  size_t size;
+  struct stats *entry = pni_track_common(clazz, o, &size);
+
+  entry->count_suballoc++;
+  entry->subrequested = requested;
+  entry->suballoc += size;
+}
+
+static void pni_track_subdealloc(const pn_class_t *clazz, void *o)
+{
+  size_t size;
+  struct stats *entry = pni_track_common(clazz, o, &size);
+
+  entry->count_subdealloc++;
+  entry->subdealloc += size;
+}
+
+static void pni_track_subrealloc(const pn_class_t *clazz, void *o, size_t oldsize, size_t requested)
+{
+  size_t size;
+  struct stats *entry = pni_track_common(clazz, o, &size);
+
+  if (oldsize) {
+    entry->count_subrealloc++;
+  } else {
+    entry->count_suballoc++;
+  }
+
+  int change = size - oldsize;
+  if (change > 0) entry->suballoc += change;
+  if (change < 0) entry->subdealloc += -change;
+}
+
+void *pni_mem_zallocate(const pn_class_t *clazz, size_t size)
+{
+  void *o = calloc(1, size);
+  pni_track_alloc(clazz, o, size);
+  return o;
+}
+
+void *pni_mem_allocate(const pn_class_t *clazz, size_t size)
+{
+  void * o = malloc(size);
+  pni_track_alloc(clazz, o, size);
+  return o;
+}
+
+void pni_mem_deallocate(const pn_class_t *clazz, void *object)
+{
+  if (!object) return;
+  pni_track_dealloc(clazz, object);
+  free(object);
+}
+
+void *pni_mem_suballocate(const pn_class_t *clazz, void *object, size_t size)
+{
+  void * o = malloc(size);
+  pni_track_suballoc(clazz, o, size);
+  return o;
+}
+
+void *pni_mem_subreallocate(const pn_class_t *clazz, void *object, void *buffer, size_t size)
+{
+  size_t oldsize = buffer ? msize(buffer) : 0;
+  void *o = realloc(buffer, size);
+  pni_track_subrealloc(clazz, o, oldsize, size);
+  return o;
+}
+
+void pni_mem_subdeallocate(const pn_class_t *clazz, void *object, void *buffer)
+{
+  if (!buffer) return;
+  pni_track_subdealloc(clazz, buffer);
+  free(buffer);
+}
+#else
+
+// Versions with no memory debugging - so we can compile with no performance penalty
+
+#include <stdlib.h>
+
+void pni_init_memory(void) {}
+void pni_fini_memory(void) {}
+
+void pni_mem_setup_logging(void) {}
+
+void *pni_mem_allocate(const pn_class_t *clazz, size_t size) { return malloc(size); }
+void *pni_mem_zallocate(const pn_class_t *clazz, size_t size) { return calloc(1, size); }
+void pni_mem_deallocate(const pn_class_t *clazz, void *object) { free(object); }
+
+void *pni_mem_suballocate(const pn_class_t *clazz, void *object, size_t size) { return malloc(size); }
+void *pni_mem_subreallocate(const pn_class_t *clazz, void *object, void *buffer, size_t size) { return realloc(buffer, size); }
+void pni_mem_subdeallocate(const pn_class_t *clazz, void *object, void *buffer) { free(buffer); }
+
+#endif

--- a/c/src/core/memory.h
+++ b/c/src/core/memory.h
@@ -1,4 +1,8 @@
+#ifndef MEMORY_H
+#define MEMORY_H 1
+
 /*
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,19 +19,24 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
  */
 
-#include "core/logger_private.h"
-#include "core/memory.h"
+#include <proton/object.h>
 
-void pn_init(void)
-{
-  pni_init_default_logger();
-  pni_init_memory();
-}
+#include <stddef.h>
 
-void pn_fini(void)
-{
-  pni_fini_memory();
-  pni_fini_default_logger();
-}
+void pni_init_memory(void);
+void pni_fini_memory(void);
+
+void pni_mem_setup_logging(void);
+
+void *pni_mem_allocate(const pn_class_t *clazz, size_t size);
+void *pni_mem_zallocate(const pn_class_t *clazz, size_t size);
+void pni_mem_deallocate(const pn_class_t *clazz, void *object);
+
+void *pni_mem_suballocate(const pn_class_t *clazz, void *object, size_t size);
+void *pni_mem_subreallocate(const pn_class_t *clazz, void *object, void *buffer, size_t size);
+void pni_mem_subdeallocate(const pn_class_t *clazz, void *object, void *buffer);
+
+#endif // MEMORY_H

--- a/c/src/core/object/iterator.c
+++ b/c/src/core/object/iterator.c
@@ -20,6 +20,9 @@
  */
 
 #include <proton/object.h>
+
+#include "core/memory.h"
+
 #include <stdlib.h>
 #include <assert.h>
 
@@ -40,7 +43,7 @@ static void pn_iterator_initialize(void *object)
 static void pn_iterator_finalize(void *object)
 {
   pn_iterator_t *it = (pn_iterator_t *) object;
-  free(it->state);
+  pni_mem_subdeallocate(pn_class(object), object, it->state);
 }
 
 #define CID_pn_iterator CID_pn_object
@@ -61,7 +64,7 @@ void  *pn_iterator_start(pn_iterator_t *iterator, pn_iterator_next_t next,
   assert(next);
   iterator->next = next;
   if (iterator->size < size) {
-    iterator->state = realloc(iterator->state, size);
+    iterator->state = pni_mem_subreallocate(pn_class(iterator), iterator, iterator->state, size);
   }
   return iterator->state;
 }

--- a/c/src/core/object/map.c
+++ b/c/src/core/object/map.c
@@ -20,7 +20,10 @@
  */
 
 #include <proton/object.h>
-#include <stdlib.h>
+
+#include "core/memory.h"
+
+#include <stddef.h>
 #include <assert.h>
 
 #define PNI_ENTRY_FREE (0)
@@ -57,7 +60,7 @@ static void pn_map_finalize(void *object)
     }
   }
 
-  free(map->entries);
+  pni_mem_subdeallocate(pn_class(map), map, map->entries);
 }
 
 static uintptr_t pn_map_hashcode(void *object)
@@ -79,7 +82,7 @@ static uintptr_t pn_map_hashcode(void *object)
 
 static void pni_map_allocate(pn_map_t *map)
 {
-  map->entries = (pni_entry_t *) malloc(map->capacity * sizeof (pni_entry_t));
+  map->entries = (pni_entry_t *) pni_mem_suballocate(pn_class(map), map, map->capacity * sizeof (pni_entry_t));
   if (map->entries != NULL) {
     for (size_t i = 0; i < map->capacity; i++) {
       map->entries[i].key = NULL;
@@ -183,7 +186,7 @@ static bool pni_map_ensure(pn_map_t *map, size_t capacity)
     }
   }
 
-  free(entries);
+  pni_mem_subdeallocate(pn_class(map), map, entries);
   return true;
 }
 

--- a/c/src/core/object/record.c
+++ b/c/src/core/object/record.c
@@ -20,7 +20,10 @@
  */
 
 #include <proton/object.h>
-#include <stdlib.h>
+
+#include "core/memory.h"
+
+#include <stddef.h>
 #include <assert.h>
 
 typedef struct {
@@ -50,7 +53,7 @@ static void pn_record_finalize(void *object)
     pni_field_t *v = &record->fields[i];
     pn_class_decref(v->clazz, v->value);
   }
-  free(record->fields);
+  pni_mem_subdeallocate(pn_class(record), record, record->fields);
 }
 
 #define pn_record_hashcode NULL
@@ -78,7 +81,7 @@ static pni_field_t *pni_record_find(pn_record_t *record, pn_handle_t key) {
 static pni_field_t *pni_record_create(pn_record_t *record) {
   record->size++;
   if (record->size > record->capacity) {
-    record->fields = (pni_field_t *) realloc(record->fields, record->size * sizeof(pni_field_t));
+    record->fields = (pni_field_t *) pni_mem_subreallocate(pn_class(record), record, record->fields, record->size * sizeof(pni_field_t));
     record->capacity = record->size;
   }
   pni_field_t *field = &record->fields[record->size - 1];

--- a/c/src/core/util.c
+++ b/c/src/core/util.c
@@ -19,8 +19,10 @@
  *
  */
 
-#include "buffer.h"
 #include "util.h"
+
+#include "buffer.h"
+#include "memory.h"
 
 #include <proton/error.h>
 #include <proton/types.h>
@@ -28,7 +30,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
-#include <stdlib.h>
+#include <stddef.h>
 #include <ctype.h>
 #include <string.h>
 
@@ -112,10 +114,12 @@ bool pn_env_bool(const char *name)
                !pn_strcasecmp(v, "yes")  || !pn_strcasecmp(v, "on"));
 }
 
+PN_STRUCT_CLASSDEF(pn_strdup)
+
 char *pn_strdup(const char *src)
 {
   if (!src) return NULL;
-  char *dest = (char *) malloc(strlen(src)+1);
+  char *dest = (char *) pni_mem_allocate(PN_CLASSCLASS(pn_strdup), strlen(src)+1);
   if (!dest) return NULL;
   return strcpy(dest, src);
 }
@@ -128,7 +132,7 @@ char *pn_strndup(const char *src, size_t n)
       size++;
     }
 
-    char *dest = (char *) malloc(size + 1);
+    char *dest = (char *) pni_mem_allocate(PN_CLASSCLASS(pn_strdup), size + 1);
     if (!dest) return NULL;
     strncpy(dest, src, pn_min(n, size));
     dest[size] = '\0';

--- a/c/src/core/util.h
+++ b/c/src/core/util.h
@@ -39,8 +39,10 @@ int pn_quote(pn_string_t *dst, const char *src, size_t size);
 bool pn_env_bool(const char *name);
 pn_timestamp_t pn_timestamp_min(pn_timestamp_t a, pn_timestamp_t b);
 
+extern const pn_class_t PN_CLASSCLASS(pn_strdup)[];
 char *pn_strdup(const char *src);
 char *pn_strndup(const char *src, size_t n);
+
 int pn_strcasecmp(const char* a, const char* b);
 int pn_strncasecmp(const char* a, const char* b, size_t len);
 

--- a/c/tests/fuzz/CMakeLists.txt
+++ b/c/tests/fuzz/CMakeLists.txt
@@ -56,7 +56,7 @@ pn_add_fuzz_test (fuzz-connection-driver fuzz-connection-driver.c)
 pn_add_fuzz_test (fuzz-message-decode fuzz-message-decode.c)
 
 # pn_url_parse is not in proton core and is only used by messenger so compile specially
-pn_add_fuzz_test (fuzz-url fuzz-url.c ${PN_C_SOURCE_DIR}/extra/url.c  ${PN_C_SOURCE_DIR}/core/util.c)
+pn_add_fuzz_test (fuzz-url fuzz-url.c ${PN_C_SOURCE_DIR}/extra/url.c  ${PN_C_SOURCE_DIR}/core/util.c ${PN_C_SOURCE_DIR}/core/memory.c)
 target_compile_definitions(fuzz-url PRIVATE PROTON_DECLARE_STATIC)
 
 # This regression test can take a very long time so don't run by default


### PR DESCRIPTION
This code is preliminary code to allow tracking of memory use in proton-c by class of memory object being used.

It tracks the various classes of memory allocated by proton-c - the number of allocations/deallocation & sizes of these for each individual memory class.

It tracks separately the memory used in the object instances themselves - direct memory and memory allocated in variable buffers by the objects - indirect memory use. For some classes of memory the direct/indirect distinction is not that clear and this code does the best it can without undue overhead.

This system is attached to the newly introduced logging system and memory usage stats will be dumped using the logger on program exit. Details appear in the DEBUG level and the summary in the INFO level. The application can request a memory dump by calling `pn_mem_dump_stats()`.

Memory tracing can be made *more* active by adding "memory" to the PN_LOG environment variable. In this case it will dump memory stats when SIGUSR1 is sent to the process - this is only on Linux or similar as there is no equivalent on Windows.

The code works well enough for basic tracking where the memory goes, however it has 2 ares that need further work before it can be safely merged to master:
* A measure of the performance impact - this code intercepts the memory allocation/deallocation paths so is potentially used a lot. It uses a single table to hold its stats so this might be a caching bottleneck in a big multi threaded application.
* There is currently no attempt to ensure that the stats update is thread safe - this could in theory lead to inconsistent updates of the stats. Making this correct either requires locking the operations, using atomic operations or keeping a stats table per thread. All of these options potentially have a (perhaps significant) performance impact.

The related issue is [PROTON-2144](https://issues.apache.org/jira/projects/PROTON/issues/PROTON-2144)