### PR TITLE
PROTON-2346: c/src/proactor/epoll-internal.h: fix build on musl

### DIFF
--- a/c/src/proactor/epoll-internal.h
+++ b/c/src/proactor/epoll-internal.h
@@ -315,6 +315,8 @@ static inline void pmutex_init(pthread_mutex_t *pm){
   pthread_mutexattr_t attr;
 
   pthread_mutexattr_init(&attr);
+  // PROTON-2346: Some stdlibs (e.g., musl) don't implement PTHREAD_MUTEX_ADAPTIVE_NP
+  //  Since this option is a performance hint, it should be harmless to drop it when it's not available.
 #ifdef PTHREAD_MUTEX_ADAPTIVE_NP
   pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ADAPTIVE_NP);
 #endif

--- a/c/src/proactor/epoll-internal.h
+++ b/c/src/proactor/epoll-internal.h
@@ -315,7 +315,9 @@ static inline void pmutex_init(pthread_mutex_t *pm){
   pthread_mutexattr_t attr;
 
   pthread_mutexattr_init(&attr);
+#ifdef PTHREAD_MUTEX_ADAPTIVE_NP
   pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ADAPTIVE_NP);
+#endif
   if (pthread_mutex_init(pm, &attr)) {
     perror("pthread failure");
     abort();


### PR DESCRIPTION
Build with epoll proactor on musl is broken since at least version 0.23.0 and
https://github.com/apache/qpid-proton/commit/37136940e3077f25ce58c94775f48c66f666f4a8
because musl does not define PTHREAD_MUTEX_ADAPTIVE_NP resulting in the
following build failure:

In file included from /home/giuliobenetti/autobuild/run/instance-0/output-1/build/qpid-proton-0.33.0/c/src/proactor/epoll.c:60:
/home/giuliobenetti/autobuild/run/instance-0/output-1/build/qpid-proton-0.33.0/c/src/proactor/epoll-internal.h: In function 'pmutex_init':
/home/giuliobenetti/autobuild/run/instance-0/output-1/build/qpid-proton-0.33.0/c/src/proactor/epoll-internal.h:319:36: error: 'PTHREAD_MUTEX_ADAPTIVE_NP' undeclared (first use in this function); did you mean 'PTHREAD_MUTEX_STALLED'?
  319 |   pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ADAPTIVE_NP);
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                                    PTHREAD_MUTEX_STALLED

Fixes:
 - http://autobuild.buildroot.org/results/6a901b9ff68b7f52cabf8273d1017025fbd93b0d

Signed-off-by: Fabrice Fontaine