### PR TITLE
[DRAFT] [cpp] Add distributed tracing using OpenTelemetry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    if: github.repository == 'DreamPearl/qpid-proton'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,6 +25,12 @@ jobs:
       InstallPrefix: ${{github.workspace}}/INSTALL
       PKG_CONFIG_PATH: ${{matrix.pkg_config_path}}
       VCPKG_DEFAULT_TRIPLET: x64-windows
+      OTelDir: ${{github.workspace}}/opentelemetry-cpp
+      OTelBuildDir: ${{github.workspace}}/opentelemetry-cpp/BLD
+      OTelInstallPrefix: /usr
+      CurlDir: ${{github.workspace}}/curl
+      CurlBuildDir: ${{github.workspace}}/curl/BLD
+      CurlInstallPrefix: /usr
     steps:
     - uses: actions/checkout@v2
     - name: Create Build and Install directories
@@ -60,9 +67,59 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install libuv swig pkgconfig jsoncpp
+    - name: Checkout curl repo (for jaeger)
+      if: runner.os == 'Linux'
+      uses: actions/checkout@v2
+      with:
+        repository: curl/curl
+        path: ${{env.CurlDir}}
+        submodules: recursive
+    - name: Create Build directory for curl
+      run: mkdir -p "${CurlBuildDir}"
+      shell: bash
+    - name: curl cmake configure
+      if: runner.os == 'Linux'
+      working-directory: ${{env.CurlBuildDir}}
+      run: cmake "${{github.workspace}}/curl" "-DCMAKE_INSTALL_PREFIX=${CurlInstallPrefix}" "-DBUILD_SHARED_LIBS=ON" "-DCMAKE_POSITION_INDEPENDENT_CODE=ON" "-DBUILD_TESTING=OFF" "-DCMAKE_BUILD_TYPE=${BuildType}"
+      shell: bash
+    - name: curl cmake build/install
+      if: runner.os == 'Linux'
+      run: |
+        cmake --build "${CurlBuildDir}" --target all
+        sudo cmake --install "${CurlBuildDir}" --config ${BuildType}
+      shell: bash
+    - name: install thrift (for jaeger)
+      if: runner.os == 'Linux'
+      run: sudo ./ci/setup_thrift.sh
+      shell: bash
+    - name: Create directory for opentelemetry-cpp
+      run: mkdir -p "${OTelDir}"
+      shell: bash
+    - name: Checkout opentelemetry-cpp repo
+      if: runner.os == 'Linux'
+      uses: actions/checkout@v2
+      with:
+        repository: open-telemetry/opentelemetry-cpp
+        path: ${{env.OTelDir}}
+        submodules: recursive
+    - name: Create Build directory for opentelemetry-cpp
+      if: runner.os == 'Linux'
+      run: mkdir -p "${OTelBuildDir}"
+      shell: bash
+    - name: opentelemetry-cpp cmake configure
+      if: runner.os == 'Linux'
+      working-directory: ${{env.OTelBuildDir}}
+      run: cmake "${{github.workspace}}/opentelemetry-cpp" "-DCMAKE_INSTALL_PREFIX=${OTelInstallPrefix}" "-DBUILD_SHARED_LIBS=ON" "-DCMAKE_POSITION_INDEPENDENT_CODE=ON" "-DBUILD_TESTING=OFF" "-DCMAKE_BUILD_TYPE=${BuildType}" "-DWITH_JAEGER=ON"
+      shell: bash
+    - name: opentelemetry-cpp cmake build/install
+      if: runner.os == 'Linux'
+      run: |
+        cmake --build "${OTelBuildDir}" --target all
+        sudo cmake --install "${OTelBuildDir}" --config ${BuildType}
+      shell: bash
     - name: cmake configure
       working-directory: ${{env.BuildDir}}
-      run: cmake "${{github.workspace}}" "-DCMAKE_BUILD_TYPE=${BuildType}" "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" ${{matrix.cmake_extra}}
+      run: cmake "${{github.workspace}}" "-DCMAKE_BUILD_TYPE=${BuildType}" "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" ${{matrix.cmake_extra}} "-Dopentelemetry-cpp_DIR=${OTelInstallPrefix}/lib/cmake/opentelemetry-cpp"
       shell: bash
     - name: cmake build/install
       run: cmake --build "${BuildDir}" --config ${BuildType} -t install

--- a/ci/setup_thrift.sh
+++ b/ci/setup_thrift.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+export DEBIAN_FRONTEND=noninteractive
+export THRIFT_VERSION=0.14.1
+
+if ! type cmake > /dev/null; then
+    #cmake not installed, exiting
+    exit 1
+fi
+export BUILD_DIR=/tmp/
+export INSTALL_DIR=/usr/
+
+apt install -y --no-install-recommends \
+      libboost-all-dev \
+      libevent-dev \
+      libssl-dev \
+      ninja-build
+
+pushd $BUILD_DIR
+wget https://github.com/apache/thrift/archive/refs/tags/v${THRIFT_VERSION}.tar.gz
+tar -zxvf v${THRIFT_VERSION}.tar.gz
+cd thrift-${THRIFT_VERSION}
+mkdir -p out
+pushd out
+cmake -G Ninja .. \
+    -DBUILD_COMPILER=OFF \
+    -DBUILD_CPP=ON \
+    -DBUILD_LIBRARIES=ON \
+    -DBUILD_NODEJS=OFF \
+    -DBUILD_PYTHON=OFF \
+    -DBUILD_JAVASCRIPT=OFF \
+    -DBUILD_C_GLIB=OFF \
+    -DBUILD_JAVA=OFF \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_TUTORIALS=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    ..
+
+ninja -j $(nproc)
+ninja install
+popd
+popd

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,10 +19,10 @@
 
 include(CMakeDependentOption)
 enable_language(CXX)
+include(CMakePrintHelpers)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads)
-
 include(versions.cmake)
 
 # Check for JSON-CPP support for connection configuration
@@ -36,10 +36,42 @@ else()
   set(CONNECT_CONFIG_SRC src/connect_config_dummy.cpp)
 endif()
 
+# Check for OPENTELEMETRY-CPP for distributed tracing
+find_package(opentelemetry-cpp)
+option(ENABLE_OPENTELEMETRYCPP "Use opentelemetry for distributed tracing" ${OPENTELEMETRY-CPP_FOUND})
+MESSAGE("opentelemetrycpp found: ${OPENTELEMETRY-CPP_FOUND}")
+MESSAGE("ENABLE_OPENTELEMETRYCPP: ${ENABLE_OPENTELEMETRYCPP}")
+
+if (ENABLE_OPENTELEMETRYCPP)
+  add_compile_definitions(ENABLE_OPENTELEMETRYCPP)
+  include_directories(${OPENTELEMETRY_CPP_INCLUDE_DIRS})
+  set(TRACING_SRC src/tracing.cpp)
+  set(TRACING_LIBS ${OPENTELEMETRY_CPP_LIBRARIES})
+
+  set(CURL_LIBRARY "-lcurl")
+  find_package(CURL REQUIRED)
+  include_directories(${CURL_INCLUDE_DIR})
+  MESSAGE("Curl found: ${CURL_FOUND}")
+  set(CURL_LIBS ${CURL_LIBRARIES})
+
+  find_package(Thrift REQUIRED)
+  include_directories(${THRIFT_INCLUDE_DIR})
+  MESSAGE("Thrift found: ${THRIFT_FOUND}")
+  set(THRIFT_LIBS ${THRIFT_LIBRARIES})
+  set(THRIFT_THRIFT thrift::thrift)
+
+else()
+  set(TRACING_SRC src/tracing_dummy.cpp)
+endif()
+
 list(APPEND PLATFORM_LIBS Threads::Threads)
 
 set(CXX_EXAMPLE_FLAGS "${CXX_WARNING_FLAGS} ${CXX_STANDARD}")
 set(CXX_EXAMPLE_LINK_FLAGS "${SANITIZE_FLAGS}")
+
+cmake_print_variables(OPENTELEMETRY_CPP_INCLUDE_DIRS OPENTELEMETRY_CPP_LIBRARIES)
+cmake_print_variables(CURL_INCLUDE_DIRS CURL_LIBRARIES)
+cmake_print_variables(THRIFT_INCLUDE_DIRS THRIFT_LIBRARIES)
 
 include_directories (
   "${CMAKE_SOURCE_DIR}/c/include"
@@ -105,6 +137,7 @@ set(qpid-proton-cpp-source
   src/value.cpp
   src/work_queue.cpp
   ${CONNECT_CONFIG_SRC}
+  ${TRACING_SRC}
   )
 
 add_library(qpid-proton-cpp SHARED ${qpid-proton-cpp-source})
@@ -119,7 +152,7 @@ if(BUILD_STATIC_LIBS)
     EXPORT_NAME cpp)
 endif(BUILD_STATIC_LIBS)
 
-target_link_libraries (qpid-proton-cpp LINK_PRIVATE ${PLATFORM_LIBS} qpid-proton-core qpid-proton-proactor ${CONNECT_CONFIG_LIBS})
+target_link_libraries (qpid-proton-cpp LINK_PRIVATE ${PLATFORM_LIBS} qpid-proton-core qpid-proton-proactor ${CONNECT_CONFIG_LIBS} ${TRACING_LIBS} ${CURL_LIBS} ${THRIFT_LIBS} ${THRIFT_THRIFT})
 
 set_target_properties (
   qpid-proton-cpp

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -52,7 +52,6 @@ else ()
   add_definitions(${CXX_STANDARD})
 endif()
 
-
 # Single-threaded examples
 foreach(example
     broker
@@ -89,3 +88,17 @@ foreach(example
   add_executable(${example} ${example}.cpp)
   target_link_libraries(${example} Proton::cpp Threads::Threads)
 endforeach()
+
+if (ENABLE_OPENTELEMETRYCPP)
+  set(example tracing_demo)
+  # set(JAEGER_THRIFT_GENCPP_SOURCES
+  #   thrift-gen/Agent.cpp thrift-gen/jaeger_types.cpp thrift-gen/Collector.cpp
+  #   thrift-gen/zipkincore_types.cpp)
+
+  # add_library(opentelemetry_exporter_jaeger_trace ${JAEGER_THRIFT_GENCPP_SOURCES})
+  add_executable(${example} ${example}.cpp)
+  include_directories(${CMAKE_SOURCE_DIR}/exporters/jaeger/include)
+  
+  target_link_libraries(${example} Proton::cpp opentelemetry_trace opentelemetry_exporter_jaeger_trace)
+  # target_link_libraries(${example} Proton::cpp opentelemetry_trace opentelemetry_exporter_ostream_span)
+endif()

--- a/cpp/examples/README.dox
+++ b/cpp/examples/README.dox
@@ -137,3 +137,55 @@ A multithreaded sender and receiver enhanced for flow control.
 __Requires C++11__
 
 */
+
+/** @example tracing_demo.cpp
+
+A working example of distributed tracing. 
+
+Steps to run this example: 
+
+# Start Jaeger, for example: 
+
+docker run -d --name jaeger \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -p 5775:5775/udp \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 14268:14268 \
+  -p 14250:14250 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:1.25 
+
+# Opentelemetry-cpp: 
+
+1. Clone opentelemetry-cpp 
+
+WORKDIR opentelemetry-cpp 
+2. RUN mkdir bld 
+
+WORKDIR bld 
+3. RUN cmake .. -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DWITH_JAEGER=ON 
+4. RUN make 
+5. RUN sudo make install 
+
+# Start broker, for example: 
+
+cd examples
+./broker
+
+# Build and run the tracing_demo example: 
+
+WORKDIR examples 
+RUN ./tracing_demo
+
+# Look in the Jaeger UI: 
+
+Browse to http://localhost:16686 
+Select the Service dropdown at the top of the Search options (if not already selected). 
+Hit Find Traces. 
+
+__Requires C++11 opentelemetry-cpp__
+
+*/

--- a/cpp/examples/tracing_demo.cpp
+++ b/cpp/examples/tracing_demo.cpp
@@ -1,0 +1,101 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <proton/connection.hpp>
+#include <proton/container.hpp>
+#include <proton/delivery.hpp>
+#include <proton/message.hpp>
+#include <proton/messaging_handler.hpp>
+#include <proton/tracker.hpp>
+#include <proton/tracing.hpp>
+
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+#include <opentelemetry/exporters/jaeger/jaeger_exporter.h>
+
+class tracing_demo : public proton::messaging_handler {
+    std::string conn_url_;
+    std::string addr_;
+
+  public:
+    tracing_demo(const std::string& u, const std::string& a) :
+        conn_url_(u), addr_(a) {}
+
+    void on_container_start(proton::container& c) override {
+        c.connect(conn_url_);
+    }
+
+    void on_connection_open(proton::connection& c) override {
+        c.open_receiver(addr_);
+        c.open_sender(addr_);
+    }
+
+    void on_sendable(proton::sender &s) override {
+        proton::message m("Hello Tracing World!");
+        s.send(m);
+        std::cout << "Message sent: " << m.body() << std::endl;
+        // std::cout << "send message_annotations: " << m.message_annotations()
+        //           << std::endl;
+        s.close();
+    }
+
+    void on_tracker_accept(proton::tracker &t) override {
+        std::cout << "all messages confirmed" << std::endl;
+    }
+
+    void on_message(proton::delivery &d, proton::message &m) override {
+        std::cout << "Message received: " << m.body() << std::endl;
+        if (m.message_annotations().empty()) {
+            std::cout << "Message annotations is empty " << std::endl;
+        } else {
+            std::cout << "Message annotations is not empty " << std::endl;
+            std::cout << "Receive message_annotations: "
+                      << m.message_annotations() << std::endl;
+        }
+        d.connection().close();
+    }
+
+};
+
+int main(int argc, char **argv) {
+    try {
+        std::string conn_url = argc > 1 ? argv[1] : "//127.0.0.1:5672";
+        std::string addr = argc > 2 ? argv[2] : "examples";
+
+        opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
+        auto exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
+            new opentelemetry::exporter::jaeger::JaegerExporter(opts));
+        // auto exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
+        //     new opentelemetry::exporter::trace::OStreamSpanExporter());
+
+        proton::initTracer(std::move(exporter));
+        tracing_demo hw(conn_url, addr);
+        proton::container(hw).run();
+
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+    }
+
+    return 1;
+}

--- a/cpp/include/proton/message.hpp
+++ b/cpp/include/proton/message.hpp
@@ -301,7 +301,7 @@ class message {
     PN_CPP_EXTERN annotation_map& message_annotations();
 
     /// Examine the message annotations map.
-    PN_CPP_EXTERN const annotation_map& message_annotations() const;
+    PN_CPP_EXTERN annotation_map& message_annotations() const;
 
     /// Get the delivery annotations map.  It can
     /// be modified in place.

--- a/cpp/include/proton/tracing.hpp
+++ b/cpp/include/proton/tracing.hpp
@@ -1,0 +1,60 @@
+#ifndef PROTON_TRACING_HPP
+#define PROTON_TRACING_HPP
+
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "./internal/export.hpp"
+#include <memory>
+
+#ifdef ENABLE_OPENTELEMETRYCPP
+    #include <opentelemetry/exporters/ostream/span_exporter.h>
+    #include <opentelemetry/sdk/trace/simple_processor.h>
+    #include <opentelemetry/sdk/trace/tracer_provider.h>
+    #include <opentelemetry/trace/provider.h>
+    #include <opentelemetry/trace/span.h>
+    #include "opentelemetry/trace/tracer.h"
+    #include <opentelemetry/trace/span.h>
+#endif
+
+#include <proton/delivery.hpp>
+
+/// @file
+/// @copybrief proton::tracing
+
+namespace proton {
+#ifdef ENABLE_OPENTELEMETRYCPP
+    namespace trace = opentelemetry::trace;
+    namespace sdktrace = opentelemetry::sdk::trace;
+
+    // Tracer initializer.
+    PN_CPP_EXTERN void initTracer(std::unique_ptr<sdktrace::SpanExporter> exporter);
+#endif
+
+// Span function.
+PN_CPP_EXTERN void on_message_start_span(message &message, delivery &d);
+PN_CPP_EXTERN void on_message_end_span(delivery &d);
+PN_CPP_EXTERN void on_settled_span(delivery &d, tracker &track);
+PN_CPP_EXTERN void send_span(const message &message, binary &tag, tracker &track);
+
+} // namespace proton
+
+#endif // PROTON_TRACING_HPP

--- a/cpp/src/message.cpp
+++ b/cpp/src/message.cpp
@@ -254,7 +254,7 @@ message::annotation_map& message::message_annotations() {
     return impl().annotations;
 }
 
-const message::annotation_map& message::message_annotations() const {
+message::annotation_map& message::message_annotations() const {
     return impl().annotations;
 }
 

--- a/cpp/src/sender.cpp
+++ b/cpp/src/sender.cpp
@@ -35,6 +35,7 @@
 #include "contexts.hpp"
 
 #include <assert.h>
+#include <proton/tracing.hpp>
 
 namespace proton {
 
@@ -70,6 +71,12 @@ tracker sender::send(const message &message, const binary &tag) {
     pn_delivery_t *dlv = pn_delivery(
         pn_object(),
         pn_dtag((reinterpret_cast<const char *>(&tag[0])), tag.size()));
+
+    // TODO: Do not copy message.
+    // proton::message message_cp = message;
+    proton::binary tag_cp = tag;
+    tracker track = make_wrapper<tracker>(dlv);
+    send_span(message, tag_cp, track);
     std::vector<char> buf;
     message.encode(buf);
     assert(!buf.empty());

--- a/cpp/src/tracing.cpp
+++ b/cpp/src/tracing.cpp
@@ -1,0 +1,229 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <opentelemetry/sdk/trace/simple_processor.h>
+#include <opentelemetry/sdk/trace/tracer_provider.h>
+#include <opentelemetry/trace/provider.h>
+#include <opentelemetry/trace/span.h>
+#include "opentelemetry/trace/context.h"
+// #include "opentelemetry/trace/experimental_semantic_conventions.h"
+
+#include <proton/messaging_handler.hpp>
+
+// Using an exporter that simply dumps span data to stdout.
+#include <opentelemetry/exporters/ostream/span_exporter.h>
+#include <proton/annotation_key.hpp>
+#include <proton/delivery.hpp>
+#include <proton/message.hpp>
+#include <proton/receiver.hpp>
+#include <proton/sender.hpp>
+#include <proton/source.hpp>
+#include <proton/target.hpp>
+#include <proton/tracing.hpp>
+#include <proton/tracker.hpp>
+#include <proton/transfer.hpp>
+
+#include "opentelemetry/nostd/unique_ptr.h"
+
+#include "opentelemetry/baggage/propagation/baggage_propagator.h"
+#include "opentelemetry/context/propagation/global_propagator.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/trace/propagation/http_trace_context.h"
+
+#include <iostream>
+#include <sstream>
+#include <memory>
+
+namespace proton
+{
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+namespace common = opentelemetry::common;
+namespace context = opentelemetry::context;
+
+const std::string kContextKey = "CONTEXT";
+
+// TODO: Delete map entries to avoid memory leakage in future
+std::map<binary, nostd::shared_ptr<trace::Span>> tag_span;
+
+template <typename T>
+class AMQPTextMapCarrier
+    : public opentelemetry::context::propagation::TextMapCarrier {
+  public:
+    AMQPTextMapCarrier<T>(T *message_annotations)
+        : message_annotations_(message_annotations) {}
+    virtual nostd::string_view
+    Get(nostd::string_view key) const noexcept override {
+        std::string key_to_compare = key.data();
+
+        if (message_annotations_->exists(annotation_key(key_to_compare))) {
+            value extracted_value =
+                message_annotations_->get(annotation_key(key_to_compare));
+            std::string extracted_string = to_string(extracted_value);
+            extracted_strings.push_back(extracted_string);
+            nostd::string_view final_extracted_string =
+                nostd::string_view(extracted_strings.back());
+
+            return final_extracted_string;
+        }
+        return "";
+    }
+
+    virtual void Set(nostd::string_view key,
+                     nostd::string_view val) noexcept override {
+
+        message_annotations_->put(annotation_key(std::string(key)),
+                                  value(std::string(val)));
+    }
+
+    T *message_annotations_;
+    mutable std::vector<std::string> extracted_strings;
+};
+
+void initTracer(std::unique_ptr<sdktrace::SpanExporter> exporter)
+{
+  // auto exporter = std::unique_ptr<sdktrace::SpanExporter>(
+  //     new opentelemetry::exporter::trace::OStreamSpanExporter);
+  auto processor = std::unique_ptr<sdktrace::SpanProcessor>(
+      new sdktrace::SimpleSpanProcessor(std::move(exporter)));
+  auto provider = nostd::shared_ptr<opentelemetry::trace::TracerProvider>(
+      new sdktrace::TracerProvider(std::move(processor)));
+
+  // Set the global trace provider
+  opentelemetry::trace::Provider::SetTracerProvider(provider);
+
+  // set global propagator
+  opentelemetry::context::propagation::GlobalTextMapPropagator::
+      SetGlobalPropagator(
+          nostd::shared_ptr<
+              opentelemetry::context::propagation::TextMapPropagator>(
+              new opentelemetry::trace::propagation::HttpTraceContext()));
+}
+
+nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  nostd::shared_ptr<opentelemetry::trace::Tracer> tracer =
+      provider->GetTracer("qpid-tracer");
+  return tracer;
+}
+
+void on_message_start_span(message &message, delivery &d) {
+
+    opentelemetry::trace::StartSpanOptions options;
+    options.kind          = opentelemetry::trace::SpanKind::kConsumer;
+
+    // extract context from AMQP message annotations
+    const AMQPTextMapCarrier<proton::message::annotation_map> carrier(
+        &message.message_annotations());
+
+    nostd::shared_ptr<
+        opentelemetry::context::propagation::TextMapPropagator>
+        prop = opentelemetry::context::propagation::GlobalTextMapPropagator::
+            GetGlobalPropagator();
+    context::Context current_ctx =
+        opentelemetry::context::RuntimeContext::GetCurrent();
+
+    context::Context new_context = prop->Extract(carrier, current_ctx);
+
+    options.parent =
+        opentelemetry::trace::GetSpan(new_context)->GetContext();
+
+    binary tag_in_binary = d.tag();
+    std::string tag_in_string = std::string(d.tag());
+    std::stringstream ss;
+    for(int i=0; i<(int)tag_in_string.length(); ++i)
+        ss << std::hex << (int)tag_in_binary[i];
+    std::string delivery_tag = ss.str();
+
+    receiver r = d.receiver();
+    source s = r.source();
+    std::string s_addr = s.address();
+
+    transfer tt(d);
+    std::string delivery_state = to_string(tt.state());
+
+    nostd::shared_ptr<trace::Span> span =
+        get_tracer()->StartSpan("amqp-message-received",
+                                {{"Delivery_tag", delivery_tag},
+                                 {"Source_address", s_addr}},
+                                options);
+
+    trace::Scope scope = get_tracer()->WithActiveSpan(span);
+
+    tag_span[tag_in_binary] = span;
+}
+
+void on_message_end_span(delivery &d) {
+    binary tag = d.tag();
+    nostd::shared_ptr<trace::Span> span = tag_span[tag];
+    span->End();
+}
+
+void on_settled_span(delivery &d, tracker &track) {
+    binary tag = d.tag();
+    nostd::shared_ptr<trace::Span> span = tag_span[tag];
+    transfer tt(track);
+    std::string delivery_state = to_string(tt.state());
+    span->AddEvent("delivery state: "+ delivery_state);
+    span->End();
+}
+
+void send_span(const message &message, binary &tag, tracker &track) {
+
+    opentelemetry::trace::StartSpanOptions options;
+    options.kind = opentelemetry::trace::SpanKind::kProducer;
+
+    binary tag_in_binary = tag;
+    std::string tag_in_string = std::string(tag);
+    std::stringstream ss;
+    for (int i = 0; i < (int)tag_in_string.length(); ++i)
+        ss << std::hex << (int)tag_in_binary[i];
+    std::string delivery_tag = ss.str();
+
+    sender s = track.sender();
+    target t = s.target();
+    std::string t_addr = t.address();
+
+    transfer tt(track);
+    std::string delivery_state = to_string(tt.state());
+
+    nostd::shared_ptr<trace::Span> span = get_tracer()->StartSpan(
+        "amqp-delivery-send",
+        {{"Delivery_tag", delivery_tag}, {"Destination_address", t_addr}},
+        options);
+
+    trace::Scope scope = proton::get_tracer()->WithActiveSpan(span);
+
+    // inject current context into AMQP message annotations
+    context::Context current_ctx =
+        opentelemetry::context::RuntimeContext::GetCurrent();
+    AMQPTextMapCarrier<proton::message::annotation_map> carrier(
+        &message.message_annotations());
+    nostd::shared_ptr<
+        opentelemetry::context::propagation::TextMapPropagator>
+        prop = opentelemetry::context::propagation::GlobalTextMapPropagator::
+            GetGlobalPropagator();
+    prop->Inject(carrier, current_ctx);
+
+    tag_span[tag_in_binary] = span;
+}
+}  // namespace proton

--- a/cpp/src/tracing_dummy.cpp
+++ b/cpp/src/tracing_dummy.cpp
@@ -1,0 +1,36 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <proton/tracing.hpp>
+#include <proton/annotation_key.hpp>
+#include <proton/message.hpp>
+
+namespace proton
+{
+void on_message_start_span(message &message, delivery &d) {}
+
+void on_message_end_span(delivery &d) {}
+
+void on_settled_span(delivery &d, tracker &track) {}
+
+void send_span(const message &message, binary &tag, tracker &track) {}
+} // namespace proton
+

--- a/cpp/src/tracing_test.cpp
+++ b/cpp/src/tracing_test.cpp
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <proton/connection.hpp>
+#include <proton/connection_options.hpp>
+#include <proton/container.hpp>
+#include <proton/delivery.hpp>
+#include <proton/link.hpp>
+#include <proton/listen_handler.hpp>
+#include <proton/listener.hpp>
+#include <proton/message.hpp>
+#include <proton/message_id.hpp>
+#include <proton/messaging_handler.hpp>
+#include <proton/tracker.hpp>
+#include <proton/types.h>
+#include <proton/types.hpp>
+#include <proton/value.hpp>
+#include <proton/tracing.hpp>
+
+#include "proton/error_condition.hpp"
+#include "proton/internal/pn_unique_ptr.hpp"
+#include "proton/receiver_options.hpp"
+#include "proton/transport.hpp"
+#include "proton/work_queue.hpp"
+#include "test_bits.hpp"
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <opentelemetry/exporters/ostream/span_exporter.h>
+
+namespace {
+std::mutex m;
+std::condition_variable cv;
+bool listener_ready = false;
+int listener_port;
+const std::string kKeyToCheck = "traceparent";
+} // namespace
+
+class test_recv : public proton::messaging_handler {
+  private:
+    class listener_ready_handler : public proton::listen_handler {
+        void on_open(proton::listener &l) override {
+            {
+                std::lock_guard<std::mutex> lk(m);
+                listener_port = l.port();
+                listener_ready = true;
+            }
+            cv.notify_one();
+        }
+    };
+
+    std::string url;
+    proton::listener listener;
+    listener_ready_handler listen_handler;
+
+  public:
+    test_recv(const std::string &s) : url(s) {}
+
+    void on_container_start(proton::container &c) override {
+        listener = c.listen(url, listen_handler);
+    }
+
+    void on_message(proton::delivery &d, proton::message &msg) override {
+
+        // Testing the existence of key in message_annotations
+        ASSERT(msg.message_annotations().exists(
+            proton::annotation_key(kKeyToCheck)));
+
+        d.receiver().close();
+        d.connection().close();
+        listener.stop();
+    }
+};
+
+class test_send : public proton::messaging_handler {
+  private:
+    std::string url;
+    proton::sender sender;
+
+  public:
+    test_send(const std::string &s) : url(s) {}
+
+    void on_container_start(proton::container &c) override {
+        proton::connection_options co;
+        sender = c.open_sender(url, co);
+    }
+
+    void on_sendable(proton::sender &s) override {
+        proton::message msg;
+        msg.body("message");
+        proton::binary test_tag_send("TESTTAG");
+        s.send(msg, test_tag_send);
+    }
+};
+
+int test_tracing() {
+    
+    std::string recv_address("127.0.0.1:0/test");
+    test_recv recv(recv_address);
+    proton::container c(recv);
+    std::thread thread_recv([&c]() -> void { c.run(); });
+
+    // wait until listener is ready
+    std::unique_lock<std::mutex> lk(m);
+    cv.wait(lk, [] { return listener_ready; });
+
+    std::string send_address =
+        "127.0.0.1:" + std::to_string(listener_port) + "/test";
+    test_send send(send_address);
+    proton::container(send).run();
+    thread_recv.join();
+
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    // auto exporter = std::unique_ptr<sdktrace::SpanExporter>(
+    //     new opentelemetry::exporter::trace::OStreamSpanExporter());
+    auto exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
+        new opentelemetry::exporter::trace::OStreamSpanExporter());
+    proton::initTracer(std::move(exporter));
+    int failed = 0;
+    RUN_ARGV_TEST(failed, test_tracing());
+    return failed;
+}

--- a/cpp/tests.cmake
+++ b/cpp/tests.cmake
@@ -62,12 +62,20 @@ add_cpp_test(reconnect_test)
 add_cpp_test(link_test)
 add_cpp_test(credit_test)
 add_cpp_test(delivery_test)
+# add_cpp_test(tracing_test)
+
+# target_link_libraries(tracing_test ${OPENTELEMETRY_CPP_LIBRARIES})
 if (ENABLE_JSONCPP)
   add_cpp_test(connect_config_test)
   target_link_libraries(connect_config_test qpid-proton-core) # For pn_sasl_enabled
   set_tests_properties(cpp-connect_config_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
   # Test data and output directories for connect_config_test
   file(COPY  "${CMAKE_CURRENT_SOURCE_DIR}/testdata" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+
+if (ENABLE_OPENTELEMETRYCPP)
+  add_cpp_test(tracing_test)
+  target_link_libraries(tracing_test ${OPENTELEMETRY_CPP_LIBRARIES})
 endif()
 
 # TODO aconway 2018-10-31: Catch2 tests


### PR DESCRIPTION
[PROTON-2487](https://issues.apache.org/jira/browse/PROTON-2487)

- Add the opentelemetry-cpp library dependencies
- Add opentelemetry-cpp install/build steps in GHA
- Add tracing.cpp file
  - Add tracing spans for messaging operations
  - Add basic attributes[delivery_tag, delivery_state, source_address, destination_address]
- Add a	tracing	demo file in examples
- Add a test file