### PR TITLE
PROTON-2220 fix cleanup in test_broker @contextmanager

### DIFF
--- a/python/tests/integration/test_PROTON_1800_syncrequestresponse_fd_leak.py
+++ b/python/tests/integration/test_PROTON_1800_syncrequestresponse_fd_leak.py
@@ -114,9 +114,10 @@ def test_broker():
     container = proton.reactor.Container(broker)
     threading.Thread(target=container.run).start()
 
-    yield broker
-
-    container.stop()
+    try:
+        yield broker
+    finally:
+        container.stop()
 
 
 PROC_SELF_FD_EXISTS = os.path.exists("/proc/self/fd"), "Skipped: Directory /proc/self/fd does not exist"

--- a/python/tests/integration/test_PROTON_2121_blocking_connection_fd_leak.py
+++ b/python/tests/integration/test_PROTON_2121_blocking_connection_fd_leak.py
@@ -101,9 +101,10 @@ def test_broker():
     container = proton.reactor.Container(broker)
     threading.Thread(target=container.run).start()
 
-    yield broker
-
-    container.stop()
+    try:
+        yield broker
+    finally:
+        container.stop()
 
 
 PROC_SELF_FD_EXISTS = os.path.exists("/proc/self/fd"), "Skipped: Directory /proc/self/fd does not exist"


### PR DESCRIPTION
Python context managers propagate thrown exceptions out of their `yield` statement.
If the test broker is to be always stopped, a finally block is necessary.