### PR TITLE
PROTON-2307 Allow access to connection properties in cpp binding

### DIFF
--- a/cpp/include/proton/connection.hpp
+++ b/cpp/include/proton/connection.hpp
@@ -28,9 +28,11 @@
 #include "./endpoint.hpp"
 #include "./session.hpp"
 #include "./symbol.hpp"
+#include "./value.hpp"
 
 #include <proton/type_compat.h>
 
+#include <map>
 #include <string>
 
 /// @file
@@ -149,6 +151,9 @@ PN_CPP_CLASS_EXTERN connection : public internal::object<pn_connection_t>, publi
 
     /// **Unsettled API** - Extension capabilities desired by the remote peer.
     PN_CPP_EXTERN std::vector<symbol> desired_capabilities() const;
+
+    /// **Unsettled API** - Connection properties
+    PN_CPP_EXTERN std::map<symbol, value> properties() const;
 
     /// Get the idle timeout set by the remote peer.
     ///

--- a/cpp/include/proton/connection_options.hpp
+++ b/cpp/include/proton/connection_options.hpp
@@ -32,6 +32,7 @@
 
 #include <proton/type_compat.h>
 
+#include <map>
 #include <vector>
 #include <string>
 
@@ -161,6 +162,9 @@ class connection_options {
 
     /// **Unsettled API** - Extension capabilities desired from the remote peer.
     PN_CPP_EXTERN connection_options& desired_capabilities(const std::vector<symbol>&);
+
+    /// **Unsettled API** - Connection properties.
+    PN_CPP_EXTERN connection_options& properties(const std::map<symbol, value>&);
 
     /// **Unsettled API** - Set the SASL configuration name.
     PN_CPP_EXTERN connection_options& sasl_config_name(const std::string&);

--- a/cpp/src/connection.cpp
+++ b/cpp/src/connection.cpp
@@ -21,6 +21,7 @@
 
 #include "proton_bits.hpp"
 
+#include "proton/codec/map.hpp"
 #include "proton/codec/vector.hpp"
 #include "proton/connection.hpp"
 #include "proton/connection_options.hpp"
@@ -190,6 +191,15 @@ std::vector<symbol> connection::offered_capabilities() const {
 std::vector<symbol> connection::desired_capabilities() const {
     value caps(pn_connection_remote_desired_capabilities(pn_object()));
     return get_multiple<std::vector<symbol> >(caps);
+}
+
+std::map<symbol, value> connection::properties() const {
+    std::map<symbol, value> props_ret;
+    value props(pn_connection_remote_properties(pn_object()));
+    if (!props.empty()) {
+        get(props, props_ret);
+    }
+    return props_ret;
 }
 
 bool connection::reconnected() const {

--- a/cpp/src/connection_options.cpp
+++ b/cpp/src/connection_options.cpp
@@ -21,6 +21,7 @@
 #include "proton/connection_options.hpp"
 
 #include "proton/connection.hpp"
+#include <proton/codec/map.hpp>
 #include "proton/codec/vector.hpp"
 #include "proton/fwd.hpp"
 #include "proton/messaging_handler.hpp"
@@ -63,6 +64,7 @@ class connection_options::impl {
     option<std::string> password;
     option<std::vector<symbol> > offered_capabilities;
     option<std::vector<symbol> > desired_capabilities;
+    option<std::map<symbol, value> > properties;
     option<reconnect_options_base> reconnect;
     option<std::string> reconnect_url;
     option<std::vector<std::string> > failover_urls;
@@ -108,6 +110,8 @@ class connection_options::impl {
             value(pn_connection_offered_capabilities(pnc)) = offered_capabilities.value;
         if (desired_capabilities.set)
             value(pn_connection_desired_capabilities(pnc)) = desired_capabilities.value;
+        if (properties.set)
+            value(pn_connection_properties(pnc)) = properties.value;
     }
 
     void apply_reconnect_urls(pn_connection_t* pnc) {
@@ -194,6 +198,7 @@ class connection_options::impl {
         password.update(x.password);
         offered_capabilities.update(x.offered_capabilities);
         desired_capabilities.update(x.desired_capabilities);
+        properties.update(x.properties);
         reconnect.update(x.reconnect);
         reconnect_url.update(x.reconnect_url);
         failover_urls.update(x.failover_urls);
@@ -238,6 +243,7 @@ connection_options& connection_options::user(const std::string &user) { impl_->u
 connection_options& connection_options::password(const std::string &password) { impl_->password = password; return *this; }
 connection_options& connection_options::offered_capabilities(const std::vector<symbol> &caps) { impl_->offered_capabilities = caps; return *this; }
 connection_options& connection_options::desired_capabilities(const std::vector<symbol> &caps) { impl_->desired_capabilities = caps; return *this; }
+connection_options& connection_options::properties(const std::map<symbol, value> &props) { impl_->properties = props; return *this; }
 connection_options& connection_options::reconnect(const reconnect_options &r) {
     if (!r.impl_->failover_urls.empty()) {
         impl_->failover_urls = r.impl_->failover_urls;


### PR DESCRIPTION
Allow setting of connection properties via connection_options
Allow reading of properties on incoming connections
Add unit test to container_test.cpp