### PR TITLE
PROTON-2225: enable threaderciser by default, suppress race checkers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,25 @@
 
 sudo: false
 language: cpp
-compiler:
-- gcc
-- clang
-env:
-- OPENSSL_ia32cap='0x00000000'
 
 matrix:
   include:
+  - os: linux
+    dist: bionic
+    dist: xenial
+    sudo: true
+    language: cpp
+    compiler: gcc
+    env:
+    - OPENSSL_ia32cap='0x00000000'
+  - os: linux
+    dist: xenial
+    language: cpp
+    compiler: clang
+    env:
+    - OPENSSL_ia32cap='0x00000000'
+    # c-threaderciser test hangs on older clang
+    - QPID_PROTON_CTEST_ARGS="--exclude-regex 'c-threaderciser'"
   - os: linux
     dist: bionic
     sudo: true
@@ -69,8 +80,9 @@ matrix:
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
     - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'
     - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13'
+    # c-threaderciser test hangs on older clang
     # python-tox-test segfaults and ruby tests do not start due to dynamic library issues
-    - QPID_PROTON_CTEST_ARGS="--exclude-regex 'python-tox-test|ruby.*'"
+    - QPID_PROTON_CTEST_ARGS="--exclude-regex 'c-threaderciser|python-tox-test|ruby.*'"
 
   - os: osx
     osx_image: xcode11.3
@@ -79,8 +91,9 @@ matrix:
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
     - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'
     - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14'
+    # TODO PROTON-2225: c-threaderciser sometimes fails with assertion error
     # python-tox-test segfaults and ruby tests do not start due to dynamic library issues
-    - QPID_PROTON_CTEST_ARGS="--exclude-regex 'python-tox-test|ruby.*'"
+    - QPID_PROTON_CTEST_ARGS="--exclude-regex 'c-threaderciser|python-tox-test|ruby.*'"
 
 addons:
   # Ubuntu 16.04 APT dependencies, https://packages.ubuntu.com/

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ matrix:
 
   - os: osx
     osx_image: xcode9.4
+    compiler: clang
     env:
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
     - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'
@@ -73,6 +74,7 @@ matrix:
 
   - os: osx
     osx_image: xcode11.3
+    compiler: clang
     env:
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
     - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'

--- a/c/tests/CMakeLists.txt
+++ b/c/tests/CMakeLists.txt
@@ -79,10 +79,13 @@ if (CMAKE_CXX_COMPILER)
     target_link_libraries(c-ssl-proactor-test qpid-proton-core qpid-proton-proactor ${PLATFORM_LIBS})
 
     # Thread race test.
-    #
-    # TODO aconway 2018-11-14: enable by default when races and xcode
-    # problems are cleared up
-    option(THREADERCISER "Run the threaderciser concurrency tests" OFF)
+    if (MSVC)
+      # test does not compile on Windows
+      set(DEFAULT_THREADERCISER OFF)
+    else (MSVC)
+      set(DEFAULT_THREADERCISER ON)
+    endif (MSVC)
+    option(THREADERCISER "Run the threaderciser concurrency tests" ${DEFAULT_THREADERCISER})
     if (THREADERCISER)
       add_executable(c-threaderciser threaderciser.c)
       set_target_properties(c-threaderciser PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} ${C_WARNING_FLAGS}")

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -26,3 +26,7 @@ race:^stop_polling$
 # PROTON-2133 in close (also match with .c/.cpp at the end)
 race:c/examples/broker
 race:cpp/examples/broker
+
+# found by threaderciser, in c/src/proactor/epoll.c
+race:^listener_final_free$
+race:^pn_proactor_connect2$

--- a/tests/valgrind.supp
+++ b/tests/valgrind.supp
@@ -171,7 +171,7 @@
 
 {
    TODO(PROTON-2225) investigate threaderciser test
-   Memcheck:leak
+   Memcheck:Leak
    ...
    fun:connection_ctx_new
    src:threaderciser.c

--- a/tests/valgrind.supp
+++ b/tests/valgrind.supp
@@ -174,5 +174,6 @@
    Memcheck:Leak
    ...
    fun:connection_ctx_new
-   src:threaderciser.c
+   ...
+   fun:proactor_thread
 }

--- a/tests/valgrind.supp
+++ b/tests/valgrind.supp
@@ -149,3 +149,30 @@
    fun:*
    fun:_nss_files_getservbyname_r
 }
+
+{
+   TODO(PROTON-2133) investigate races in tests (threaderciser, c-fd-leak)
+   Helgrind:Race
+   ...
+   fun:proactor_do_epoll
+   fun:pn_proactor_wait
+   fun:proactor_thread
+}
+
+{
+   TODO(PROTON-2133) investigate races in tests (threaderciser, c-fd-leak)
+   Helgrind:Race
+   ...
+   fun:pmutex_finalize
+   fun:pcontext_finalize
+   fun:pconnection_final_free
+   fun:pconnection_cleanup
+}
+
+{
+   TODO(PROTON-2225) investigate threaderciser test
+   Memcheck:leak
+   ...
+   fun:connection_ctx_new
+   src:threaderciser.c
+}


### PR DESCRIPTION
@astitcher Can you please help me figure out why is this failing on Windows (AppVeyor)? I cannot even identify the cause in the error ouptut. (Link here, or one of the previous builds at https://ci.appveyor.com/project/jirkadanek/qpid-proton/builds/33002940)