### PR TITLE
Fix "${InstallPrefix}" variable in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Create Build and Install directories
-      run: mkdir -p "${BuildDir}" "{InstallPrefix}"
+      run: mkdir -p "${BuildDir}" "${InstallPrefix}"
       shell: bash
 
     # PROTON-2295 avoid using go 1.15.3 on macOS, which is broken


### PR DESCRIPTION
In CI, a variable InstallPrefix is written as `“{InstallPrefix}”` instead of `“${InstallPrefix}”`.
https://github.com/apache/qpid-proton/blob/main/.github/workflows/build.yml#L30

```run: mkdir -p "${BuildDir}" "{InstallPrefix}"```

This line creating a directory called `"{InstallPrefix}"`.
https://github.com/DreamPearl/qpid-proton/runs/2884823842?check_suite_focus=true#step:11:2297

Later, while cmake build/install, creating the correct one called `“INSTALL”` when using the variable properly.
https://github.com/DreamPearl/qpid-proton/runs/2884823842?check_suite_focus=true#step:11:2279 
