### PR TITLE
PROTON-2125: suppress annoying deprecation warning from Minitest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,14 @@
 
 sudo: false
 language: cpp
+env:
+  global:
+  # PROTON-2125 suppress annoying deprecation warning from Minitest in Ruby tests
+  - RUBYOPT='-W0'  # ruby 2.7.0 introduced a more targeted -W:no-deprecated
 
 matrix:
   include:
   - os: linux
-    dist: bionic
     dist: xenial
     sudo: true
     language: cpp


### PR DESCRIPTION
I am not completely convinced this is a good idea, but it is the only easy thing I could think of (since on ruby <2.7.0 it is not possible to suppress deprecation warnings selectively by a switch).