### PR TITLE
Tkettenb

### DIFF
--- a/cpp/examples/ssl.cpp
+++ b/cpp/examples/ssl.cpp
@@ -176,6 +176,8 @@ int main(int argc, char **argv) {
         hello_world_direct hwd;
         proton::container(hwd).run();
         return 0;
+    } catch (const example::bad_option& e) {
+        std::cout << opts << std::endl << e.what() << std::endl;
     } catch (const std::exception& e) {
         std::cerr << e.what() << std::endl;
     }

--- a/cpp/examples/ssl.cpp
+++ b/cpp/examples/ssl.cpp
@@ -165,9 +165,10 @@ int main(int argc, char **argv) {
         opts.parse();
 
         size_t sz = cert_directory.size();
-        if (sz && cert_directory[sz -1] != '/')
-            cert_directory.append("/");
-        else cert_directory = "ssl-certs/";
+        if (sz) {
+           if (cert_directory[sz -1] != '/')
+               cert_directory.append("/");
+        } else cert_directory = "ssl-certs/";
 
         if (verify != verify_noname && verify != verify_full && verify != verify_fail)
             throw std::runtime_error("bad verify argument: " + verify);


### PR DESCRIPTION
Hi all,

this is a minor issue, there is no jira Task for this. I am addressing an issue in a cpp example.

Changes:
 - Added 'bad_option' Exception handler, so the help message is displayed.
 - Fix '-c' command line option. It now searches in the given directory for tserver, tclient files, old behaviour was falling back to default setting 'ssl-certs/'

Test Suite fails on one test-case, but i can't tell where it breaks.

    $ make test

fails in:
    Start 22: cpp-connect_config_test
    22/29 Test #22: cpp-connect_config_test ..........***Failed    0.15 sec

BR,
Thomas
