### PR TITLE
PROTON-2441: [cpp] Fix connection_options failover urls segfault

### DIFF
--- a/cpp/src/connection_options.cpp
+++ b/cpp/src/connection_options.cpp
@@ -124,7 +124,7 @@ class connection_options::impl {
             cc.reconnect_url_ = reconnect_url.value;
             cc.reconnect_context_->current_url_ = -1;
         }
-        if (failover_urls.set) {
+        if (failover_urls.set && !failover_urls.value.empty()) {
             failover_urls.set = false;
             cc.failover_urls_ = failover_urls.value;
             cc.reconnect_context_->current_url_ = 0;
@@ -252,7 +252,13 @@ connection_options& connection_options::reconnect(const reconnect_options &r) {
     return *this;
 }
 connection_options& connection_options::reconnect_url(const std::string& u) { impl_->reconnect_url = u; return *this; }
-connection_options& connection_options::failover_urls(const std::vector<std::string>& us) { impl_->failover_urls = us; return *this; }
+connection_options &
+connection_options::failover_urls(const std::vector<std::string> &us) {
+    if (!us.empty()) {
+        impl_->failover_urls = us;
+    }
+    return *this;
+}
 connection_options& connection_options::ssl_client_options(const class ssl_client_options &c) { impl_->ssl_client_options = c; return *this; }
 connection_options& connection_options::ssl_server_options(const class ssl_server_options &c) { impl_->ssl_server_options = c; return *this; }
 connection_options& connection_options::sasl_enabled(bool b) { impl_->sasl_enabled = b; return *this; }


### PR DESCRIPTION
Issue: [PROTON-2441](https://issues.apache.org/jira/browse/PROTON-2441)