### PR TITLE
PROTON-2171: Add BUILD_EXAMPLES option, to optionally skip building examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,4 +431,6 @@ configure_file(${CMAKE_SOURCE_DIR}/misc/config.sh.in
 configure_file(${CMAKE_SOURCE_DIR}/misc/config.bat.in
                ${CMAKE_BINARY_DIR}/config.bat @ONLY)
 
-add_subdirectory(tests/examples)
+if (BUILD_EXAMPLES)
+  add_subdirectory(tests/examples)
+endif (BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,8 @@ option(ENABLE_HIDE_UNEXPORTED_SYMBOLS "Only export library symbols that are expl
 option(ENABLE_FUZZ_TESTING "Enable building fuzzers and regression testing with libFuzzer" ${DEFAULT_FUZZ_TESTING})
 option(ENABLE_BENCHMARKS "Enable building and running benchmarks with Google Benchmark" ${DEFAULT_BENCHMARKS})
 
+option(BUILD_EXAMPLES "Enable building example programs" ON)
+
 # Set any additional compiler specific flags
 set (LTO_GNU "-flto -fno-fat-lto-objects")
 set (LTO_Clang "-flto=thin")

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -582,8 +582,9 @@ if (ENABLE_BENCHMARKS)
 endif (ENABLE_BENCHMARKS)
 
 add_subdirectory(docs)
-add_subdirectory(examples)
-add_subdirectory(tests)
+if (BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif (BUILD_EXAMPLES)
 add_subdirectory(tools)
 
 install (DIRECTORY examples/

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -207,7 +207,9 @@ set(PROTONCPPLIB ${CMAKE_SHARED_LIBRARY_PREFIX}qpid-proton-cpp${CMAKE_SHARED_LIB
 set(PROTONCPPLIBDEBUG ${CMAKE_SHARED_LIBRARY_PREFIX}qpid-proton-cpp${CMAKE_DEBUG_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif ()
 
-add_subdirectory(examples)
+if (BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif (BUILD_EXAMPLES)
 add_subdirectory(docs)
 
 # Pkg config file

--- a/go/CMakeLists.txt
+++ b/go/CMakeLists.txt
@@ -88,7 +88,9 @@ if (BUILD_GO)
   # Clean up go output directories.
   list(APPEND ADDITIONAL_MAKE_CLEAN_FILES ${GOPATH}/pkg ${GOPATH}/bin)
 
-  add_subdirectory(examples)
+  if (BUILD_EXAMPLES)
+    add_subdirectory(examples)
+  endif (BUILD_EXAMPLES)
 
   # Install go sources.
   set (GO_INSTALL_DIR ${SHARE_INSTALL_DIR}/gocode/pkg CACHE PATH "Installation directory for Go code")


### PR DESCRIPTION
This seems to be working, but I'll want to test it more, if I forgot anything. It was suspiciously easy to accomplish.