### PR TITLE
PROTON-2217 Prefer first working Python on PATH, prefer Py3 over Py2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@ cache:
 before_build:
 - mkdir BLD
 - cd BLD
-- cmake %VCPKG_INTEGRATION% -G "%CMAKE_GENERATOR%" -DPYTHON_EXECUTABLE=%PYTHON%\\python.exe %QPID_PROTON_CMAKE_ARGS% ..
+- cmake %VCPKG_INTEGRATION% -G "%CMAKE_GENERATOR%" -DPython_EXECUTABLE=%PYTHON%\\python.exe %QPID_PROTON_CMAKE_ARGS% ..
 - cd ..
 build:
   project: BLD/Proton.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         go-version: '^1.15.4'
 
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.2.1
       with:
         python-version: 3.6
         architecture: x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         go-version: '^1.15.4'
 
     - name: Setup python
-      uses: actions/setup-python@v2.2.1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.6
         architecture: x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,7 +160,7 @@ install:
 before_script:
 - mkdir build
 - cd build
-- cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/install -DPYTHON_EXECUTABLE="$(which ${PYTHON})" ${QPID_PROTON_CMAKE_ARGS}
+- cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/install -DPython_EXECUTABLE="$(which ${PYTHON})" ${QPID_PROTON_CMAKE_ARGS}
 
 script:
 # travis timeouts a job after 600 s elapses without any new output being printed; use 360 s here to preempt that

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,27 @@ include (CheckPythonModule)
 
 find_package (OpenSSL)
 find_package (Threads)
-find_package (PythonInterp REQUIRED)
+# FindPython was added in CMake 3.12, but there it always returned
+#  newest Python on the entire PATH. We want to use the first one.
+if (CMAKE_VERSION VERSION_LESS "3.15.0")
+  find_package (PythonInterp REQUIRED)
+  # forward compatibility with FindPython
+  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+  set(Python_LIBRARIES "${PYTHON_LIBRARIES}")
+  set(Python_INCLUDE_DIRS "${PYTHON_INCLUDE_PATH}")
+  set(Python_VERSION_STRING "${PYTHON_VERSION_STRING}")
+  # for completeness, these are not actually used now
+  set(Python_VERSION_MAJOR "${PYTHON_VERSION_MAJOR}")
+  set(Python_VERSION_MINOR "${PYTHON_VERSION_MINOR}")
+  set(Python_VERSION_PATCH "${PYTHON_VERSION_PATCH}")
+else ()
+  if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
+    cmake_policy(SET CMP0094 NEW)  # FindPython should return the first matching Python on PATH
+  endif ()
+
+  find_package(Python REQUIRED COMPONENTS Interpreter
+          OPTIONAL_COMPONENTS Development)
+endif()
 find_package (SWIG)
 find_package (CyrusSASL)
 
@@ -47,7 +67,7 @@ set (ProtonCpp_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/config)
 
 ## Variables used across components
 
-set (PN_ENV_SCRIPT "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/scripts/env.py")
+set (PN_ENV_SCRIPT "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/scripts/env.py")
 set (PN_C_INCLUDE_DIR "${CMAKE_BINARY_DIR}/c/include")
 set (PN_C_LIBRARY_DIR "${CMAKE_BINARY_DIR}/c")
 set (PN_C_SOURCE_DIR "${CMAKE_BINARY_DIR}/c/src")
@@ -383,8 +403,11 @@ if(SWIG_FOUND)
   # DEFAULT_{uppercase name of binding} to ON
 
   # Prerequisites for Python wrapper:
-  find_package (PythonLibs ${PYTHON_VERSION_STRING} EXACT)
-  if (PYTHONLIBS_FOUND)
+  if (CMAKE_VERSION VERSION_LESS "3.15.0")
+    find_package (PythonLibs ${PYTHON_VERSION_STRING} EXACT)
+    set (Python_Development_FOUND "${PYTHONLIBS_FOUND}")
+  endif ()
+  if (Python_Development_FOUND)
     set (DEFAULT_PYTHON ON)
   endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,27 +32,9 @@ include (CheckPythonModule)
 
 find_package (OpenSSL)
 find_package (Threads)
-# FindPython was added in CMake 3.12, but there it always returned
-#  newest Python on the entire PATH. We want to use the first one.
-if (CMAKE_VERSION VERSION_LESS "3.15.0")
-  find_package (PythonInterp REQUIRED)
-  # forward compatibility with FindPython
-  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  set(Python_LIBRARIES "${PYTHON_LIBRARIES}")
-  set(Python_INCLUDE_DIRS "${PYTHON_INCLUDE_PATH}")
-  set(Python_VERSION_STRING "${PYTHON_VERSION_STRING}")
-  # for completeness, these are not actually used now
-  set(Python_VERSION_MAJOR "${PYTHON_VERSION_MAJOR}")
-  set(Python_VERSION_MINOR "${PYTHON_VERSION_MINOR}")
-  set(Python_VERSION_PATCH "${PYTHON_VERSION_PATCH}")
-else ()
-  if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
-    cmake_policy(SET CMP0094 NEW)  # FindPython should return the first matching Python on PATH
-  endif ()
-
-  find_package(Python REQUIRED COMPONENTS Interpreter
-          OPTIONAL_COMPONENTS Development)
-endif()
+find_package(Python
+        REQUIRED COMPONENTS Interpreter
+        OPTIONAL_COMPONENTS Development)
 find_package (SWIG)
 find_package (CyrusSASL)
 
@@ -403,10 +385,6 @@ if(SWIG_FOUND)
   # DEFAULT_{uppercase name of binding} to ON
 
   # Prerequisites for Python wrapper:
-  if (CMAKE_VERSION VERSION_LESS "3.15.0")
-    find_package (PythonLibs ${PYTHON_VERSION_STRING} EXACT)
-    set (Python_Development_FOUND "${PYTHONLIBS_FOUND}")
-  endif ()
   if (Python_Development_FOUND)
     set (DEFAULT_PYTHON ON)
   endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,19 @@ include (CheckPythonModule)
 
 find_package (OpenSSL)
 find_package (Threads)
+find_package (SWIG)
+find_package (CyrusSASL)
+
+# This setting mirrors FindPythonInterp behavior on Windows/macOS, which did not consult registry/frameworks first.`
+if (NOT DEFINED Python_FIND_REGISTRY)
+  set(Python_FIND_REGISTRY "LAST")
+endif ()
+if (NOT DEFINED Python_FIND_FRAMEWORK)
+  set(Python_FIND_FRAMEWORK "LAST")
+endif ()
 find_package(Python
         REQUIRED COMPONENTS Interpreter
         OPTIONAL_COMPONENTS Development)
-find_package (SWIG)
-find_package (CyrusSASL)
 
 include(tests/PNAddTest.cmake)
 

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -65,13 +65,13 @@ include_directories (
 
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/encodings.h
-  COMMAND ${PN_ENV_SCRIPT} PYTHONPATH=${CMAKE_SOURCE_DIR}/tools/python ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/src/encodings.h.py > ${CMAKE_CURRENT_BINARY_DIR}/src/encodings.h
+  COMMAND ${PN_ENV_SCRIPT} PYTHONPATH=${CMAKE_SOURCE_DIR}/tools/python ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/src/encodings.h.py > ${CMAKE_CURRENT_BINARY_DIR}/src/encodings.h
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/encodings.h.py
   )
 
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/protocol.h
-  COMMAND ${PN_ENV_SCRIPT} PYTHONPATH=${CMAKE_SOURCE_DIR}/tools/python ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/src/protocol.h.py > ${CMAKE_CURRENT_BINARY_DIR}/src/protocol.h
+  COMMAND ${PN_ENV_SCRIPT} PYTHONPATH=${CMAKE_SOURCE_DIR}/tools/python ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/src/protocol.h.py > ${CMAKE_CURRENT_BINARY_DIR}/src/protocol.h
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/protocol.h.py
   )
 

--- a/c/tests/CMakeLists.txt
+++ b/c/tests/CMakeLists.txt
@@ -116,7 +116,7 @@ if (CMAKE_CXX_COMPILER)
       PREPEND_ENVIRONMENT "PATH=${path}" "PYTHONPATH=${pypath}" "${test_env}"
       APPEND_ENVIRONMENT "TEST_EXE_PREFIX="
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/fdlimit.py)
+      COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/fdlimit.py)
   endif(HAS_PROACTOR)
 else (CMAKE_CXX_COMPILER)
   message(WARNING "No C++ compiler, some C library tests were not built")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(CMAKE_SWIG_FLAGS "-threads" "-DUINTPTR_SIZE=${CMAKE_SIZEOF_VOID_P}")
 
-include_directories (${PN_C_INCLUDE_DIR} ${PYTHON_INCLUDE_PATH})
+include_directories (${PN_C_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
 
 set_source_files_properties(cproton.i PROPERTIES CPLUSPLUS NO)
 
@@ -41,15 +41,13 @@ list(APPEND SWIG_MODULE_cproton_EXTRA_DEPS
 )
 
 swig_add_library(cproton LANGUAGE python SOURCES cproton.i)
-swig_link_libraries(cproton ${BINDING_DEPS} ${PYTHON_LIBRARIES} -lm)
+swig_link_libraries(cproton ${BINDING_DEPS} ${Python_LIBRARIES} -lm)
 set_target_properties(${SWIG_MODULE_cproton_REAL_NAME}
     PROPERTIES
     LINK_FLAGS "${CATCH_UNDEFINED}")
 
-find_package(PythonInterp REQUIRED)
-
 if (CHECK_SYSINSTALL_PYTHON)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE}
+  execute_process(COMMAND ${Python_EXECUTABLE}
     -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(True))"
     OUTPUT_VARIABLE PYTHON_SITEARCH_PACKAGES_DEFAULT
     OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -105,9 +103,9 @@ set(py_dist_files
 
 macro (py_compile directory files artifacts)
   foreach (src_file ${files})
-    install(CODE "execute_process(COMMAND \"${PYTHON_EXECUTABLE}\" -c \"import py_compile; py_compile.compile('${src_file}', cfile='${src_file}c')\"
+    install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -c \"import py_compile; py_compile.compile('${src_file}', cfile='${src_file}c')\"
                                   WORKING_DIRECTORY ${directory})")
-    install(CODE "execute_process(COMMAND \"${PYTHON_EXECUTABLE}\" -O -c \"import py_compile; py_compile.compile('${src_file}', cfile='${src_file}o')\"
+    install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -O -c \"import py_compile; py_compile.compile('${src_file}', cfile='${src_file}o')\"
                                   WORKING_DIRECTORY ${directory})")
     list(APPEND ${artifacts} ${directory}/${src_file}
       ${directory}/${src_file}c
@@ -127,7 +125,7 @@ else ()
         COMMAND ${PN_ENV_SCRIPT} --
         PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_CURRENT_SOURCE_DIR}
         LD_LIBRARY_PATH="${CMAKE_CURRENT_BINARY_DIR}/c"
-        ${PYTHON_EXECUTABLE} -m sphinx "${CMAKE_CURRENT_SOURCE_DIR}/docs" "${CMAKE_CURRENT_BINARY_DIR}/docs")
+        ${Python_EXECUTABLE} -m sphinx "${CMAKE_CURRENT_SOURCE_DIR}/docs" "${CMAKE_CURRENT_BINARY_DIR}/docs")
     add_dependencies(docs docs-py)
     install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/docs/"
             DESTINATION "${PROTON_SHARE}/docs/api-py"
@@ -206,12 +204,12 @@ if (SETUPTOOLS_MODULE_FOUND)
                      WORKING_DIRECTORY dist
                      DEPENDS py_src_dist
 		     COMMAND ${PN_ENV_SCRIPT} "SWIG=${SWIG_EXECUTABLE}" --
-		      ${PYTHON_EXECUTABLE} setup.py sdist --dist-dir ${CMAKE_CURRENT_BINARY_DIR}/pkgs)
+		      ${Python_EXECUTABLE} setup.py sdist --dist-dir ${CMAKE_CURRENT_BINARY_DIR}/pkgs)
   if (WHEEL_MODULE_FOUND)
     add_custom_target(py_pkg_wheel ALL
                        WORKING_DIRECTORY dist
                        DEPENDS py_pkg_src
-                       COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel --dist-dir ${CMAKE_CURRENT_BINARY_DIR}/pkgs)
+                       COMMAND ${Python_EXECUTABLE} setup.py bdist_wheel --dist-dir ${CMAKE_CURRENT_BINARY_DIR}/pkgs)
   endif ()
 endif ()
 
@@ -239,7 +237,7 @@ pn_add_test(
     "PATH=${py_path}"
     "PYTHONPATH=${py_pythonpath}"
     "SASLPASSWD=${CyrusSASL_Saslpasswd_EXECUTABLE}"
-  COMMAND ${PYTHON_EXECUTABLE} ${python_coverage_options} -- "${py_tests}/proton-test")
+  COMMAND ${Python_EXECUTABLE} ${python_coverage_options} -- "${py_tests}/proton-test")
 set_tests_properties(python-test PROPERTIES PASS_REGULAR_EXPRESSION "Totals: .* 0 failed")
 
 set(PYTHON_TEST_COMMAND "-m" "unittest")
@@ -251,7 +249,7 @@ pn_add_test(
     "PYTHONPATH=${py_pythonpath}"
     "SASLPASSWD=${CyrusSASL_Saslpasswd_EXECUTABLE}"
   COMMAND
-    ${PYTHON_EXECUTABLE}
+    ${Python_EXECUTABLE}
       ${python_coverage_options}
       ${PYTHON_TEST_COMMAND} discover -v -s "${py_tests}/integration")
 
@@ -285,7 +283,7 @@ else ()
           "SWIG=${SWIG_EXECUTABLE}"
           "TOXENV=${TOX_ENVLIST}"
           "PY_TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/tests"
-        COMMAND ${PYTHON_EXECUTABLE} -m tox)
+        COMMAND ${Python_EXECUTABLE} -m tox)
       set_tests_properties(python-tox-test
         PROPERTIES
         PASS_REGULAR_EXPRESSION "Totals: .* ignored, 0 failed"

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 
 
-if (NOT PYTHON_EXECUTABLE)
+if (NOT Python_EXECUTABLE)
   return()
 endif()
 
@@ -38,7 +38,7 @@ pn_add_test(
   NAME c-example-tests
   PREPEND_ENVIRONMENT "${c_test_env}"
   WORKING_DIRECTORY ${ProtonCExamples_SOURCE_DIR}
-  COMMAND ${PYTHON_EXECUTABLE} testme -v)
+  COMMAND ${Python_EXECUTABLE} testme -v)
 
 if (BUILD_CPP)
   if(WIN32)
@@ -58,7 +58,7 @@ if (BUILD_CPP)
     NAME cpp-example-container
     PREPEND_ENVIRONMENT "${cpp_test_env}"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMAND ${PYTHON_EXECUTABLE} ${ProtonCppExamples_SOURCE_DIR}/testme -v ContainerExampleTest)
+    COMMAND ${Python_EXECUTABLE} ${ProtonCppExamples_SOURCE_DIR}/testme -v ContainerExampleTest)
 
   if (NOT SSL_IMPL STREQUAL none)
     pn_add_test(
@@ -66,6 +66,6 @@ if (BUILD_CPP)
       NAME cpp-example-container-ssl
       PREPEND_ENVIRONMENT "${cpp_test_env}"
       WORKING_DIRECTORY ${ProtonCppExamples_SOURCE_DIR}
-      COMMAND ${PYTHON_EXECUTABLE} testme -v ContainerExampleSSLTest)
+      COMMAND ${Python_EXECUTABLE} testme -v ContainerExampleSSLTest)
   endif()
 endif()

--- a/tools/cmake/Modules/CheckPythonModule.cmake
+++ b/tools/cmake/Modules/CheckPythonModule.cmake
@@ -33,13 +33,13 @@
 #   python interpreter and store the result in an internal cache entry
 #   named ``<variable>``.
 #
-#   The ``PYTHON_EXECUTABLE`` variable must be set before calling this
-#   macro, usually by using find_package(PythonInterp).
+#   The ``Python_EXECUTABLE`` variable must be set before calling this
+#   macro, usually by using find_package(Python).
 
 macro (CHECK_PYTHON_MODULE MODULE VARIABLE)
-  if (NOT ${VARIABLE} AND PYTHON_EXECUTABLE)
+  if (NOT ${VARIABLE} AND Python_EXECUTABLE)
     execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader('${MODULE}') else 1)"
+      COMMAND ${Python_EXECUTABLE} -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader('${MODULE}') else 1)"
       RESULT_VARIABLE RESULT)
     if (RESULT EQUAL 0)
       if(NOT CMAKE_REQUIRED_QUIET)

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This is a wrapper hack purely so that we can use FindPython
+# with cmake 2.8.12 and its supplied older modules
+
+# FindPython was added in CMake 3.12, but there it always returned
+#  newest Python on the entire PATH. We want to use the first one.
+if (CMAKE_VERSION VERSION_LESS "3.15.0")
+    find_package (PythonInterp REQUIRED)
+    # forward compatibility with FindPython
+    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+    set(Python_LIBRARIES "${PYTHON_LIBRARIES}")
+    set(Python_INCLUDE_DIRS "${PYTHON_INCLUDE_PATH}")
+    set(Python_VERSION_STRING "${PYTHON_VERSION_STRING}")
+    # for completeness, these are not actually used now
+    set(Python_VERSION_MAJOR "${PYTHON_VERSION_MAJOR}")
+    set(Python_VERSION_MINOR "${PYTHON_VERSION_MINOR}")
+    set(Python_VERSION_PATCH "${PYTHON_VERSION_PATCH}")
+
+    find_package (PythonLibs ${PYTHON_VERSION_STRING} EXACT)
+    set(Python_Development_FOUND "${PYTHONLIBS_FOUND}")
+else ()
+    if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
+        cmake_policy(SET CMP0094 NEW)  # FindPython should return the first matching Python on PATH
+    endif ()
+
+    if (DEFINED PYTHON_EXECUTABLE)
+        set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
+    endif ()
+
+    include(${CMAKE_ROOT}/Modules/FindPython.cmake)
+endif ()

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -24,6 +24,10 @@ if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
     cmake_policy(SET CMP0094 NEW)  # FindPython should return the first matching Python on PATH
 endif ()
 
+if (DEFINED PYTHON_EXECUTABLE AND DEFINED Python_EXECUTABLE)
+    message(FATAL_ERROR "Both PYTHON_EXECUTABLE and Python_EXECUTABLE were defined. Define at most one of those.")
+endif ()
+
 # FindPython was added in CMake 3.12, but there it always returned
 #  newest Python on the entire PATH. We want to use the first one.
 if (CMAKE_VERSION VERSION_LESS "3.15.0")

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -23,6 +23,10 @@
 # FindPython was added in CMake 3.12, but there it always returned
 #  newest Python on the entire PATH. We want to use the first one.
 if (CMAKE_VERSION VERSION_LESS "3.15.0")
+    if (DEFINED Python_EXECUTABLE)
+        set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+    endif ()
+
     find_package (PythonInterp REQUIRED)
     # forward compatibility with FindPython
     set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -53,14 +53,5 @@ else ()
         set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
     endif ()
 
-    # needed on GitHub Actions CI: actions/setup-python does not touch registry/frameworks on Windows/macOS
-    # this mirrors PythonInterp behavior which did not consult registry/frameworks first
-    if (NOT DEFINED Python_FIND_REGISTRY)
-        set(Python_FIND_REGISTRY "LAST")
-    endif ()
-    if (NOT DEFINED Python_FIND_FRAMEWORK)
-        set(Python_FIND_FRAMEWORK "LAST")
-    endif ()
-
     include(${CMAKE_ROOT}/Modules/FindPython.cmake)
 endif ()

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -53,5 +53,14 @@ else ()
         set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
     endif ()
 
+    # needed on GitHub Actions CI: actions/setup-python does not touch registry/frameworks on Windows/macOS
+    # this mirrors PythonInterp behavior which did not consult registry/frameworks first
+    if (NOT DEFINED Python_FIND_REGISTRY)
+        set(Python_FIND_REGISTRY "LAST")
+    endif ()
+    if (NOT DEFINED Python_FIND_FRAMEWORK)
+        set(Python_FIND_FRAMEWORK "LAST")
+    endif ()
+
     include(${CMAKE_ROOT}/Modules/FindPython.cmake)
 endif ()

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -25,7 +25,7 @@ if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
 endif ()
 
 if (DEFINED PYTHON_EXECUTABLE AND DEFINED Python_EXECUTABLE)
-    message(FATAL_ERROR "Both PYTHON_EXECUTABLE and Python_EXECUTABLE were defined. Define at most one of those.")
+    message(FATAL_ERROR "Both PYTHON_EXECUTABLE and Python_EXECUTABLE are defined. Define at most one of those.")
 endif ()
 
 # FindPython was added in CMake 3.12, but there it always returned

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -20,6 +20,10 @@
 # This is a wrapper hack purely so that we can use FindPython
 # with cmake 2.8.12 and its supplied older modules
 
+if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
+    cmake_policy(SET CMP0094 NEW)  # FindPython should return the first matching Python on PATH
+endif ()
+
 # FindPython was added in CMake 3.12, but there it always returned
 #  newest Python on the entire PATH. We want to use the first one.
 if (CMAKE_VERSION VERSION_LESS "3.15.0")
@@ -41,10 +45,6 @@ if (CMAKE_VERSION VERSION_LESS "3.15.0")
     set(Python_INCLUDE_DIRS "${PYTHON_INCLUDE_PATH}")
     set(Python_LIBRARIES "${PYTHON_LIBRARIES}")
 else ()
-    if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
-        cmake_policy(SET CMP0094 NEW)  # FindPython should return the first matching Python on PATH
-    endif ()
-
     if (DEFINED PYTHON_EXECUTABLE)
         set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
     endif ()

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -29,10 +29,8 @@ if (CMAKE_VERSION VERSION_LESS "3.15.0")
 
     find_package (PythonInterp REQUIRED)
     # forward compatibility with FindPython
-    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
-    set(Python_LIBRARIES "${PYTHON_LIBRARIES}")
-    set(Python_INCLUDE_DIRS "${PYTHON_INCLUDE_PATH}")
     set(Python_VERSION_STRING "${PYTHON_VERSION_STRING}")
+    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
     # for completeness, these are not actually used now
     set(Python_VERSION_MAJOR "${PYTHON_VERSION_MAJOR}")
     set(Python_VERSION_MINOR "${PYTHON_VERSION_MINOR}")
@@ -40,6 +38,8 @@ if (CMAKE_VERSION VERSION_LESS "3.15.0")
 
     find_package (PythonLibs ${PYTHON_VERSION_STRING} EXACT)
     set(Python_Development_FOUND "${PYTHONLIBS_FOUND}")
+    set(Python_INCLUDE_DIRS "${PYTHON_INCLUDE_PATH}")
+    set(Python_LIBRARIES "${PYTHON_LIBRARIES}")
 else ()
     if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
         cmake_policy(SET CMP0094 NEW)  # FindPython should return the first matching Python on PATH


### PR DESCRIPTION
Use https://cmake.org/cmake/help/git-stage/module/FindPython.html

There is few issues with doing this

* branching on CMake version is bad practice
* PYTHON_EXECUTABLE can be specified from outside, this changes user API (depending on CMake version)
* Travis CI apparently uses CMake 3.12 (on all Ubuntu versions); can be upgraded