### PR TITLE
Document ttl=0 behavior

### DIFF
--- a/c/include/proton/message.h
+++ b/c/include/proton/message.h
@@ -203,6 +203,9 @@ PN_EXTERN pn_millis_t    pn_message_get_ttl               (pn_message_t *msg);
  *
  * See ::pn_message_get_ttl() for a detailed description of message ttl.
  *
+ * The default ttl value for a new message is 0. If this value is 0, Proton
+ * will send no ttl message header.
+ *
  * @param[in] msg a message object
  * @param[in] ttl the new value for the message ttl
  * @return zero on success or an error code on failure

--- a/python/proton/_message.py
+++ b/python/proton/_message.py
@@ -225,6 +225,9 @@ class Message(object):
         """The time to live of the message measured in seconds. Expired messages
         may be dropped.
 
+        The default ttl value for a new message is 0. If this value is 0,
+        Proton will send no ttl message header.
+
         :raise: :exc:`MessageException` if there is any Proton error when using the setter.
         """
         return millis2secs(pn_message_get_ttl(self._msg))

--- a/ruby/lib/core/message.rb
+++ b/ruby/lib/core/message.rb
@@ -201,6 +201,9 @@ module Qpid::Proton
 
     # Returns the time-to-live, in milliseconds.
     #
+    # The default ttl value for a new message is 0. If this value is 0, Proton
+    # will send no ttl message header.
+    #
     def ttl
       Cproton.pn_message_get_ttl(@impl)
     end


### PR DESCRIPTION
Update the API documentation to explain that the default message `ttl` value is `0`.

Explain that Proton does not send any `ttl` header on the wire when a message's ttl is `0`.