### PR TITLE
PROTON-2406: [cpp] Replace uses of deprecated reconnect_options::failover_urls with conn…

### DIFF
--- a/cpp/examples/reconnect_client.cpp
+++ b/cpp/examples/reconnect_client.cpp
@@ -54,10 +54,8 @@ class reconnect_client : public proton::messaging_handler {
   private:
     void on_container_start(proton::container &c) override {
         proton::connection_options co;
-        proton::reconnect_options ro;
 
-        ro.failover_urls(failovers);
-        co.reconnect(ro);
+        co.failover_urls(failovers);
         c.connect(url, co);
     }
 

--- a/cpp/include/proton/connection_options.hpp
+++ b/cpp/include/proton/connection_options.hpp
@@ -197,6 +197,13 @@ class connection_options {
     /// If the connection to the primary connection url fails then try each of the fail-over
     /// connection urls in turn.
     ///
+    /// If this option is set then it will by default set the default reconnect timing options.
+    ///
+    /// If this option is changed using @ref connection::update_options before a reconnection
+    /// attempt (for example in the @ref messaging_handler::on_transport_error callback) then
+    /// the new values of the failover urls will be used for the reconnect attempt rather then
+    /// any previous value.
+    ///
     /// If both the failover_urls and reconnect_url options are set then the behavior is not defined.
     PN_CPP_EXTERN connection_options& failover_urls(const std::vector<std::string>&);
 


### PR DESCRIPTION
[PROTON-2406](https://issues.apache.org/jira/browse/PROTON-2406)

First, I wanted to reproduce the bug to make sure I understand the issue properly.
It would also help me to verify my changes made, now I can see the warnings are really gone.

Steps I took to reproduce the bug:

- Remove "-DPN_CPP_USE_DEPRECATED_API=1" from cpp/CMakeLists to actually deprecate the targeted lines.
- Add "remove_definitions(-Werror)" so that warnings are not treated as errors; to allow build not to fail in the middle.

