### PR TITLE
PROTON-2200 Fix memory leak in go message unmarshal

### DIFF
--- a/go/pkg/amqp/message.go
+++ b/go/pkg/amqp/message.go
@@ -326,6 +326,7 @@ func (m *message) Marshal(v interface{}) { m.body = v }
 
 func (m *message) Unmarshal(v interface{}) {
 	pnData := C.pn_data(2)
+	defer C.pn_data_free(pnData)
 	marshal(m.body, pnData)
 	unmarshal(v, pnData)
 }


### PR DESCRIPTION
When using this library in an application to receive messages from QPID, we found our containers were getting OOM killed in kubernetes. 

This fixes the memory leak we uncovered.