### PR TITLE
PROTON-2298: Disable default running of c-threaderciser tests, enable only through cmake option

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,16 +11,19 @@ environment:
       QPID_PROTON_CMAKE_ARGS: "-A x64"
       VCPKG_INTEGRATION: '-DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake'
       VCPKG_DEFAULT_TRIPLET: x64-windows
+      THREADERCISER: "ON"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 15 2017
       PYTHON: "C:\\Python37-x64"
       QPID_PROTON_CMAKE_ARGS: "-A x64"
       VCPKG_INTEGRATION: '-DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake'
       VCPKG_DEFAULT_TRIPLET: x64-windows
+      THREADERCISER: "ON"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CMAKE_GENERATOR: Visual Studio 14 2015
       PYTHON: "C:\\Python36-x64"
       QPID_PROTON_CMAKE_ARGS: "-A x64"
+      THREADERCISER: "ON"
       # vcpkg is supported on VS2015, we are just not enabling the CMake integration
       # https://docs.microsoft.com/en-us/cpp/build/vcpkg?view=vs-2015
 
@@ -43,7 +46,7 @@ cache:
 before_build:
 - mkdir BLD
 - cd BLD
-- cmake %VCPKG_INTEGRATION% -G "%CMAKE_GENERATOR%" -DPYTHON_EXECUTABLE=%PYTHON%\\python.exe %QPID_PROTON_CMAKE_ARGS% ..
+- cmake %VCPKG_INTEGRATION% -G "%CMAKE_GENERATOR%" -DTHREADERCISER=%THREADERCISER% -DPYTHON_EXECUTABLE=%PYTHON%\\python.exe %QPID_PROTON_CMAKE_ARGS% ..
 - cd ..
 build:
   project: BLD/Proton.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ jobs:
         buildType: [RelWithDebInfo]
         include:
         - os: windows-latest
-          cmake_extra: '-A x64 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
+          cmake_extra: '-A x64 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DTHREADERCISER=ON'
           cmake_generator: '-G "Visual Studio 16 2019"'
         - os: macOS-latest
           pkg_config_path: '/usr/local/opt/openssl@1.1/lib/pkgconfig'
-          cmake_extra: '-DBUILD_RUBY=no'
+          cmake_extra: '-DBUILD_RUBY=no -DTHREADERCISER=ON'
     env:
       BuildType: ${{matrix.buildType}}
       BuildDir: ${{github.workspace}}/BLD

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     env:
     - OPENSSL_ia32cap='0x00000000'
     # c-threaderciser test hangs on older clang
-    - QPID_PROTON_CMAKE_ARGS='-DENABLE_LINKTIME_OPTIMIZATION=OFF'
+    - QPID_PROTON_CMAKE_ARGS='-DENABLE_LINKTIME_OPTIMIZATION=OFF -DTHREADERCISER=ON'
     - QPID_PROTON_CTEST_ARGS='--exclude-regex c-threaderciser'
   - name: static libs
     os: linux
@@ -41,7 +41,7 @@ jobs:
     compiler: gcc
     env:
     - PYTHON=python3
-    - QPID_PROTON_CMAKE_ARGS='-DBUILD_STATIC_LIBS=ON'
+    - QPID_PROTON_CMAKE_ARGS='-DBUILD_STATIC_LIBS=ON -DTHREADERCISER=ON'
   - name: benchmarks
     os: linux
     dist: focal
@@ -49,7 +49,7 @@ jobs:
     compiler: gcc
     env:
     - PYTHON=python3
-    - QPID_PROTON_CMAKE_ARGS='-DENABLE_BENCHMARKS=ON -DRUNTIME_CHECK=OFF'
+    - QPID_PROTON_CMAKE_ARGS='-DENABLE_BENCHMARKS=ON -DRUNTIME_CHECK=OFF -DTHREADERCISER=ON'
     before_install:
     - sudo apt-get install -y libbenchmark-dev
   - name: gcc asan
@@ -62,7 +62,7 @@ jobs:
     - CXX=g++-10
     - PYTHON=python3
     # python-tox-test fails and ruby tests segfault
-    - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DENABLE_TOX_TEST=OFF'
+    - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DENABLE_TOX_TEST=OFF -DTHREADERCISER=ON'
     - QPID_PROTON_CTEST_ARGS='-E ^ruby.*'
   - name: clang asan
     os: linux
@@ -73,7 +73,7 @@ jobs:
     - CC=clang-10
     - CXX=clang++-10
     - PYTHON=python3
-    - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DENABLE_TOX_TEST=OFF'
+    - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DENABLE_TOX_TEST=OFF -DTHREADERCISER=ON'
     # otherwise, on Travis ldd gives `libclang_rt.asan-x86_64.so => not found` and binaries don't work
     - LD_LIBRARY_PATH=/usr/lib/llvm-10/lib/clang/10.0.0/lib/linux/
   - name: gcc tsan
@@ -86,7 +86,7 @@ jobs:
     - CXX=g++-10
     - PYTHON=python3
     # python-test, python-integration-test, and python-tox-test segfault
-    - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=tsan -DENABLE_TOX_TEST=OFF'
+    - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=tsan -DENABLE_TOX_TEST=OFF -DTHREADERCISER=ON'
     - QPID_PROTON_CTEST_ARGS="-E 'python-test|python-integration-test'"
   - name: coverage
     os: linux
@@ -94,7 +94,7 @@ jobs:
     language: cpp
     compiler: gcc
     env:
-    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Coverage'
+    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Coverage -DTHREADERCISER=ON'
     after_success:
     - bash <(curl -s https://codecov.io/bash)
 
@@ -105,7 +105,7 @@ jobs:
     env:
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
     - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'
-    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13'
+    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 -DTHREADERCISER=ON'
     # c-threaderciser test hangs on older clang
     # python-tox-test segfaults and ruby tests do not start due to dynamic library issues
     - QPID_PROTON_CTEST_ARGS="--exclude-regex 'c-threaderciser|python-tox-test|ruby.*'"
@@ -117,7 +117,7 @@ jobs:
     env:
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
     - PKG_CONFIG_PATH='/usr/local/opt/openssl@1.1/lib/pkgconfig'
-    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14'
+    - QPID_PROTON_CMAKE_ARGS='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 -DTHREADERCISER=ON'
     # TODO PROTON-2225: c-threaderciser sometimes fails with assertion error
     # python-tox-test segfaults and ruby tests do not start due to dynamic library issues
     - QPID_PROTON_CTEST_ARGS="--exclude-regex 'c-threaderciser|python-tox-test|ruby.*'"

--- a/c/tests/CMakeLists.txt
+++ b/c/tests/CMakeLists.txt
@@ -83,12 +83,14 @@ if (CMAKE_CXX_COMPILER)
     target_link_libraries(c-ssl-proactor-test qpid-proton-core qpid-proton-proactor ${PLATFORM_LIBS})
 
     # Thread race test.
-    if (CMAKE_USE_PTHREADS_INIT OR CMAKE_HP_PTHREADS_INIT)
-      # test requires pthreads
-      set(DEFAULT_THREADERCISER ON)
-    else (CMAKE_USE_PTHREADS_INIT OR CMAKE_HP_PTHREADS_INIT)
-      set(DEFAULT_THREADERCISER OFF)
-    endif (CMAKE_USE_PTHREADS_INIT OR CMAKE_HP_PTHREADS_INIT)
+    # Temporarily disable all threaderciser tests
+    #if (CMAKE_USE_PTHREADS_INIT OR CMAKE_HP_PTHREADS_INIT)
+    #  # test requires pthreads
+    #  set(DEFAULT_THREADERCISER ON)
+    #else (CMAKE_USE_PTHREADS_INIT OR CMAKE_HP_PTHREADS_INIT)
+    #  set(DEFAULT_THREADERCISER OFF)
+    #endif (CMAKE_USE_PTHREADS_INIT OR CMAKE_HP_PTHREADS_INIT)
+    set(DEFAULT_THREADERCISER OFF)
     option(THREADERCISER "Run the threaderciser concurrency tests" ${DEFAULT_THREADERCISER})
     if (THREADERCISER)
       add_executable(c-threaderciser threaderciser.c)


### PR DESCRIPTION
The earlier test to set the default for c-threaderciser is commented out and replaced with a hard OFF.