### PR TITLE
Fix variable lengths in go wrapper for proton 

### DIFF
--- a/go/genwrap.go
+++ b/go/genwrap.go
@@ -94,10 +94,10 @@ package amqp
 
 // #include <proton/version.h>
 // #if PN_VERSION_MAJOR == %s && PN_VERSION_MINOR < %s
-// #error packages qpid.apache.org/... require Proton-C library version 0.10 or greater
+// #error packages qpid.apache.org/... require Proton-C library version %s.%s or greater
 // #endif
 import "C"
-`, splitVersion[0], splitVersion[1])
+`, splitVersion[0], splitVersion[1], splitVersion[0], splitVersion[1])
 }
 
 func genWrappers() {
@@ -352,15 +352,15 @@ func mapType(ctype string) (g genType) {
 	case "C.int64_t":
 		g.Gotype = "int64"
 	case "C.int32_t":
-		g.Gotype = "int16"
-	case "C.int16_t":
 		g.Gotype = "int32"
+	case "C.int16_t":
+		g.Gotype = "int16"
 	case "C.uint64_t":
 		g.Gotype = "uint64"
 	case "C.uint32_t":
-		g.Gotype = "uint16"
-	case "C.uint16_t":
 		g.Gotype = "uint32"
+	case "C.uint16_t":
+		g.Gotype = "uint16"
 	case "C.const char *":
 		fallthrough
 	case "C.char *":

--- a/go/src/qpid.apache.org/amqp/version.go
+++ b/go/src/qpid.apache.org/amqp/version.go
@@ -30,6 +30,6 @@ package amqp
 
 // #include <proton/version.h>
 // #if PN_VERSION_MAJOR == 0 && PN_VERSION_MINOR < 27
-// #error packages qpid.apache.org/... require Proton-C library version 0.10 or greater
+// #error packages qpid.apache.org/... require Proton-C library version 0.27 or greater
 // #endif
 import "C"

--- a/go/src/qpid.apache.org/proton/wrappers_gen.go
+++ b/go/src/qpid.apache.org/proton/wrappers_gen.go
@@ -467,10 +467,10 @@ func (d Disposition) Condition() Condition {
 func (d Disposition) Data() Data {
 	return Data{C.pn_disposition_data(d.pn)}
 }
-func (d Disposition) SectionNumber() uint16 {
-	return uint16(C.pn_disposition_get_section_number(d.pn))
+func (d Disposition) SectionNumber() uint32 {
+	return uint32(C.pn_disposition_get_section_number(d.pn))
 }
-func (d Disposition) SetSectionNumber(section_number uint16) {
+func (d Disposition) SetSectionNumber(section_number uint32) {
 	C.pn_disposition_set_section_number(d.pn, C.uint32_t(section_number))
 }
 func (d Disposition) SectionOffset() uint64 {
@@ -828,23 +828,23 @@ func (t Transport) Log(message string) {
 
 	C.pn_transport_log(t.pn, messageC)
 }
-func (t Transport) ChannelMax() uint32 {
-	return uint32(C.pn_transport_get_channel_max(t.pn))
+func (t Transport) ChannelMax() uint16 {
+	return uint16(C.pn_transport_get_channel_max(t.pn))
 }
-func (t Transport) SetChannelMax(channel_max uint32) int {
+func (t Transport) SetChannelMax(channel_max uint16) int {
 	return int(C.pn_transport_set_channel_max(t.pn, C.uint16_t(channel_max)))
 }
-func (t Transport) RemoteChannelMax() uint32 {
-	return uint32(C.pn_transport_remote_channel_max(t.pn))
+func (t Transport) RemoteChannelMax() uint16 {
+	return uint16(C.pn_transport_remote_channel_max(t.pn))
 }
-func (t Transport) MaxFrame() uint16 {
-	return uint16(C.pn_transport_get_max_frame(t.pn))
+func (t Transport) MaxFrame() uint32 {
+	return uint32(C.pn_transport_get_max_frame(t.pn))
 }
-func (t Transport) SetMaxFrame(size uint16) {
+func (t Transport) SetMaxFrame(size uint32) {
 	C.pn_transport_set_max_frame(t.pn, C.uint32_t(size))
 }
-func (t Transport) RemoteMaxFrame() uint16 {
-	return uint16(C.pn_transport_get_remote_max_frame(t.pn))
+func (t Transport) RemoteMaxFrame() uint32 {
+	return uint32(C.pn_transport_get_remote_max_frame(t.pn))
 }
 func (t Transport) IdleTimeout() time.Duration {
 	return (time.Duration(C.pn_transport_get_idle_timeout(t.pn)) * time.Millisecond)


### PR DESCRIPTION
The mappings from C types to Go types are incorrect in the latest generated wrapper for proton. This PR fixes that issue.

I made this change on version 0.27.0 because that was the version that was last used to generate the wrapped code. Nothing I have changed would require a later version.