### PR TITLE
PROTON-2167 Upgrade macOS images in .travis.yml and exclude failing ruby and python tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,29 +34,22 @@ matrix:
     - bash <(curl -s https://codecov.io/bash)
 
   - os: osx
-    osx_image: xcode8.3
-    env:
-    - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
-    - PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'
-    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DBUILD_RUBY=NO -DBUILD_GO=OFF'
-    before_install:
-    # addons:homebrew:packages is slow and hard to get right on older macOS travis images
-    - brew update
-    - brew install libuv swig jsoncpp
-
-  - os: osx
-    osx_image: xcode10.1
+    osx_image: xcode9.4
     env:
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
     - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'
-    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 -DBUILD_RUBY=NO -DBUILD_PYTHON=OFF -DBUILD_GO=ON'
-    addons:
-      # macOS Homebrew dependencies, https://formulae.brew.sh/
-      homebrew:
-        packages:
-        - jsoncpp
-        - libuv
-        - swig
+    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 -DBUILD_GO=OFF'
+    # python-tox-test segfaults and ruby tests do not start due to dynamic library issues
+    - QPID_PROTON_CTEST_ARGS="--exclude-regex 'python-tox-test|ruby.*'"
+
+  - os: osx
+    osx_image: xcode11.3
+    env:
+    - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
+    - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'
+    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 -DBUILD_GO=ON'
+    # python-tox-test segfaults and ruby tests do not start due to dynamic library issues
+    - QPID_PROTON_CTEST_ARGS="--exclude-regex 'python-tox-test|ruby.*'"
 
 addons:
   # Ubuntu 16.04 APT dependencies, https://packages.ubuntu.com/
@@ -75,6 +68,12 @@ addons:
     - golang
     - lcov
     - libjsoncpp-dev
+  # macOS Homebrew dependencies, https://formulae.brew.sh/
+  homebrew:
+    packages:
+      - jsoncpp
+      - libuv
+      - swig
 
 install:
 - python -m pip install --user --upgrade pip
@@ -87,4 +86,4 @@ before_script:
 - cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/install ${QPID_PROTON_CMAKE_ARGS}
 
 script:
-- cmake --build . --target install -- -j$(nproc) && ctest -V ${QPID_PROTON_CTEST_ARGS}
+- cmake --build . --target install -- -j$(nproc) && eval ctest -V ${QPID_PROTON_CTEST_ARGS}


### PR DESCRIPTION
Without the test excludes, these are the failures in logs

ruby:

```
30: /Users/travis/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': incompatible library version - /Users/travis/build/jdanekrh/qpid-proton/build/ruby/cproton.bundle (LoadError)

30: 	from /Users/travis/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'

30: 	from /Users/travis/build/jdanekrh/qpid-proton/ruby/lib/qpid_proton.rb:19:in `<top (required)>'

30: 	from /Users/travis/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'

30: 	from /Users/travis/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'

30: 	from /Users/travis/build/jdanekrh/qpid-proton/ruby/tests/test_tools.rb:22:in `<top (required)>'

30: 	from /Users/travis/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'

30: 	from /Users/travis/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'

30: 	from /Users/travis/build/jdanekrh/qpid-proton/ruby/tests/test_container.rb:19:in `<main>'

30/44 Test #30: ruby-test-container ..............***Failed    0.29 sec
```

Python:

```
27: proton_tests.handler.HandlerTest.test_add_handler .......................ERROR: InvocationError for command /Users/travis/build/jdanekrh/qpid-proton/build/python/.tox/py27/bin/python /Users/travis/build/jdanekrh/qpid-proton/python/tests/proton-test --ignore-file=/Users/travis/build/jdanekrh/qpid-proton/python/tests/tox-blacklist (exited with code -11 (SIGSEGV)) (exited with code -11)

...

27: py37 installed: linecache2==1.0.0,python-qpid-proton==0.31.0,six==1.14.0,traceback2==1.4.0,unittest2==1.1.0

27: py37 run-test-pre: PYTHONHASHSEED='774661195'

27: py37 run-test: commands[0] | python /Users/travis/build/jdanekrh/qpid-proton/python/tests/proton-test --ignore-file=/Users/travis/build/jdanekrh/qpid-proton/python/tests/tox-blacklist

27: Traceback (most recent call last):

27:   File "/Users/travis/build/jdanekrh/qpid-proton/python/tests/proton-test", line 24, in <module>

27:     from proton_tests.main import main

27:   File "/Users/travis/build/jdanekrh/qpid-proton/python/tests/proton_tests/__init__.py", line 22, in <module>

27:     from . import codec

27:   File "/Users/travis/build/jdanekrh/qpid-proton/python/tests/proton_tests/codec.py", line 25, in <module>

27:     from proton import *

27:   File "/Users/travis/build/jdanekrh/qpid-proton/build/python/.tox/py37/lib/python3.7/site-packages/proton/__init__.py", line 35, in <module>

27:     from cproton import PN_VERSION_MAJOR, PN_VERSION_MINOR, PN_VERSION_POINT

27:   File "/Users/travis/build/jdanekrh/qpid-proton/build/python/.tox/py37/lib/python3.7/site-packages/cproton.py", line 15, in <module>

27:     import _cproton

27: ImportError: dlopen(/Users/travis/build/jdanekrh/qpid-proton/build/python/.tox/py37/lib/python3.7/site-packages/_cproton.cpython-37m-darwin.so, 2): Symbol not found: _DH_set0_pqg

27:   Referenced from: /Users/travis/build/jdanekrh/qpid-proton/build/python/.tox/py37/lib/python3.7/site-packages/_cproton.cpython-37m-darwin.so

27:   Expected in: flat namespace

27:  in /Users/travis/build/jdanekrh/qpid-proton/build/python/.tox/py37/lib/python3.7/site-packages/_cproton.cpython-37m-darwin.so

27: ERROR: InvocationError for command /Users/travis/build/jdanekrh/qpid-proton/build/python/.tox/py37/bin/python /Users/travis/build/jdanekrh/qpid-proton/python/tests/proton-test --ignore-file=/Users/travis/build/jdanekrh/qpid-proton/python/tests/tox-blacklist (exited with code 1)

...

27/44 Test #27: python-tox-test ..................***Failed  Error regular expression found in output. Regex=[ERROR:[ ]+py[0-9]*: commands failed] 46.38 sec
```