### PR TITLE
PROTON-2187: Python client: connection cleanup on close while still c…

### DIFF
--- a/python/proton/_transport.py
+++ b/python/proton/_transport.py
@@ -102,6 +102,7 @@ class Transport(Wrapper):
         self._sasl = None
         self._ssl = None
         self._reactor = None
+        self._connecting = False
 
     def _check(self, err):
         if err < 0:


### PR DESCRIPTION
Proposed fix: Check if the close operation precedes the TCP handshake completion, and reproduce the missing cleanup steps.

This requires remembering the transport's selectable so that it can be accessed at the tie of the close.

The deleted lines in _handlers.py:

        # TODO: Don't understand why we need this now - how can we get PN_TRANSPORT until the connection succeeds?

       t._selectable = None

were investigated.  No PN_TRANSPORT events are generated before the TCP handshake completes, even with first SASL frame output.
