### PR TITLE
PROTON-2355: Fix build with -DPROACTOR=none

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -464,7 +464,11 @@ set(qpid-proton-noncore-src
   ${qpid-proton-include-extra}
 )
 
-add_library (qpid-proton SHARED $<TARGET_OBJECTS:qpid-proton-core-objects> $<TARGET_OBJECTS:qpid-proton-platform-io-objects> $<TARGET_OBJECTS:qpid-proton-proactor-objects> ${qpid-proton-noncore-src})
+add_library (qpid-proton SHARED
+  $<TARGET_OBJECTS:qpid-proton-core-objects>
+  $<TARGET_OBJECTS:qpid-proton-platform-io-objects>
+  $<$<TARGET_EXISTS:qpid-proton-proactor-objects>:$<TARGET_OBJECTS:qpid-proton-proactor-objects>>
+  ${qpid-proton-noncore-src})
 target_link_libraries (qpid-proton LINK_PRIVATE ${SSL_LIB} ${SASL_LIB} ${TIME_LIB} ${PLATFORM_LIBS} ${PROACTOR_LIBS})
 set_target_properties (qpid-proton
   PROPERTIES
@@ -480,7 +484,10 @@ if (BUILD_STATIC_LIBS)
     C_EXTENSIONS ON)
   add_library(qpid-proton-static STATIC $<TARGET_OBJECTS:qpid-proton-platform-io-static> ${qpid-proton-noncore-src})
   target_compile_definitions(qpid-proton-static PUBLIC PROTON_DECLARE_STATIC)
-  target_link_libraries (qpid-proton-static qpid-proton-core-static qpid-proton-proactor-static ${SSL_LIB} ${SASL_LIB} ${TIME_LIB} ${PLATFORM_LIBS} ${PROACTOR_LIBS})
+  target_link_libraries (qpid-proton-static
+    qpid-proton-core-static
+    $<$<TARGET_EXISTS:qpid-proton-proactor-static>:qpid-proton-proactor-static>
+    ${SSL_LIB} ${SASL_LIB} ${TIME_LIB} ${PLATFORM_LIBS} ${PROACTOR_LIBS})
 endif(BUILD_STATIC_LIBS)
 
 # Install executables and libraries


### PR DESCRIPTION
epoll proactor unconditionally uses pthread.h which will result in the
following build failure:

[  3%] Building C object c/CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/epoll.c.o
In file included from /nvme/rc-buildroot-test/scripts/instance-0/output-1/build/qpid-proton-0.33.0/c/src/proactor/epoll.c:60:
/nvme/rc-buildroot-test/scripts/instance-0/output-1/build/qpid-proton-0.33.0/c/src/proactor/epoll-internal.h:37:10: fatal error: pthread.h: No such file or directory
   37 | #include <pthread.h>
      |          ^~~~~~~~~~~

To fix this failure, the user could use -DPROACTOR=none but it also
fails on:

CMake Error at c/CMakeLists.txt:481 (add_library):
  Error evaluating generator expression:

    $<TARGET_OBJECTS:qpid-proton-proactor-objects>

  Objects of target "qpid-proton-proactor-objects" referenced but no such
  target exists.