### PR TITLE
PROTON-2270 remove explicit threaderciser timeout; set a global one for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,4 +163,5 @@ before_script:
 - cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/install -DPYTHON_EXECUTABLE="$(which ${PYTHON})" ${QPID_PROTON_CMAKE_ARGS}
 
 script:
-- cmake --build . --target install -- -j$(nproc) && eval ctest -V ${QPID_PROTON_CTEST_ARGS}
+# travis timeouts a job after 600 s elapses without any new output being printed; use 360 s here to preempt that
+- cmake --build . --target install -- -j$(nproc) && eval ctest --timeout 360 -V ${QPID_PROTON_CTEST_ARGS}

--- a/c/tests/CMakeLists.txt
+++ b/c/tests/CMakeLists.txt
@@ -101,7 +101,6 @@ if (CMAKE_CXX_COMPILER)
         PREPEND_ENVIRONMENT ${test_env}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND $<TARGET_FILE:c-threaderciser>)
-      set_tests_properties (c-threaderciser PROPERTIES TIMEOUT 120)
     endif()
 
     if(WIN32)


### PR DESCRIPTION
This should make `ctest --timeout` work like in qpid-dispatch. CC @ChugR 