### PR TITLE
NO-JIRA Remove header duplicacy in node_options.cpp and target.cpp

### DIFF
--- a/cpp/src/node_options.cpp
+++ b/cpp/src/node_options.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-#include "proton/codec/vector.hpp"
 #include "proton/map.hpp"
 #include "proton/source.hpp"
 #include "proton/source_options.hpp"

--- a/cpp/src/target.cpp
+++ b/cpp/src/target.cpp
@@ -25,8 +25,6 @@
 #include "proton/sender.hpp"
 #include "proton/receiver.hpp"
 
-#include "proton_bits.hpp"
-
 namespace proton {
 
 // Set parent_ non-null when the local terminus is authoritative and may need to be looked up.


### PR DESCRIPTION
- node_options.cpp includes both `#include "proton/codec/vector.hpp"` and  `#include "proton/types.hpp"` 
  - `#include "proton/types.hpp"` includes proton types used to represent AMQP types and thus already consist `#include "proton/codec/vector.hpp"`
  - Note: node_options.cpp also needs `#include "proton/codec/map.hpp"` which is being covered by types.hpp file.

- target.cpp includes `#include "proton_bits.hpp"` twice.

