### PR TITLE
SASL Changes - Authzid and plugin API review

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -303,7 +303,7 @@ set (qpid-proton-include
   include/proton/object.h
   include/proton/proactor.h
   include/proton/sasl.h
-  include/proton/sasl-plugin.h
+  include/proton/sasl_plugin.h
   include/proton/session.h
   include/proton/ssl.h
   include/proton/terminus.h

--- a/c/docs/user.doxygen.in
+++ b/c/docs/user.doxygen.in
@@ -65,7 +65,7 @@ EXCLUDE_PATTERNS        = @CMAKE_SOURCE_DIR@/c/examples/*.c \
                           @CMAKE_SOURCE_DIR@/c/include/proton/log.h \
                           @CMAKE_SOURCE_DIR@/c/include/proton/object.h \
                           @CMAKE_SOURCE_DIR@/c/include/proton/reactor.h \
-                          @CMAKE_SOURCE_DIR@/c/include/proton/sasl-plugin.h \
+                          @CMAKE_SOURCE_DIR@/c/include/proton/sasl_plugin.h \
                           @CMAKE_SOURCE_DIR@/c/include/proton/selectable.h \
                           @CMAKE_SOURCE_DIR@/c/include/proton/type_compat.h
 FULL_PATH_NAMES         = YES

--- a/c/include/proton/connection.h
+++ b/c/include/proton/connection.h
@@ -322,12 +322,37 @@ PN_EXTERN void pn_connection_set_user(pn_connection_t *connection, const char *u
 PN_EXTERN void pn_connection_set_password(pn_connection_t *connection, const char *password);
 
 /**
+ * Set the authorization id for a client connection
+ *
+ * It is necessary to set the authorization before binding the connection
+ * to a transport and it isn't allowed to change it after the binding.
+ *
+ * This is only useful if the negotiated sasl mechanism supports transporting an authorization id separate from
+ * the authentication user.
+ *
+ * By default all mechanisms will consider the requested authorization as identical to the authentication if it
+ * is not supplied.
+ *
+ * @param[in] connection the connection
+ * @param[in] authzid the authorization id
+ */
+PN_EXTERN void pn_connection_set_authorization(pn_connection_t *connection, const char *authzid);
+
+/**
  * Get the authentication username for a client connection
  *
  * @param[in] connection the connection
  * @return the username passed into the connection
  */
 PN_EXTERN const char *pn_connection_get_user(pn_connection_t *connection);
+
+/**
+ * Get the authorization id for a client connection
+ *
+ * @param[in] connection the connection
+ * @return the authorization passed into the connection
+ */
+PN_EXTERN const char *pn_connection_get_authorization(pn_connection_t *connection);
 
 /**
  * Get the value of the AMQP Hostname used by a connection object.

--- a/c/include/proton/sasl-plugin.h
+++ b/c/include/proton/sasl-plugin.h
@@ -123,6 +123,7 @@ PN_EXTERN int   pnx_sasl_get_external_ssf(pn_transport_t *transport);
 
 PN_EXTERN const char *pnx_sasl_get_username(pn_transport_t *transport);
 PN_EXTERN const char *pnx_sasl_get_password(pn_transport_t *transport);
+PN_EXTERN const char *pnx_sasl_get_authorization(pn_transport_t *transport);
 PN_EXTERN void  pnx_sasl_clear_password(pn_transport_t *transport);
 PN_EXTERN const char *pnx_sasl_get_remote_fqdn(pn_transport_t *transport);
 PN_EXTERN const char *pnx_sasl_get_selected_mechanism(pn_transport_t *transport);
@@ -131,7 +132,7 @@ PN_EXTERN void  pnx_sasl_set_bytes_out(pn_transport_t *transport, pn_bytes_t byt
 PN_EXTERN void  pnx_sasl_set_desired_state(pn_transport_t *transport, enum pnx_sasl_state desired_state);
 PN_EXTERN void  pnx_sasl_set_selected_mechanism(pn_transport_t *transport, const char *mechanism);
 PN_EXTERN void  pnx_sasl_set_local_hostname(pn_transport_t * transport, const char * fqdn);
-PN_EXTERN void  pnx_sasl_succeed_authentication(pn_transport_t *transport, const char *username);
+PN_EXTERN void  pnx_sasl_succeed_authentication(pn_transport_t *transport, const char *username, const char *authzid);
 PN_EXTERN void  pnx_sasl_fail_authentication(pn_transport_t *transport);
 
 PN_EXTERN void  pnx_sasl_set_implementation(pn_transport_t *transport, const pnx_sasl_implementation *impl, void *context);

--- a/c/include/proton/sasl.h
+++ b/c/include/proton/sasl.h
@@ -125,6 +125,26 @@ PN_EXTERN pn_sasl_outcome_t pn_sasl_outcome(pn_sasl_t *sasl);
 PN_EXTERN const char *pn_sasl_get_user(pn_sasl_t *sasl);
 
 /**
+ * Retrieve the authorization id
+ *
+ * This is usually used at the the server end to find the name of the requested authorization id.
+ * On the client it will merely return whatever was passed in to the
+ * pn_transport_set_authorization() API.
+ *
+ * If pn_sasl_outcome() returns a value other than PN_SASL_OK, then there will be no user to return.
+ * The returned value is only reliable after the PN_TRANSPORT_AUTHENTICATED event has been received.
+ *
+ * @param[in] sasl the sasl layer
+ *
+ * @return
+ * If the SASL layer was not negotiated then 0 is returned
+ * If the ANONYMOUS mechanism is used then 0 is returned
+ * If no authorization id was requested then 0 is returned
+ * Otherwise a string containing the requested authorization id is returned.
+ */
+PN_EXTERN const char *pn_sasl_get_authorization(pn_sasl_t *sasl);
+
+/**
  * Return the selected SASL mechanism
  *
  * The returned value is only reliable after the PN_TRANSPORT_AUTHENTICATED event has been received.

--- a/c/src/core/engine-internal.h
+++ b/c/src/core/engine-internal.h
@@ -243,6 +243,7 @@ struct pn_connection_t {
   pn_string_t *container;
   pn_string_t *hostname;
   pn_string_t *auth_user;
+  pn_string_t *authzid;
   pn_string_t *auth_password;
   pn_data_t *offered_capabilities;
   pn_data_t *desired_capabilities;

--- a/c/src/core/engine.c
+++ b/c/src/core/engine.c
@@ -496,6 +496,7 @@ static void pn_connection_finalize(void *object)
   pn_free(conn->container);
   pn_free(conn->hostname);
   pn_free(conn->auth_user);
+  pn_free(conn->authzid);
   pn_free(conn->auth_password);
   pn_free(conn->offered_capabilities);
   pn_free(conn->desired_capabilities);
@@ -530,6 +531,7 @@ pn_connection_t *pn_connection()
   conn->container = pn_string(NULL);
   conn->hostname = pn_string(NULL);
   conn->auth_user = pn_string(NULL);
+  conn->authzid = pn_string(NULL);
   conn->auth_password = pn_string(NULL);
   conn->offered_capabilities = pn_data(0);
   conn->desired_capabilities = pn_data(0);
@@ -603,6 +605,18 @@ void pn_connection_set_user(pn_connection_t *connection, const char *user)
 {
     assert(connection);
     pn_string_set(connection->auth_user, user);
+}
+
+const char *pn_connection_get_authorization(pn_connection_t *connection)
+{
+  assert(connection);
+  return pn_string_get(connection->authzid);
+}
+
+void pn_connection_set_authorization(pn_connection_t *connection, const char *authzid)
+{
+  assert(connection);
+  pn_string_set(connection->authzid, authzid);
 }
 
 void pn_connection_set_password(pn_connection_t *connection, const char *password)

--- a/c/src/core/transport.c
+++ b/c/src/core/transport.c
@@ -695,9 +695,12 @@ int pn_transport_bind(pn_transport_t *transport, pn_connection_t *connection)
   pn_connection_bound(connection);
 
   // set the hostname/user/password
-  if (pn_string_size(connection->auth_user)) {
+  if (pn_string_size(connection->auth_user) || pn_string_size(connection->authzid)) {
     pn_sasl(transport);
-    pni_sasl_set_user_password(transport, pn_string_get(connection->auth_user), pn_string_get(connection->auth_password));
+    pni_sasl_set_user_password(transport,
+                               pn_string_get(connection->auth_user),
+                               pn_string_get(connection->authzid),
+                               pn_string_get(connection->auth_password));
   }
 
   if (pn_string_size(connection->hostname)) {

--- a/c/src/sasl/cyrus_sasl.c
+++ b/c/src/sasl/cyrus_sasl.c
@@ -25,7 +25,7 @@
 #include "core/logger_private.h"
 
 #include "proton/sasl.h"
-#include "proton/sasl-plugin.h"
+#include "proton/sasl_plugin.h"
 #include "proton/transport.h"
 
 #include <sasl/sasl.h>
@@ -50,7 +50,7 @@ static void cyrus_sasl_process_response(pn_transport_t *transport, const pn_byte
 static bool cyrus_sasl_init_client(pn_transport_t *transport);
 static bool cyrus_sasl_process_mechanisms(pn_transport_t *transport, const char *mechs);
 static void cyrus_sasl_process_challenge(pn_transport_t *transport, const pn_bytes_t *recv);
-static void cyrus_sasl_process_outcome(pn_transport_t *transport);
+static void cyrus_sasl_process_outcome(pn_transport_t *transport, const pn_bytes_t *recv);
 
 static bool cyrus_sasl_can_encrypt(pn_transport_t *transport);
 static ssize_t cyrus_sasl_max_encrypt_size(pn_transport_t *transport);
@@ -137,7 +137,7 @@ static void pni_cyrus_interact(pn_transport_t *transport, sasl_interact_t *inter
       break;
     }
     default:
-      pnx_sasl_logf(transport, "(%s): %s - %s", i->challenge, i->prompt, i->defresult);
+      pnx_sasl_logf(transport, PN_LEVEL_ERROR, "(%s): %s - %s", i->challenge, i->prompt, i->defresult);
     }
   }
 }
@@ -304,8 +304,8 @@ bool cyrus_sasl_init_client(pn_transport_t* transport) {
 
     sasl_security_properties_t secprops = {0};
     secprops.security_flags =
-      ( pnx_sasl_get_allow_insecure_mechs(transport) ? 0 : SASL_SEC_NOPLAINTEXT ) |
-      ( pnx_sasl_get_auth_required(transport) ? SASL_SEC_NOANONYMOUS : 0 ) ;
+      ( pnx_sasl_get_allow_insecure_mechanisms(transport) ? 0 : SASL_SEC_NOPLAINTEXT ) |
+      ( pnx_sasl_get_authentication_required(transport) ? SASL_SEC_NOANONYMOUS : 0 ) ;
     secprops.min_ssf = 0;
     secprops.max_ssf = 2048;
     secprops.maxbufsize = CYRUS_SASL_MAX_BUFFSIZE;
@@ -398,8 +398,7 @@ void cyrus_sasl_process_challenge(pn_transport_t *transport, const pn_bytes_t *r
     int result = pni_wrap_client_step(transport, recv);
     switch (result) {
         case SASL_OK:
-            // Authenticated
-            // TODO: Documented that we need to call sasl_client_step() again to be sure!;
+            // Potentially authenticated
         case SASL_CONTINUE:
             // Need to send a response
             pnx_sasl_set_desired_state(transport, SASL_POSTED_RESPONSE);
@@ -408,13 +407,13 @@ void cyrus_sasl_process_challenge(pn_transport_t *transport, const pn_bytes_t *r
             pni_check_sasl_result(cyrus_conn, result, transport);
 
             // Failed somehow - equivalent to failing authentication
-            pnx_sasl_fail_authentication(transport);
-            pnx_sasl_set_desired_state(transport, SASL_RECVED_OUTCOME_FAIL);
+            pnx_sasl_set_failed(transport);
+            pnx_sasl_set_desired_state(transport, SASL_RECVED_FAILURE);
             break;
     }
 }
 
-void cyrus_sasl_process_outcome(pn_transport_t* transport)
+void cyrus_sasl_process_outcome(pn_transport_t* transport, const pn_bytes_t *recv)
 {
 }
 
@@ -433,8 +432,8 @@ bool cyrus_sasl_init_server(pn_transport_t* transport)
 
     sasl_security_properties_t secprops = {0};
     secprops.security_flags =
-      ( pnx_sasl_get_allow_insecure_mechs(transport) ? 0 : SASL_SEC_NOPLAINTEXT ) |
-      ( pnx_sasl_get_auth_required(transport) ? SASL_SEC_NOANONYMOUS : 0 ) ;
+      ( pnx_sasl_get_allow_insecure_mechanisms(transport) ? 0 : SASL_SEC_NOPLAINTEXT ) |
+      ( pnx_sasl_get_authentication_required(transport) ? SASL_SEC_NOANONYMOUS : 0 ) ;
     secprops.min_ssf = 0;
     secprops.max_ssf = 2048;
     secprops.maxbufsize = CYRUS_SASL_MAX_BUFFSIZE;
@@ -501,7 +500,7 @@ static void pni_process_server_result(pn_transport_t *transport, int result)
             // Get authzid from SASL
             const void* authzid;
             sasl_getprop(cyrus_conn, SASL_USERNAME, &authzid);
-            pnx_sasl_succeed_authentication(transport, (const char*) authcid, (const char*) authzid);
+            pnx_sasl_set_succeeded(transport, (const char*) authcid, (const char*) authzid);
             pnx_sasl_set_desired_state(transport, SASL_POSTED_OUTCOME);
             break;
         }
@@ -513,7 +512,7 @@ static void pni_process_server_result(pn_transport_t *transport, int result)
             pni_check_sasl_result(cyrus_conn, result, transport);
 
             // Failed to authenticate
-            pnx_sasl_fail_authentication(transport);
+            pnx_sasl_set_failed(transport);
             pnx_sasl_set_desired_state(transport, SASL_POSTED_OUTCOME);
             break;
     }
@@ -529,13 +528,13 @@ static int pni_wrap_server_step(pn_transport_t *transport, const pn_bytes_t *in)
 {
     int result;
     const char *out;
-    unsigned outlen;
+    unsigned outlen = 0; // Initialise to defend against buggy cyrus mech plugins
     sasl_conn_t *cyrus_conn = (sasl_conn_t*)pnx_sasl_get_context(transport);
     result = sasl_server_step(cyrus_conn,
                               in->start, in->size,
                               &out, &outlen);
 
-    pnx_sasl_set_bytes_out(transport, pn_bytes(outlen, out));
+    pnx_sasl_set_bytes_out(transport, pn_bytes(outlen, outlen ? out : NULL));
     return result;
 }
 

--- a/c/src/sasl/cyrus_stub.c
+++ b/c/src/sasl/cyrus_stub.c
@@ -20,7 +20,7 @@
  */
 
 #include "proton/sasl.h"
-#include "proton/sasl-plugin.h"
+#include "proton/sasl_plugin.h"
 
 extern const pnx_sasl_implementation * const cyrus_sasl_impl;
 const pnx_sasl_implementation * const cyrus_sasl_impl = NULL;

--- a/c/src/sasl/sasl-internal.h
+++ b/c/src/sasl/sasl-internal.h
@@ -34,7 +34,7 @@ extern const pnx_sasl_implementation * const cyrus_sasl_impl;
 
 // SASL APIs used by transport code
 void pn_sasl_free(pn_transport_t *transport);
-void pni_sasl_set_user_password(pn_transport_t *transport, const char *user, const char *password);
+void pni_sasl_set_user_password(pn_transport_t *transport, const char *user, const char *authzid, const char *password);
 void pni_sasl_set_remote_hostname(pn_transport_t *transport, const char* fqdn);
 void pni_sasl_set_external_security(pn_transport_t *transport, int ssf, const char *authid);
 
@@ -44,6 +44,7 @@ struct pni_sasl_t {
   char *selected_mechanism;
   char *included_mechanisms;
   const char *username;
+  const char *authzid;
   char *password;
   const char *remote_fqdn;
   char *local_fqdn;

--- a/c/src/sasl/sasl-internal.h
+++ b/c/src/sasl/sasl-internal.h
@@ -27,7 +27,7 @@
 
 #include "proton/types.h"
 #include "proton/sasl.h"
-#include "proton/sasl-plugin.h"
+#include "proton/sasl_plugin.h"
 
 extern const pnx_sasl_implementation default_sasl_impl;
 extern const pnx_sasl_implementation * const cyrus_sasl_impl;

--- a/c/src/sasl/sasl.c
+++ b/c/src/sasl/sasl.c
@@ -43,18 +43,18 @@ static const char pni_excluded_mechs[] = "GSSAPI GSS-SPNEGO GS2-KRB5 GS2-IAKERB"
 //-----------------------------------------------------------------------------
 // pnx_sasl: API for SASL implementations to use
 
-void pnx_sasl_logf(pn_transport_t *logger, const char *fmt, ...)
+void pnx_sasl_logf(pn_transport_t *logger, pn_log_level_t level, const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    if (PN_SHOULD_LOG(&logger->logger, PN_SUBSYSTEM_SASL, PN_LEVEL_ERROR))
-        pni_logger_vlogf(&logger->logger, PN_SUBSYSTEM_SASL, PN_LEVEL_ERROR, fmt, ap);
+    if (PN_SHOULD_LOG(&logger->logger, PN_SUBSYSTEM_SASL, level))
+        pni_logger_vlogf(&logger->logger, PN_SUBSYSTEM_SASL, level, fmt, ap);
     va_end(ap);
 }
 
 void pnx_sasl_error(pn_transport_t *logger, const char* err, const char* condition_name)
 {
-    pnx_sasl_logf(logger, "sasl error: %s", err);
+    pnx_sasl_logf(logger, PN_LEVEL_ERROR, "sasl error: %s", err);
     pn_condition_t* c = pn_transport_condition(logger);
     pn_condition_set_name(c, condition_name);
     pn_condition_set_description(c, err);
@@ -80,12 +80,12 @@ bool  pnx_sasl_is_transport_encrypted(pn_transport_t *transport)
   return transport->sasl ? transport->sasl->external_ssf>0 : false;
 }
 
-bool  pnx_sasl_get_allow_insecure_mechs(pn_transport_t *transport)
+bool  pnx_sasl_get_allow_insecure_mechanisms(pn_transport_t *transport)
 {
   return transport->sasl ? transport->sasl->allow_insecure_mechs : false;
 }
 
-bool  pnx_sasl_get_auth_required(pn_transport_t *transport)
+bool  pnx_sasl_get_authentication_required(pn_transport_t *transport)
 {
   return transport->auth_required;
 }
@@ -148,7 +148,7 @@ void  pnx_sasl_set_selected_mechanism(pn_transport_t *transport, const char *mec
   }
 }
 
-void  pnx_sasl_succeed_authentication(pn_transport_t *transport, const char *username, const char *authzid)
+void  pnx_sasl_set_succeeded(pn_transport_t *transport, const char *username, const char *authzid)
 {
   if (transport->sasl) {
     transport->sasl->username = username;
@@ -166,7 +166,7 @@ void  pnx_sasl_succeed_authentication(pn_transport_t *transport, const char *use
   }
 }
 
-void  pnx_sasl_fail_authentication(pn_transport_t *transport)
+void  pnx_sasl_set_failed(pn_transport_t *transport)
 {
   if (transport->sasl) {
     transport->sasl->outcome = PN_SASL_AUTH;
@@ -195,7 +195,7 @@ static inline void pni_sasl_impl_free(pn_transport_t *transport)
 
 static inline const char *pni_sasl_impl_list_mechs(pn_transport_t *transport)
 {
-  return transport->sasl->impl->list_mechs(transport);
+  return transport->sasl->impl->list_mechanisms(transport);
 }
 
 static inline bool pni_sasl_impl_init_server(pn_transport_t *transport)
@@ -233,9 +233,9 @@ static inline void pni_sasl_impl_process_challenge(pn_transport_t *transport, co
   transport->sasl->impl->process_challenge(transport, recv);
 }
 
-static inline void pni_sasl_impl_process_outcome(pn_transport_t *transport)
+static inline void pni_sasl_impl_process_outcome(pn_transport_t *transport, const pn_bytes_t *recv)
 {
-  transport->sasl->impl->process_outcome(transport);
+  transport->sasl->impl->process_outcome(transport, recv);
 }
 
 static inline bool pni_sasl_impl_can_encrypt(pn_transport_t *transport)
@@ -332,16 +332,16 @@ static bool pni_sasl_is_client_state(enum pnx_sasl_state state)
   return state==SASL_NONE
       || state==SASL_POSTED_INIT
       || state==SASL_POSTED_RESPONSE
-      || state==SASL_RECVED_OUTCOME_SUCCEED
-      || state==SASL_RECVED_OUTCOME_FAIL
+      || state==SASL_RECVED_SUCCESS
+      || state==SASL_RECVED_FAILURE
       || state==SASL_ERROR;
 }
 
 static bool pni_sasl_is_final_input_state(pni_sasl_t *sasl)
 {
   enum pnx_sasl_state desired_state = sasl->desired_state;
-  return desired_state==SASL_RECVED_OUTCOME_SUCCEED
-      || desired_state==SASL_RECVED_OUTCOME_FAIL
+  return desired_state==SASL_RECVED_SUCCESS
+      || desired_state==SASL_RECVED_FAILURE
       || desired_state==SASL_ERROR
       || desired_state==SASL_POSTED_OUTCOME;
 }
@@ -350,9 +350,9 @@ static bool pni_sasl_is_final_output_state(pni_sasl_t *sasl)
 {
   enum pnx_sasl_state last_state = sasl->last_state;
   enum pnx_sasl_state desired_state = sasl->desired_state;
-  return (desired_state==SASL_RECVED_OUTCOME_SUCCEED && last_state>=SASL_POSTED_INIT)
-      || last_state==SASL_RECVED_OUTCOME_SUCCEED
-      || last_state==SASL_RECVED_OUTCOME_FAIL
+  return (desired_state==SASL_RECVED_SUCCESS && last_state>=SASL_POSTED_INIT)
+      || last_state==SASL_RECVED_SUCCESS
+      || last_state==SASL_RECVED_FAILURE
       || last_state==SASL_ERROR
       || last_state==SASL_POSTED_OUTCOME;
 }
@@ -429,7 +429,7 @@ static bool pni_sasl_client_included_mech(const char *included_mech_list, pn_byt
 // Look for symbol in the mech include list - plugin API version
 //
 // Note that if there is no inclusion list then every mech is implicitly included.
-bool pnx_sasl_is_included_mech(pn_transport_t* transport, pn_bytes_t s)
+bool pnx_sasl_is_mechanism_included(pn_transport_t* transport, pn_bytes_t s)
 {
   return pni_sasl_server_included_mech(transport->sasl->included_mechanisms, s);
 }
@@ -513,7 +513,7 @@ static void pni_post_sasl_frame(pn_transport_t *transport)
         desired_state = SASL_POSTED_MECHANISMS;
         continue;
       }
-      pn_post_frame(transport, SASL_FRAME_TYPE, 0, "DL[B]", SASL_OUTCOME, sasl->outcome);
+      pn_post_frame(transport, SASL_FRAME_TYPE, 0, "DL[Bz]", SASL_OUTCOME, sasl->outcome, out.size, out.start);
       pni_emit(transport);
       if (sasl->outcome!=PN_SASL_OK) {
         pn_do_error(transport, "amqp:unauthorized-access", "Failed to authenticate client [mech=%s]",
@@ -521,13 +521,13 @@ static void pni_post_sasl_frame(pn_transport_t *transport)
         desired_state = SASL_ERROR;
       }
       break;
-    case SASL_RECVED_OUTCOME_SUCCEED:
+    case SASL_RECVED_SUCCESS:
       if (sasl->last_state < SASL_POSTED_INIT) {
         desired_state = SASL_POSTED_INIT;
         continue;
       }
       break;
-    case SASL_RECVED_OUTCOME_FAIL:
+    case SASL_RECVED_FAILURE:
       pn_do_error(transport, "amqp:unauthorized-access", "Authentication failed [mech=%s]",
                   transport->sasl->selected_mechanism ? transport->sasl->selected_mechanism : "none");
       desired_state = SASL_ERROR;
@@ -944,7 +944,7 @@ int pn_do_mechanisms(pn_transport_t *transport, uint8_t frame_type, uint16_t cha
         pn_string_size(mechs) &&
         pni_sasl_impl_process_mechanisms(transport, pn_string_get(mechs)))) {
     sasl->outcome = PN_SASL_PERM;
-    pnx_sasl_set_desired_state(transport, SASL_RECVED_OUTCOME_FAIL);
+    pnx_sasl_set_desired_state(transport, SASL_RECVED_FAILURE);
   }
 
   pn_free(mechs);
@@ -1006,16 +1006,21 @@ int pn_do_outcome(pn_transport_t *transport, uint8_t frame_type, uint16_t channe
   if (!sasl->client) return PN_ERR;
 
   uint8_t outcome;
-  int err = pn_data_scan(args, "D.[B]", &outcome);
+  pn_bytes_t recv;
+  int err = pn_data_scan(args, "D.[Bz]", &outcome, &recv);
   if (err) return err;
 
+  // Preset the outcome to what the server sent us - the plugin can alter this.
+  // In practise the plugin processing here should only fail because it fails
+  // to authenticate the server id after the server authenticates our user.
+  // It should never succeed after the server outcome was failure.
   sasl->outcome = (pn_sasl_outcome_t) outcome;
+
+  pni_sasl_impl_process_outcome(transport, &recv);
+
   bool authenticated = sasl->outcome==PN_SASL_OK;
   transport->authenticated = authenticated;
-  pnx_sasl_set_desired_state(transport, authenticated ? SASL_RECVED_OUTCOME_SUCCEED : SASL_RECVED_OUTCOME_FAIL);
-
-  pni_sasl_impl_process_outcome(transport);
-
+  pnx_sasl_set_desired_state(transport, authenticated ? SASL_RECVED_SUCCESS : SASL_RECVED_FAILURE);
   return 0;
 }
 

--- a/python/proton/_endpoints.py
+++ b/python/proton/_endpoints.py
@@ -31,10 +31,12 @@ from cproton import PN_CONFIGURATION, PN_COORDINATOR, PN_DELIVERIES, PN_DIST_MOD
     PN_RCV_SECOND, PN_REMOTE_ACTIVE, PN_REMOTE_CLOSED, PN_REMOTE_UNINIT, PN_SND_MIXED, PN_SND_SETTLED, PN_SND_UNSETTLED, \
     PN_SOURCE, PN_TARGET, PN_UNSPECIFIED, pn_connection, pn_connection_attachments, pn_connection_close, \
     pn_connection_collect, pn_connection_condition, pn_connection_desired_capabilities, pn_connection_error, \
-    pn_connection_get_container, pn_connection_get_hostname, pn_connection_get_user, pn_connection_offered_capabilities, \
+    pn_connection_get_authorization, pn_connection_get_container, pn_connection_get_hostname, pn_connection_get_user, \
+    pn_connection_offered_capabilities, \
     pn_connection_open, pn_connection_properties, pn_connection_release, pn_connection_remote_condition, \
     pn_connection_remote_container, pn_connection_remote_desired_capabilities, pn_connection_remote_hostname, \
-    pn_connection_remote_offered_capabilities, pn_connection_remote_properties, pn_connection_set_container, \
+    pn_connection_remote_offered_capabilities, pn_connection_remote_properties, \
+    pn_connection_set_authorization, pn_connection_set_container, \
     pn_connection_set_hostname, pn_connection_set_password, pn_connection_set_user, pn_connection_state, \
     pn_connection_transport, pn_delivery, pn_error_code, pn_error_text, pn_link_advance, pn_link_attachments, \
     pn_link_available, pn_link_close, pn_link_condition, pn_link_credit, pn_link_current, pn_link_detach, pn_link_drain, \
@@ -262,6 +264,25 @@ class Connection(Wrapper, Endpoint):
         client sasl layer is explicitly created (this would be for something
         like Kerberos where the credentials are implicit in the environment,
         or to explicitly use the ``ANONYMOUS`` SASL mechanism)
+
+        :type: ``str``
+        """)
+
+    def _get_authorization(self):
+        return utf82unicode(pn_connection_get_authorization(self._impl))
+
+    def _set_authorization(self, name):
+        pn_connection_set_authorization(self._impl, unicode2utf8(name))
+
+    authorization = property(_get_authorization, _set_authorization, doc="""
+        The authorization username for a client connection.
+
+        It is necessary to set the authorization before binding
+        the connection to a transport and it isn't allowed to change
+        after the binding.
+
+        If not set then implicitly the requested authorization is the same as the
+        authentication user.
 
         :type: ``str``
         """)

--- a/python/proton/_transport.py
+++ b/python/proton/_transport.py
@@ -26,7 +26,7 @@ from cproton import PN_EOS, PN_OK, PN_SASL_AUTH, PN_SASL_NONE, PN_SASL_OK, PN_SA
     PN_SSL_RESUME_REUSED, PN_SSL_RESUME_UNKNOWN, PN_SSL_SHA1, PN_SSL_SHA256, PN_SSL_SHA512, PN_SSL_VERIFY_PEER, \
     PN_SSL_VERIFY_PEER_NAME, PN_TRACE_DRV, PN_TRACE_FRM, PN_TRACE_OFF, PN_TRACE_RAW, pn_error_text, pn_sasl, \
     pn_sasl_allowed_mechs, pn_sasl_config_name, pn_sasl_config_path, pn_sasl_done, pn_sasl_extended, \
-    pn_sasl_get_allow_insecure_mechs, pn_sasl_get_mech, pn_sasl_get_user, pn_sasl_outcome, \
+    pn_sasl_get_allow_insecure_mechs, pn_sasl_get_mech, pn_sasl_get_user, pn_sasl_get_authorization, pn_sasl_outcome, \
     pn_sasl_set_allow_insecure_mechs, pn_ssl, pn_ssl_domain, pn_ssl_domain_allow_unsecured_client, pn_ssl_domain_free, \
     pn_ssl_domain_set_credentials, pn_ssl_domain_set_peer_authentication, pn_ssl_domain_set_trusted_ca_db, \
     pn_ssl_get_cert_fingerprint, pn_ssl_get_cipher_name, pn_ssl_get_peer_hostname, pn_ssl_get_protocol_name, \
@@ -606,6 +606,31 @@ class SASL(Wrapper):
                   returned.
         """
         return pn_sasl_get_user(self._sasl)
+
+    @property
+    def authorization(self):
+        """
+        Retrieve the requested authorization user. This is usually used at the the
+        server end to find the name of any requested authorization user.
+
+        If the peer has not requested an authorization user or the SASL mechanism has
+        no capability to transport an authorization id this will be the same as the
+        authenticated user.
+
+        Note that it is the role of the server to ensure that the authenticated user is
+        actually allowed to act as the requested authorization user.
+
+        If :meth:`outcome` returns a value other than :const:`OK`, then
+        there will be no user to return. The returned value is only reliable
+        after the ``PN_TRANSPORT_AUTHENTICATED`` event has been received.
+
+        :rtype: * If the SASL layer was not negotiated then ``0`` is returned.
+                * If the ``ANONYMOUS`` mechanism is used then the user will be
+                  ``"anonymous"``.
+                * Otherwise a string containing the user is
+                  returned.
+        """
+        return pn_sasl_get_authorization(self._sasl)
 
     @property
     def mech(self):


### PR DESCRIPTION
This is a combined PR both adding authorization id capability to proton-c's SASL handling and tidying up the SASL plugin API.

It make sense to combine them into a single change as adding authorization id capability changes the plugin API so as to make any code using need at least some simple changes. So adding in the renamings and other simple changes coming from the API review at the same time avoids more churn than necessary in code using the API.