### PR TITLE
PROTON-2481: [cpp] Improve constructor syntax for maps

### DIFF
--- a/cpp/include/proton/map.hpp
+++ b/cpp/include/proton/map.hpp
@@ -26,6 +26,8 @@
 #include "./internal/pn_unique_ptr.hpp"
 
 #include <cstddef>
+#include <initializer_list>
+#include <map>
 
 /// @file
 /// @copybrief proton::map
@@ -78,6 +80,12 @@ class PN_CPP_CLASS_EXTERN map {
 
     /// Copy a map.
     PN_CPP_EXTERN map& operator=(const map&);
+
+    /// Copy a std::map.
+    PN_CPP_EXTERN map(const std::map<K, T>&);
+
+    /// Initializer_list constructor.
+    PN_CPP_EXTERN map(const std::initializer_list<std::pair<const K, T>>&);
 
     /// Move a map.
     PN_CPP_EXTERN map(map&&);

--- a/cpp/src/map.cpp
+++ b/cpp/src/map.cpp
@@ -49,6 +49,14 @@ template <class K, class T>
 map<K,T>::map(const map& x) { *this = x; }
 
 template <class K, class T>
+map<K, T>::map(const std::map<K, T>& x) { *this = x; }
+
+template <class K, class T>
+map<K, T>::map(const std::initializer_list<std::pair<const K, T>>& x) {
+    *this = std::map<K, T>(x);
+}
+
+template <class K, class T>
 map<K,T>::map(pn_data_t *d) : value_(d) {
     // NOTE: for internal use. Don't verify that the data is valid here as that
     // would forcibly decode message maps immediately, we want to decode on-demand.


### PR DESCRIPTION
[PROTON-2481](https://issues.apache.org/jira/browse/PROTON-2481)
- Add a copy constructor to copy from std::map
- Add an initializer_list constructor