### PR TITLE
PROTON-2244: Fix for Array of lists with first list empty encoding

### DIFF
--- a/c/src/core/encoder.c
+++ b/c/src/core/encoder.c
@@ -336,8 +336,9 @@ static int pni_encoder_exit(void *ctx, pn_data_t *data, pni_node_t *node)
   pn_encoder_t *encoder = (pn_encoder_t *) ctx;
   char *pos;
 
-  // Special case 0 length list
-  if (node->atom.type==PN_LIST && node->children-encoder->null_count==0) {
+  // Special case 0 length list, but not as element in an array
+  pni_node_t *parent = pn_data_node(data, node->parent);
+  if (node->atom.type==PN_LIST && node->children-encoder->null_count==0 && !pn_is_in_array(data, parent, node)) {
     encoder->position = node->start-1; // position of list opcode
     pn_encoder_writef8(encoder, PNE_LIST0);
     encoder->null_count = 0;


### PR DESCRIPTION
All tests pass.
It appears necessary to test for both pn_is_in_array() && pn_is_first_in_array(), using only the latter causes failures in the list tests.