### PR TITLE
PROTON-2116 [python] add test for the object leak issue in BlockingConnection

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -227,9 +227,10 @@ set (py_bin "${CMAKE_CURRENT_BINARY_DIR}")
 set (py_dll "$<TARGET_FILE_DIR:_cproton>")
 set (py_bld "$<TARGET_FILE_DIR:qpid-proton-core>") # For windows
 set (py_tests "${py_src}/tests")
+set (tests_py "${py_src}/../tests/py")
 
 set (py_path ${CMAKE_BINARY_DIR}/c/tools ${py_bld} $ENV{PATH})
-set (py_pythonpath ${py_tests} ${py_src} ${py_bin} ${py_dll} $ENV{PYTHONPATH})
+set (py_pythonpath ${py_tests} ${py_src} ${py_bin} ${py_dll} ${tests_py} $ENV{PYTHONPATH})
 to_native_path ("${py_pythonpath}" py_pythonpath)
 to_native_path ("${py_path}" py_path)
 
@@ -246,6 +247,33 @@ pn_add_test(
     "SASLPASSWD=${CyrusSASL_Saslpasswd_EXECUTABLE}"
   COMMAND ${PYTHON_EXECUTABLE} ${python_coverage_options} -- "${py_tests}/proton-test")
 set_tests_properties(python-test PROPERTIES PASS_REGULAR_EXPRESSION "Totals: .* 0 failed")
+
+if(PYTHON_VERSION_MAJOR EQUAL 2 AND PYTHON_VERSION_MINOR LESS 7)
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import unittest2"
+          RESULT_VARIABLE UNITTEST_MISSING
+          ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(UNITTEST_MISSING)
+    message(WARNING "unittest2 is not installed. ***some unit tests cannot be run***\ntry 'pip install unittest2' to install unittest2")
+  else(UNITTEST_MISSING)
+    set(PYTHON_TEST_COMMAND "-m" "unittest2")
+  endif(UNITTEST_MISSING)
+else(PYTHON_VERSION_MAJOR EQUAL 2 AND PYTHON_VERSION_MINOR LESS 7)
+  set(PYTHON_TEST_COMMAND "-m" "unittest")
+endif(PYTHON_VERSION_MAJOR EQUAL 2 AND PYTHON_VERSION_MINOR LESS 7)
+
+if (PYTHON_TEST_COMMAND)
+  pn_add_test(
+    INTERPRETED
+    NAME python-integration-test
+    PREPEND_ENVIRONMENT
+      "PATH=${py_path}"
+      "PYTHONPATH=${py_pythonpath}"
+      "SASLPASSWD=${CyrusSASL_Saslpasswd_EXECUTABLE}"
+    COMMAND
+      ${PYTHON_EXECUTABLE}
+        ${python_coverage_options}
+        ${PYTHON_TEST_COMMAND} discover -v -s "${py_tests}/integration" -p *_test.py)
+endif(PYTHON_TEST_COMMAND)
 
 check_python_module("tox" TOX_MODULE_FOUND)
 if (NOT TOX_MODULE_FOUND)

--- a/python/tests/integration/blocking_connection_object_leak_test.py
+++ b/python/tests/integration/blocking_connection_object_leak_test.py
@@ -1,0 +1,153 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import gc
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+import unittest
+import uuid
+
+import proton.handlers
+import proton.reactor
+import proton.utils
+
+logger = logging.getLogger(__name__)
+
+
+class ReconnectingTestClient:
+    def __init__(self, hostport):
+        # type: (str) -> None
+        self.hostport = hostport
+
+        self.object_counts = []
+        self.done = threading.Event()
+
+    def count_objects(self, message):
+        # type: (str) -> None
+        gc.collect()
+        n = len(gc.get_objects())
+        if message == "loop":
+            self.object_counts.append(n)
+        logger.debug("Message %s, Count %d", message, n)
+
+    def run(self):
+        ADDR = "testing123"
+        HEARTBEAT = 5
+        SLEEP = 5
+
+        recv = None
+        conn = None
+        for _ in range(5):
+            subscribed = False
+            while not subscribed:
+                try:
+                    conn = proton.utils.BlockingConnection(self.hostport, ssl_domain=None, heartbeat=HEARTBEAT)
+                    recv = conn.create_receiver(ADDR, name=str(uuid.uuid4()), dynamic=False, options=None)
+                    subscribed = True
+                except Exception as e:
+                    logger.info("received exception %s on connect/subscribe, retry", e)
+                    time.sleep(0.5)
+
+            self.count_objects("loop")
+            logger.debug("connected")
+            while subscribed:
+                try:
+                    recv.receive(SLEEP)
+                except proton.Timeout:
+                    pass
+                except Exception as e:
+                    logger.info(e)
+                    try:
+                        recv.close()
+                        recv = None
+                    except:
+                        self.count_objects("link close() failed")
+                        pass
+                    try:
+                        conn.close()
+                        conn = None
+                        self.count_objects("conn closed")
+                    except:
+                        self.count_objects("conn close() failed")
+                        pass
+                    subscribed = False
+        self.done.set()
+
+
+class BlockingConnectionObjectLeakTests(unittest.TestCase):
+    def test_blocking_connection_object_leak(self):
+        """Kills and restarts broker repeatedly, while client is reconnecting.
+
+        The value of `gc.get_objects()` should not keep increasing in the client.
+
+        These are the automated reproduction steps for PROTON-2116"""
+        gc.collect()
+
+        thread = None
+        client = None
+
+        host_port = ""  # random on first broker startup
+        broker_process = None
+
+        while not client or not client.done.is_set():
+            try:
+                params = []
+                if host_port:
+                    params = ['-b', host_port]
+                broker_process = subprocess.Popen(
+                    args=[sys.executable, os.path.join(os.path.dirname(__file__), 'broker.py')] + params,
+                    stdout=subprocess.PIPE,
+                    universal_newlines=True,
+                )
+                host_port = broker_process.stdout.readline()
+
+                if not client:
+                    client = ReconnectingTestClient(host_port)
+                    thread = threading.Thread(target=client.run)
+                    thread.start()
+
+                time.sleep(3)
+            finally:
+                if broker_process:
+                    broker_process.kill()
+                    broker_process.wait()
+                    broker_process.stdout.close()
+            time.sleep(0.3)
+
+        thread.join()
+
+        logger.info("client.object_counts:", client.object_counts)
+
+        # drop first value, it is usually different (before counts settle)
+        object_counts = client.object_counts[1:]
+
+        diffs = [c - object_counts[0] for c in object_counts]
+        self.assertEqual([0] * 4, diffs, "Object counts should not be increasing")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/integration/broker.py
+++ b/python/tests/integration/broker.py
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import optparse
+import socket
+import sys
+import threading
+
+import cproton
+import proton.handlers
+import proton.reactor
+import proton.utils
+
+
+class Broker(proton.handlers.MessagingHandler):
+    def __init__(self, acceptor_url):
+        # type: (str) -> None
+        super(Broker, self).__init__()
+        self.acceptor_url = acceptor_url
+
+        self.acceptor = None
+        self._acceptor_opened_event = threading.Event()
+
+    def get_acceptor_sockname(self):
+        # type: () -> (str, int)
+        self._acceptor_opened_event.wait()
+        if hasattr(self.acceptor, '_selectable'):  # proton 0.30.0+
+            sockname = self.acceptor._selectable._delegate.getsockname()
+        else:  # works in proton 0.27.0
+            selectable = cproton.pn_cast_pn_selectable(self.acceptor._impl)
+            fd = cproton.pn_selectable_get_fd(selectable)
+            s = socket.fromfd(fd, socket.AF_INET, socket.SOCK_STREAM)
+            sockname = s.getsockname()
+        return sockname[:2]
+
+    def on_start(self, event):
+        self.acceptor = event.container.listen(self.acceptor_url)
+        self._acceptor_opened_event.set()
+
+    def on_link_opening(self, event):
+        if event.link.is_sender:
+            assert not event.link.remote_source.dynamic, "This cannot happen"
+            event.link.source.address = event.link.remote_source.address
+        elif event.link.remote_target.address:
+            event.link.target.address = event.link.remote_target.address
+
+
+def main():
+    parser = optparse.OptionParser()
+    parser.add_option("-b", dest="hostport", default="localhost:0", type="string",
+                      help="port number to use")
+    options, args = parser.parse_args()
+
+    broker = Broker(options.hostport)
+    container = proton.reactor.Container(broker)
+    threading.Thread(target=container.run).start()
+    print("{0}:{1}".format(*broker.get_acceptor_sockname()))
+    sys.stdout.flush()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/py/test_unittest.py
+++ b/tests/py/test_unittest.py
@@ -21,40 +21,63 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import unittest
+import sys
 
-# Monkey-patch a few unittest 2.7 features for Python 2.6.
-#
-# These are not the pretty versions provided by 2.7 but they do the
-# same job as far as correctness is concerned.
+__all__ = ['unittest']
 
-if not hasattr(unittest.TestCase, "assertMultiLineEqual"):
-    def assertMultiLineEqual(self, a, b, msg=None): self.assertEqual(a, b, msg)
-    unittest.TestCase.assertMultiLineEqual = assertMultiLineEqual
 
-if not hasattr(unittest.TestCase, "assertIn"):
-    def assertIn(self, a, b, msg=None): self.assertTrue(a in b, msg)
-    unittest.TestCase.assertIn = assertIn
+def _monkey_patch():
+    """Monkey-patch a few unittest 2.7 features for Python 2.6.
 
-if not hasattr(unittest.TestCase, "assertIsNone"):
-    def assertIsNone(self, obj, msg=None): self.assertEqual(obj, None, msg)
-    unittest.TestCase.assertIsNone = assertIsNone
+    These are not the pretty versions provided by 2.7, but they do the
+    same job as far as correctness is concerned.
 
-if not hasattr(unittest, "skip"):
-    def skip(reason="Test skipped"):
-        return lambda f: print(reason)
-    unittest.skip = skip
+    Only used as a measure of last resort if unittest2 is not available.
+    """
+    if not hasattr(unittest.TestCase, "assertMultiLineEqual"):
+        def assertMultiLineEqual(self, a, b, msg=None): self.assertEqual(a, b, msg)
 
-if not hasattr(unittest, "skipIf"):
-    def skipIf(condition, reason):
-        if condition:
-            return skip(reason)
-        return lambda f: f
-    unittest.skipIf = skipIf
+        unittest.TestCase.assertMultiLineEqual = assertMultiLineEqual
 
-if not hasattr(unittest, "skipUnless"):
-    def skipUnless(condition, reason):
-        if not condition:
-            return skip(reason)
-        return lambda f: f
-    unittest.skipUnless = skipUnless
+    if not hasattr(unittest.TestCase, "assertIn"):
+        def assertIn(self, a, b, msg=None): self.assertTrue(a in b, msg)
+
+        unittest.TestCase.assertIn = assertIn
+
+    if not hasattr(unittest.TestCase, "assertIsNone"):
+        def assertIsNone(self, obj, msg=None): self.assertEqual(obj, None, msg)
+
+        unittest.TestCase.assertIsNone = assertIsNone
+
+    if not hasattr(unittest, "skip"):
+        def skip(reason="Test skipped"):
+            return lambda f: print(reason)
+
+        unittest.skip = skip
+
+    if not hasattr(unittest, "skipIf"):
+        def skipIf(condition, reason):
+            if condition:
+                return skip(reason)
+            return lambda f: f
+
+        unittest.skipIf = skipIf
+
+    if not hasattr(unittest, "skipUnless"):
+        def skipUnless(condition, reason):
+            if not condition:
+                return skip(reason)
+            return lambda f: f
+
+        unittest.skipUnless = skipUnless
+
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        import unittest
+
+        _monkey_patch()


### PR DESCRIPTION
The issue fixed in https://issues.apache.org/jira/browse/PROTON-2116 is fixed on Linux, but not on Windows: the test fails there.

@astitcher This one takes 18 s. I guess it can be easilly sped up by running the outer for loop 3 times, instead of 5 (so 40 % improvement), then it would take larger changes to make it even faster.

```27: Test timeout computed to be: 1500
27: test_blocking_connection_object_leak (blocking_connection_object_leak_test.BlockingConnectionObjectLeakTests)
27: Kills and restarts broker repeatedly, while client is reconnecting. ... FAIL
27: 
27: ======================================================================
27: FAIL: test_blocking_connection_object_leak (blocking_connection_object_leak_test.BlockingConnectionObjectLeakTests)
27: Kills and restarts broker repeatedly, while client is reconnecting.
27: ----------------------------------------------------------------------
27: Traceback (most recent call last):
27:   File "C:\projects\qpid-proton\python\tests\integration\blocking_connection_object_leak_test.py", line 149, in test_blocking_connection_object_leak
27:     self.assertEqual([0] * 4, diffs, "Object counts should not be increasing")
27: AssertionError: Lists differ: [0, 0, 0, 0] != [0, 30, 60, 90]
27: 
27: First differing element 1:
27: 0
27: 30
27: 
27: - [0, 0, 0, 0]
27: + [0, 30, 60, 90]
27: ?     +   +   +
27:  : Object counts should not be increasing
27: 
27: ----------------------------------------------------------------------
27: Ran 1 test in 17.445s
27: 
27: FAILED (failures=1)
27/28 Test #27: python-integration-test ..........***Failed   17.77 sec
test 28
```