### PR TITLE
PROTON-2295 avoid broken Go 1.15.3 on macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,12 @@ jobs:
     - name: Create Build and Install directories
       run: mkdir -p "${BuildDir}" "{InstallPrefix}"
       shell: bash
+    # PROTON-2295 avoid using go 1.15.3 on macOS, which is broken
+    - name: Setup go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.15.4'
+      if: runner.os == 'macOS'
     - name: Setup python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,14 @@ jobs:
     - name: Create Build and Install directories
       run: mkdir -p "${BuildDir}" "{InstallPrefix}"
       shell: bash
+
     # PROTON-2295 avoid using go 1.15.3 on macOS, which is broken
-    - name: Setup go
+    - if: runner.os == 'macOS'
+      name: Setup go (Mac OS)
       uses: actions/setup-go@v2
       with:
         go-version: '^1.15.4'
-      if: runner.os == 'macOS'
+
     - name: Setup python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
This is mainly tp avoid the broken 1.15.3 which is default on macOS.