### PR TITLE
PROTON-2194 Fix for incorrect memory deallocation

### DIFF
--- a/c/src/ssl/schannel.c
+++ b/c/src/ssl/schannel.c
@@ -2075,7 +2075,7 @@ static bool server_name_matches(const char *server_name, CERT_EXTENSION *alt_nam
         }
       }
     }
-    LocalFree(&alt_name_info);
+    LocalFree(alt_name_info);
   }
 
   if (!matched) {


### PR DESCRIPTION
When execution gets to `server_name_matches` in `schannel.c`, an attempt is made to deallocate a chunk of memory here: https://github.com/apache/qpid-proton/blob/0.30.0/c/src/ssl/schannel.c#L2078
However, this is incorrect because the code is passing the pointer's address (which is a memory location on the stack, not the heap) to LocalFree . This causes a crash. The fix is simply to pass the pointer's value: https://github.com/attila-kun/qpid-proton/commit/21e88fe0b18a4587768b16ae275a8ae88fd919bb