### PR TITLE
PROTON-2281 Fix flakiness in ruby-message-spec test

### DIFF
--- a/ruby/spec/message_spec.rb
+++ b/ruby/spec/message_spec.rb
@@ -109,7 +109,7 @@ module Qpid
 
       it "raises an error when the time-to-live is negative" do
         proc {
-          @message.ttl = (0 - rand(1000))
+          @message.ttl = (0 - (rand(1000) + 1))
         }.must_raise(RangeError)
       end
 


### PR DESCRIPTION
I strongly dislike using random numbers in tests in this particular manner. I'd have much preferred doing a simple

```ruby
@message.ttl = -1
```

That would be a perfectly clear and understandable test for this boundary condition, in my view.

However, this is not something I am ready to go on a crusade about, at least not right now.