### PR TITLE
PROTON-2323 Propagate requested version from FindPython to FindPythonInterp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,10 @@ before_install:
   - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then curl -sSf --retry 5 -o python-3.6.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-3.6.8.tar.bz2; fi
   - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then sudo tar xjf python-3.6.8.tar.bz2 --directory /; fi
   - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then PATH="/opt/python/3.6.8/bin:${PATH}"; fi
+  # same thing for bionic
+  - if [[ "${TRAVIS_DIST}" == "bionic" ]]; then curl -sSf --retry 5 -o python-3.6.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/python-3.6.8.tar.bz2; fi
+  - if [[ "${TRAVIS_DIST}" == "bionic" ]]; then sudo tar xjf python-3.6.8.tar.bz2 --directory /; fi
+  - if [[ "${TRAVIS_DIST}" == "bionic" ]]; then PATH="/opt/python/3.6.8/bin:${PATH}"; fi
 
 install:
 - echo "Using PYTHON=${PYTHON:=python}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,6 +158,10 @@ before_install:
   # https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527
   - if [[ "${TRAVIS_DIST}" == "focal" ]]; then sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2; fi
   - if [[ "${TRAVIS_DIST}" == "focal" ]]; then sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install valgrind -o Debug::pkgProblemResolver=yes; fi
+  # install Python 3.6.8; Travis has a mechanism for this, but that would activate it in a venv, which older CMake does not deal well with
+  - curl -sSf --retry 5 -o python-3.6.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-3.6.8.tar.bz2
+  - sudo tar xjf python-3.6.8.tar.bz2 --directory /
+  - PATH="/opt/python/3.6.8/bin:${PATH}"
 
 install:
 - echo "Using PYTHON=${PYTHON:=python}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,9 +159,9 @@ before_install:
   - if [[ "${TRAVIS_DIST}" == "focal" ]]; then sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2; fi
   - if [[ "${TRAVIS_DIST}" == "focal" ]]; then sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install valgrind -o Debug::pkgProblemResolver=yes; fi
   # install Python 3.6.8; Travis has a mechanism for this, but that would activate it in a venv, which older CMake does not deal well with
-  - curl -sSf --retry 5 -o python-3.6.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-3.6.8.tar.bz2
-  - sudo tar xjf python-3.6.8.tar.bz2 --directory /
-  - PATH="/opt/python/3.6.8/bin:${PATH}"
+  - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then curl -sSf --retry 5 -o python-3.6.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-3.6.8.tar.bz2; fi
+  - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then sudo tar xjf python-3.6.8.tar.bz2 --directory /; fi
+  - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then PATH="/opt/python/3.6.8/bin:${PATH}"; fi
 
 install:
 - echo "Using PYTHON=${PYTHON:=python}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif ()
 if (NOT DEFINED Python_FIND_FRAMEWORK)
   set(Python_FIND_FRAMEWORK "LAST")
 endif ()
-find_package(Python
+find_package(Python 3.6.8
         REQUIRED COMPONENTS Interpreter
         OPTIONAL_COMPONENTS Development)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif ()
 if (NOT DEFINED Python_FIND_FRAMEWORK)
   set(Python_FIND_FRAMEWORK "LAST")
 endif ()
-find_package(Python 3.6.8
+find_package(Python 3.6
         REQUIRED COMPONENTS Interpreter
         OPTIONAL_COMPONENTS Development)
 

--- a/tools/cmake/Modules/FindPython.cmake
+++ b/tools/cmake/Modules/FindPython.cmake
@@ -35,7 +35,7 @@ if (CMAKE_VERSION VERSION_LESS "3.15.0")
         set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
     endif ()
 
-    find_package (PythonInterp REQUIRED)
+    find_package (PythonInterp ${Python_FIND_VERSION} REQUIRED)
     # forward compatibility with FindPython
     set(Python_VERSION_STRING "${PYTHON_VERSION_STRING}")
     set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")


### PR DESCRIPTION
Not immediately useful in Proton. This is to keep the module in sync with Dispatch code where it is duplicated.