### PR TITLE
WIP: update incorrect variable lengths in proton generator code

### DIFF
--- a/go/genwrap.go
+++ b/go/genwrap.go
@@ -43,11 +43,11 @@ import (
 	"text/template"
 )
 
-// Note last code generation was from 0.27 source, but we should still
+// Note last code generation was from 0.31 source, but we should still
 // be binary compatible back to 0.10. Only change was the type name
 // for pn_proton_tick() from pn_timestamp_t to int64_t, identical type.
 
-var minVersion = "0.27" // The proton-c header version last used to generate code
+var minVersion = "0.31" // The proton-c header version last used to generate code
 
 var include = flag.String("include", "../c/include", "Directory containing proton/*.h include files")
 
@@ -94,10 +94,10 @@ package amqp
 
 // #include <proton/version.h>
 // #if PN_VERSION_MAJOR == %s && PN_VERSION_MINOR < %s
-// #error module github.com/apache/qpid-proton requires Proton-C library version 0.10 or greater
+// #error module github.com/apache/qpid-proton requires Proton-C library version %s.%s or greater
 // #endif
 import "C"
-`, splitVersion[0], splitVersion[1])
+`, splitVersion[0], splitVersion[1], splitVersion[0], splitVersion[1])
 }
 
 func genWrappers() {
@@ -352,15 +352,15 @@ func mapType(ctype string) (g genType) {
 	case "C.int64_t":
 		g.Gotype = "int64"
 	case "C.int32_t":
-		g.Gotype = "int16"
-	case "C.int16_t":
 		g.Gotype = "int32"
+	case "C.int16_t":
+		g.Gotype = "int16"
 	case "C.uint64_t":
 		g.Gotype = "uint64"
 	case "C.uint32_t":
-		g.Gotype = "uint16"
-	case "C.uint16_t":
 		g.Gotype = "uint32"
+	case "C.uint16_t":
+		g.Gotype = "uint16"
 	case "C.const char *":
 		fallthrough
 	case "C.char *":

--- a/go/pkg/amqp/version.go
+++ b/go/pkg/amqp/version.go
@@ -22,16 +22,14 @@ under the License.
 // Update the generator and re-run if you need to modify this code.
 //
 
+
 package amqp
 
-// Version check for compatible proton-c library.
-//
-// NOTE: the required version should NOT be increased unless the Go
-// library is modified to require some new proton-c API. That hasn't
-// happened for a long time.
+// Version check for proton library.
+// Done here because this is the lowest-level dependency for all the proton Go packages.
 
 // #include <proton/version.h>
-// #if PN_VERSION_MAJOR == 0 && PN_VERSION_MINOR < 10
-// #error packages qpid.apache.org/... require Proton-C library version 0.10 or greater
+// #if PN_VERSION_MAJOR == 0 && PN_VERSION_MINOR < 31
+// #error module github.com/apache/qpid-proton requires Proton-C library version 0.31 or greater
 // #endif
 import "C"

--- a/go/pkg/proton/wrappers_gen.go
+++ b/go/pkg/proton/wrappers_gen.go
@@ -467,10 +467,10 @@ func (d Disposition) Condition() Condition {
 func (d Disposition) Data() Data {
 	return Data{C.pn_disposition_data(d.pn)}
 }
-func (d Disposition) SectionNumber() uint16 {
-	return uint16(C.pn_disposition_get_section_number(d.pn))
+func (d Disposition) SectionNumber() uint32 {
+	return uint32(C.pn_disposition_get_section_number(d.pn))
 }
-func (d Disposition) SetSectionNumber(section_number uint16) {
+func (d Disposition) SetSectionNumber(section_number uint32) {
 	C.pn_disposition_set_section_number(d.pn, C.uint32_t(section_number))
 }
 func (d Disposition) SectionOffset() uint64 {
@@ -813,6 +813,9 @@ func (t Transport) IsEncrypted() bool {
 func (t Transport) Condition() Condition {
 	return Condition{C.pn_transport_condition(t.pn)}
 }
+func (t Transport) Logger() Logger {
+	return Logger{C.pn_transport_logger(t.pn)}
+}
 func (t Transport) Error() error {
 	return PnError(C.pn_transport_error(t.pn))
 }
@@ -828,23 +831,23 @@ func (t Transport) Log(message string) {
 
 	C.pn_transport_log(t.pn, messageC)
 }
-func (t Transport) ChannelMax() uint32 {
-	return uint32(C.pn_transport_get_channel_max(t.pn))
+func (t Transport) ChannelMax() uint16 {
+	return uint16(C.pn_transport_get_channel_max(t.pn))
 }
-func (t Transport) SetChannelMax(channel_max uint32) int {
+func (t Transport) SetChannelMax(channel_max uint16) int {
 	return int(C.pn_transport_set_channel_max(t.pn, C.uint16_t(channel_max)))
 }
-func (t Transport) RemoteChannelMax() uint32 {
-	return uint32(C.pn_transport_remote_channel_max(t.pn))
+func (t Transport) RemoteChannelMax() uint16 {
+	return uint16(C.pn_transport_remote_channel_max(t.pn))
 }
-func (t Transport) MaxFrame() uint16 {
-	return uint16(C.pn_transport_get_max_frame(t.pn))
+func (t Transport) MaxFrame() uint32 {
+	return uint32(C.pn_transport_get_max_frame(t.pn))
 }
-func (t Transport) SetMaxFrame(size uint16) {
+func (t Transport) SetMaxFrame(size uint32) {
 	C.pn_transport_set_max_frame(t.pn, C.uint32_t(size))
 }
-func (t Transport) RemoteMaxFrame() uint16 {
-	return uint16(C.pn_transport_get_remote_max_frame(t.pn))
+func (t Transport) RemoteMaxFrame() uint32 {
+	return uint32(C.pn_transport_get_remote_max_frame(t.pn))
 }
 func (t Transport) IdleTimeout() time.Duration {
 	return (time.Duration(C.pn_transport_get_idle_timeout(t.pn)) * time.Millisecond)


### PR DESCRIPTION
Some of the mappings from C types to Go types were incorrect. This fixes those mappings and updates the generated wrapper.

Also update the error message to use the compiled version, rather than a hard coded value.

(Not sure that I needed to bump the proton-c header version)