### PR TITLE
PROTON-2453 fix socket.socket type annotations and add more types

### DIFF
--- a/python/proton/_data.py
+++ b/python/proton/_data.py
@@ -18,7 +18,7 @@
 #
 
 import uuid
-from typing import Callable, List, Tuple, Union, Optional, Any, Dict, Iterable, overload, TypeVar
+from typing import Callable, List, Tuple, Union, Optional, Any, Dict, Iterable, TypeVar
 try:
     from typing import Literal
 except ImportError:
@@ -27,7 +27,7 @@ except ImportError:
         def __getitem__(self, item):
             pass
 
-    class Literal(metaclass=GenericMeta):
+    class Literal(metaclass=GenericMeta):  # type: ignore[no-redef]
         pass
 
 from cproton import PN_ARRAY, PN_BINARY, PN_BOOL, PN_BYTE, PN_CHAR, PN_DECIMAL128, PN_DECIMAL32, PN_DECIMAL64, \

--- a/python/proton/_handlers.py
+++ b/python/proton/_handlers.py
@@ -1325,7 +1325,14 @@ class IOHandler(Handler):
 
 
 class ConnectSelectable(Selectable):
-    def __init__(self, sock, reactor, addrs, transport, iohandler):
+    def __init__(
+            self,
+            sock: socket.socket,
+            reactor: 'Container',
+            addrs: List[Any],
+            transport: Transport,
+            iohandler: IOHandler
+    ) -> None:
         super(ConnectSelectable, self).__init__(sock, reactor)
         self.writing = True
         self._addrs = addrs

--- a/python/proton/_io.py
+++ b/python/proton/_io.py
@@ -35,16 +35,16 @@ PN_INVALID_SOCKET = -1
 class IO(object):
 
     @staticmethod
-    def _setupsocket(s: socket) -> None:
+    def _setupsocket(s: socket.socket) -> None:
         s.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, True)
         s.setblocking(False)
 
     @staticmethod
-    def close(s: socket) -> None:
+    def close(s: socket.socket) -> None:
         s.close()
 
     @staticmethod
-    def listen(host, port):
+    def listen(host, port) -> socket.socket:
         s = socket.socket()
         IO._setupsocket(s)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
@@ -53,13 +53,13 @@ class IO(object):
         return s
 
     @staticmethod
-    def accept(s: socket):
+    def accept(s: socket.socket):
         n = s.accept()
         IO._setupsocket(n[0])
         return n
 
     @staticmethod
-    def connect(addr):
+    def connect(addr) -> socket.socket:
         s = socket.socket(addr[0], addr[1], addr[2])
         IO._setupsocket(s)
         try:


### PR DESCRIPTION
This started as https://issues.apache.org/jira/browse/PROTON-2407

Today, I tried using qpid-proton at HEAD and I haven't found any weird PyCharm warnings caused by the annotations. I mostly used Dispatch tests as examples of user-written programs. There was one annoyance: The time handlers scheduled with `reactor.schedule()` now have to be subclasses of `proton.Handler`, in order to pass typecheck, to not be highlighted in annoying yellow. Other than that, it looked OK.

I tried running mypy on qpid-proton (https://issues.apache.org/jira/browse/PROTON-2453), but that did not go well, regarding 'internal consistency' of the type annotations. One thing that I noticed and am repairing here is the `socket.socket` mistake that I made before.

To tell the truth, I am not sure what the best next step now is. Probably to clean up what is already there so that mypy is happy.