### PR TITLE
PROTON-2254 Use more modern CMake install machinery for better config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,21 +276,17 @@ set (MAN_INSTALL_DIR share/man CACHE PATH "Manpage directory")
 
 mark_as_advanced (INCLUDE_INSTALL_DIR LIB_INSTALL_DIR SYSCONF_INSTALL_DIR SHARE_INSTALL_DIR MAN_INSTALL_DIR)
 
-macro (pn_absolute_install_dir NAME VALUE PREFIX)
+# ${PACKAGE_PREFIX_DIR} is expanded from @PACKAGE_INIT@
+# by configure_package_config_file(), and available in ProtonConfig.cmake
+macro (pn_relative_install_dir NAME VALUE)
   if (IS_ABSOLUTE ${VALUE})
-    set (${NAME} "${VALUE}")
-  elseif (IS_ABSOLUTE ${PREFIX})
-    set (${NAME} "${PREFIX}/${VALUE}")
-  else ()
-    set (${NAME} "${CMAKE_BINARY_DIR}/${PREFIX}/${VALUE}")
+    message(FATAL_ERROR "pn_relative_install_dir requires relative directory")
   endif ()
-  get_filename_component (${NAME} ${${NAME}} ABSOLUTE)
+
+  set (${NAME} "\${PACKAGE_PREFIX_DIR}/${VALUE}")
 endmacro ()
 
-pn_absolute_install_dir (PREFIX "." ${CMAKE_INSTALL_PREFIX})
-pn_absolute_install_dir (EXEC_PREFIX "." ${CMAKE_INSTALL_PREFIX})
-pn_absolute_install_dir (LIBDIR ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX})
-pn_absolute_install_dir (INCLUDEDIR ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX})
+pn_relative_install_dir (INCLUDEDIR ${INCLUDE_INSTALL_DIR})
 
 ## LANGUAGE BINDINGS
 

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -509,7 +509,7 @@ install(TARGETS qpid-proton qpid-proton-core
   ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
   LIBRARY DESTINATION ${LIB_INSTALL_DIR})
 if (BUILD_STATIC_LIBS)
-  install(TARGETS qpid-proton-static qpid-proton-core-static}
+  install(TARGETS qpid-proton-static qpid-proton-core-static
     EXPORT  ProtonTargetsStatic
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION ${LIB_INSTALL_DIR}

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -413,12 +413,15 @@ set_target_properties (qpid-proton-core
   VERSION   "${PN_LIB_CORE_VERSION}"
   SOVERSION "${PN_LIB_CORE_MAJOR_VERSION}"
   COMPILE_FLAGS "${LTO}"
-  LINK_FLAGS "${CATCH_UNDEFINED} ${LINK_LTO}")
+  LINK_FLAGS "${CATCH_UNDEFINED} ${LINK_LTO}"
+  EXPORT_NAME core)
 
 if (BUILD_STATIC_LIBS)
   add_library (qpid-proton-core-static STATIC ${qpid-proton-core-src})
   target_compile_definitions(qpid-proton-core-static PUBLIC PROTON_DECLARE_STATIC)
   target_link_libraries (qpid-proton-core-static ${SSL_LIB} ${SASL_LIB} ${PLATFORM_LIBS})
+  set_target_properties(qpid-proton-core-static PROPERTIES
+    EXPORT_NAME core)
 endif(BUILD_STATIC_LIBS)
 
 if (qpid-proton-proactor)
@@ -451,11 +454,16 @@ if (qpid-proton-proactor)
     SOVERSION "${PN_LIB_PROACTOR_MAJOR_VERSION}"
     LINK_FLAGS "${CATCH_UNDEFINED} ${LINK_LTO}"
     COMPILE_FLAGS "${LTO}"
+    EXPORT_NAME proactor
     )
   if (BUILD_STATIC_LIBS)
     add_library (qpid-proton-proactor-static STATIC ${qpid-proton-proactor})
     target_compile_definitions(qpid-proton-proactor-static PUBLIC PROTON_DECLARE_STATIC)
-    target_link_libraries (qpid-proton-proactor-static ${PLATFORM_LIBS} ${PROACTOR_LIBS})
+    target_link_libraries (qpid-proton-proactor-static LINK_PUBLIC qpid-proton-core-static)
+    target_link_libraries (qpid-proton-proactor-static PRIVATE ${PLATFORM_LIBS} ${PROACTOR_LIBS})
+    set_target_properties(qpid-proton-proactor-static PROPERTIES
+      EXPORT_NAME proactor)
+    set(TARGET_qpid-proton-proactor-static qpid-proton-proactor-static)
   endif(BUILD_STATIC_LIBS)
 endif()
 
@@ -477,6 +485,7 @@ set_target_properties (qpid-proton
   SOVERSION "${PN_LIB_LEGACY_MAJOR_VERSION}"
   LINK_FLAGS "${CATCH_UNDEFINED} ${LINK_LTO}"
   COMPILE_FLAGS "${LTO}"
+  EXPORT_NAME qpid-proton
 )
 
 if (BUILD_STATIC_LIBS)
@@ -487,19 +496,25 @@ if (BUILD_STATIC_LIBS)
   target_compile_definitions(qpid-proton-static PUBLIC PROTON_DECLARE_STATIC)
   target_link_libraries (qpid-proton-static
     qpid-proton-core-static
-    $<$<BOOL:${HAS_PROACTOR}>:qpid-proton-proactor-static>
+    ${TARGET_qpid-proton-proactor-static}
     ${SSL_LIB} ${SASL_LIB} ${TIME_LIB} ${PLATFORM_LIBS} ${PROACTOR_LIBS})
+  set_target_properties(qpid-proton-static PROPERTIES
+    EXPORT_NAME qpid-proton)
 endif(BUILD_STATIC_LIBS)
 
 # Install executables and libraries
-if (BUILD_STATIC_LIBS)
-  set(STATIC_LIBS qpid-proton-static qpid-proton-core-static)
-endif()
-install(TARGETS qpid-proton qpid-proton-core ${STATIC_LIBS}
-  EXPORT  proton
+install(TARGETS qpid-proton qpid-proton-core
+  EXPORT  ProtonTargets
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
   LIBRARY DESTINATION ${LIB_INSTALL_DIR})
+if (BUILD_STATIC_LIBS)
+  install(TARGETS qpid-proton-static qpid-proton-core-static}
+    EXPORT  ProtonTargetsStatic
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR})
+endif()
 
 # Install windows pdb files
 if (MSVC)
@@ -512,14 +527,18 @@ if (MSVC)
 endif (MSVC)
 
 if (HAS_PROACTOR)
-  if (BUILD_STATIC_LIBS)
-    set(STATIC_LIBS qpid-proton-proactor-static)
-  endif()
   install(TARGETS qpid-proton-proactor ${STATIC_LIBS}
-    EXPORT  proton
+    EXPORT  ProtonTargets
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
     LIBRARY DESTINATION ${LIB_INSTALL_DIR})
+  if (BUILD_STATIC_LIBS)
+    install(TARGETS qpid-proton-proactor-static
+      EXPORT  ProtonTargetsStatic
+      RUNTIME DESTINATION bin
+      ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+      LIBRARY DESTINATION ${LIB_INSTALL_DIR})
+  endif()
 
   # Install windows pdb files
   if (MSVC)
@@ -557,11 +576,24 @@ if(HAS_PROACTOR)
   configure_lib(PROTONPROACTORLIB qpid-proton-proactor)
 endif(HAS_PROACTOR)
 
+install(EXPORT ProtonTargets
+  FILE ProtonTargets.cmake
+  NAMESPACE Proton::
+  DESTINATION ${LIB_INSTALL_DIR}/cmake/Proton)
+if (BUILD_STATIC_LIBS)
+  install(EXPORT ProtonTargetsStatic
+    FILE ProtonTargetsStatic.cmake
+    NAMESPACE Proton::
+    DESTINATION ${LIB_INSTALL_DIR}/cmake/Proton)
+endif()
+
+include(CMakePackageConfigHelpers)
 include(WriteBasicConfigVersionFile)
 
-configure_file(
+configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ProtonConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/ProtonConfig.cmake @ONLY)
+  ${CMAKE_CURRENT_BINARY_DIR}/ProtonConfig.cmake
+  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/cmake/Proton)
 write_basic_config_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/ProtonConfigVersion.cmake
   VERSION ${PN_VERSION}
@@ -569,6 +601,11 @@ write_basic_config_version_file(
 install (FILES
   ${CMAKE_CURRENT_BINARY_DIR}/ProtonConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/ProtonConfigVersion.cmake
+  DESTINATION ${LIB_INSTALL_DIR}/cmake/Proton)
+install (FILES
+  ../tools/cmake/Modules/FindCyrusSASL.cmake
+  ../tools/cmake/Modules/FindOpenSSL.cmake
+  ../tools/cmake/Modules/FindThreads.cmake
   DESTINATION ${LIB_INSTALL_DIR}/cmake/Proton)
 
 if (ENABLE_BENCHMARKS)

--- a/c/src/ProtonConfig.cmake.in
+++ b/c/src/ProtonConfig.cmake.in
@@ -62,7 +62,7 @@ set (Proton_Core_FOUND True)
 
 set (HAS_PROACTOR @HAS_PROACTOR@)
 if (HAS_PROACTOR)
-  set (Proton_Proactor_INCLUDE_DIRS  @INCLUDEDIR@)
+  set (Proton_Proactor_INCLUDE_DIRS @INCLUDEDIR@)
   set (Proton_Proactor_LIBRARIES Proton::proactor)
   set (Proton_Proactor_FOUND True)
 endif()

--- a/c/src/ProtonConfig.cmake.in
+++ b/c/src/ProtonConfig.cmake.in
@@ -52,7 +52,7 @@ if (Proton_USE_STATIC_LIBS)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_OLD})
 endif()
 
-set(Proton_INCLUDE_DIRS @INCLUDEDIR@)
+set (Proton_INCLUDE_DIRS @INCLUDEDIR@)
 set (Proton_LIBRARIES Proton::qpid-proton)
 set (Proton_FOUND True)
 

--- a/c/src/ProtonConfig.cmake.in
+++ b/c/src/ProtonConfig.cmake.in
@@ -22,50 +22,49 @@
 # Version: @PN_VERSION@
 # URL: http://qpid.apache.org/proton/
 
-set (Proton_VERSION       @PN_VERSION@)
-
-set (Proton_INCLUDE_DIRS  @INCLUDEDIR@)
-set (Proton_LIBRARIES     optimized @LIBDIR@/@PROTONLIB@ debug @LIBDIR@/@PROTONLIBDEBUG@)
-set (Proton_FOUND True)
-
-set (Proton_Core_INCLUDE_DIRS  @INCLUDEDIR@)
-set (Proton_Core_LIBRARIES     optimized @LIBDIR@/@PROTONCORELIB@ debug @LIBDIR@/@PROTONCORELIBDEBUG@)
-
-# Add modular target in a way compatible with cmake 2.8.12
-if (NOT TARGET Proton::core)
-  add_library(Proton::core UNKNOWN IMPORTED)
-  set_target_properties(Proton::core
-    PROPERTIES
-      IMPORTED_LOCATION "@LIBDIR@/@PROTONCORELIB@"
-      IMPORTED_LOCATION_DEBUG "@LIBDIR@/@PROTONCORELIBDEBUG@"
-      INTERFACE_INCLUDE_DIRECTORIES "${Proton_Core_INCLUDE_DIRS}")
+@PACKAGE_INIT@
+if (NOT Proton_USE_STATIC_LIBS)
+  include("${CMAKE_CURRENT_LIST_DIR}/ProtonTargets.cmake")
+else()
+  include("${CMAKE_CURRENT_LIST_DIR}/ProtonTargetsStatic.cmake")
 endif()
 
+set(Proton_VERSION @PN_VERSION@)
+
+# find dependencies, because static libs don't transitively pull them
+if (Proton_USE_STATIC_LIBS)
+    set(CMAKE_MODULE_PATH_OLD ${CMAKE_MODULE_PATH})
+    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+    set(CyrusSASL_FOUND @CyrusSASL_FOUND@)
+    if (CyrusSASL_FOUND)
+        find_package (CyrusSASL REQUIRED)
+    endif()
+
+    set(OPENSSL_FOUND @OPENSSL_FOUND@)
+    set(OpenSSL_FOUND @OpenSSL_FOUND@)
+    if (OPENSSL_FOUND OR OpenSSL_FOUND)
+        find_package (OpenSSL REQUIRED)
+    endif()
+
+    find_package (Threads REQUIRED)
+
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_OLD})
+endif()
+
+set(Proton_INCLUDE_DIRS @INCLUDEDIR@)
+set (Proton_LIBRARIES Proton::qpid-proton)
+set (Proton_FOUND True)
+
+set (Proton_Core_INCLUDE_DIRS @INCLUDEDIR@)
+set (Proton_Core_LIBRARIES Proton::core)
 set (Proton_Core_FOUND True)
 
 set (HAS_PROACTOR @HAS_PROACTOR@)
 if (HAS_PROACTOR)
   set (Proton_Proactor_INCLUDE_DIRS  @INCLUDEDIR@)
-  set (Proton_Proactor_LIBRARIES     optimized @LIBDIR@/@PROTONPROACTORLIB@ debug @LIBDIR@/@PROTONPROACTORLIBDEBUG@)
-  # Add modular target in a way compatible with cmake 2.8.12
-  if (NOT TARGET Proton::proactor)
-    add_library(Proton::proactor UNKNOWN IMPORTED)
-    set_target_properties(Proton::proactor
-      PROPERTIES
-        IMPORTED_LOCATION "@LIBDIR@/@PROTONPROACTORLIB@"
-        IMPORTED_LOCATION_DEBUG "@LIBDIR@/@PROTONPROACTORLIBDEBUG@"
-        INTERFACE_INCLUDE_DIRECTORIES "${Proton_Proactor_INCLUDE_DIRS}")
-  endif()
-
+  set (Proton_Proactor_LIBRARIES Proton::proactor)
   set (Proton_Proactor_FOUND True)
 endif()
 
-# Check for all required components
-foreach(comp ${Proton_FIND_COMPONENTS})
-  if(NOT Proton_${comp}_FOUND)
-    if(Proton_FIND_REQUIRED_${comp})
-      set(Proton_FOUND FALSE)
-      set(Proton_NOT_FOUND_MESSAGE "Didn't find required component ${comp}")
-    endif()
-  endif()
-endforeach()
+check_required_components(Proton)


### PR DESCRIPTION
This supersedes #312 and allows building static Dispatch on CentOS 7.

* Build Proton with `-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_STATIC_LIBS=ON -DBUILD_BINDINGS=OFF -DCMAKE_INSTALL_PREFIX=install`
* Build Dispatch with `-DProton_DIR=qpid-proton/build/install/lib64/cmake/Proton -DProton_USE_STATIC_LIBS=ON`

This version will be hopefully upstreamable.