### PR TITLE
PROTON-2389 Add COMPILE_FLAGS for test_main.cpp

### DIFF
--- a/c/tests/CMakeLists.txt
+++ b/c/tests/CMakeLists.txt
@@ -39,6 +39,8 @@ endif()
 if (CMAKE_CXX_COMPILER)
 
   add_library(test_main OBJECT test_main.cpp)
+  set_target_properties(test_main PROPERTIES
+    COMPILE_FLAGS "${CXX_STANDARD} ${CMAKE_CXX_FLAGS} ${CXX_WARNING_FLAGS} ${LTO}")
 
   macro(add_c_test exe)
     add_executable(${exe} $<TARGET_OBJECTS:test_main> pn_test.cpp ${ARGN})


### PR DESCRIPTION
This is needed on RHEL 7, which defaults to -std=c++03, causing compilation failure.