### PR TITLE
PROTON-2502: Stop testing using MD5 SASL mechanisms

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ Dependencies
 Cross-platform dependencies
 
   - CMake 3.16+
-  - Python 3.9+ (required to build core C library)
+  - Python 3.9+ (required to build core C library and Python binding)
   - Swig 1.3+ (for the Ruby binding)
   - Ruby 1.9+ (for the Ruby binding)
   - Go 1.11+ (for the Go binding)
@@ -19,7 +19,7 @@ Linux dependencies
 
   - GNU Make 3.81+
   - GCC 9+
-  - Cyrus SASL 2.1+ (for SASL support)
+  - Cyrus SASL 2.1.26+ (for SASL support)
   - OpenSSL 1.0.2a+ (for SSL support)
   - JsonCpp 1.8+ for C++ connection configuration file support
 
@@ -42,7 +42,7 @@ language.
     $ yum install openssl-devel
 
     # Dependencies needed for Cyrus SASL support
-    $ yum install cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-md5
+    $ yum install cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-scram
 
     # Dependencies needed for bindings
     $ yum install swig                                       # Required for ruby binding

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -29,14 +29,12 @@ jobs:
     name: InstallExtraStuff
   - template: steps.yml
 - job: Ubuntu
-  variables:
-    PythonVersion: '3.8'
   pool:
     vmImage: 'ubuntu-latest'
   steps:
   - script: |
       sudo apt-get update
-      sudo apt-get install -y swig libpython3-dev libsasl2-dev libjsoncpp-dev libc-ares-dev
+      sudo apt-get install -y swig sasl2-bin libpython3-dev libsasl2-dev libjsoncpp-dev libc-ares-dev
     name: InstallExtraStuff
   - template: steps.yml
 - job: MacOS

--- a/python/tests/proton_tests/sasl.py
+++ b/python/tests/proton_tests/sasl.py
@@ -324,20 +324,6 @@ class SASLMechTest(Test):
         self.t2.bind(self.c2)
         _testSaslMech(self, 'ANONYMOUS', authUser='anonymous')
 
-    def testCRAMMD5(self):
-        common.ensureCanTestExtendedSASL()
-
-        self.t1.bind(self.c1)
-        self.t2.bind(self.c2)
-        _testSaslMech(self, 'CRAM-MD5')
-
-    def testDIGESTMD5(self):
-        common.ensureCanTestExtendedSASL()
-
-        self.t1.bind(self.c1)
-        self.t2.bind(self.c2)
-        _testSaslMech(self, 'DIGEST-MD5')
-
     # PLAIN shouldn't work without encryption without special setting
     def testPLAINfail(self):
         common.ensureCanTestExtendedSASL()
@@ -365,15 +351,12 @@ class SASLMechTest(Test):
         self.t2.bind(self.c2)
         _testSaslMech(self, 'PLAIN')
 
-# SCRAM not supported before Cyrus SASL 2.1.26
-# so not universal and hence need a test for support
-# to keep it in tests.
-#  def testSCRAMSHA1(self):
-#    common.ensureCanTestExtendedSASL()
-#
-#    self.t1.bind(self.c1)
-#    self.t2.bind(self.c2)
-#    _testSaslMech(self, 'SCRAM-SHA-1')
+    def testSCRAMSHA1(self):
+        common.ensureCanTestExtendedSASL()
+
+        self.t1.bind(self.c1)
+        self.t2.bind(self.c2)
+        _testSaslMech(self, 'SCRAM-SHA-1')
 
 
 def _sslConnection(domain, transport, connection):
@@ -548,7 +531,7 @@ class SASLEventTest(engine.CollectorTest):
         self.c1.collect(self.collector)
         self.t1.bind(self.c1)
         self.t2.bind(self.c2)
-        _testSaslMech(self, 'DIGEST-MD5')
+        _testSaslMech(self, 'SCRAM-SHA-1')
         self.expect(Event.CONNECTION_INIT, Event.CONNECTION_BOUND,
                     Event.CONNECTION_LOCAL_OPEN, Event.TRANSPORT,
                     Event.CONNECTION_REMOTE_OPEN)
@@ -558,7 +541,7 @@ class SASLEventTest(engine.CollectorTest):
         self.c2.collect(self.collector)
         self.t1.bind(self.c1)
         self.t2.bind(self.c2)
-        _testSaslMech(self, 'DIGEST-MD5')
+        _testSaslMech(self, 'SCRAM-SHA-1')
         self.expect(Event.CONNECTION_INIT, Event.CONNECTION_BOUND,
                     Event.CONNECTION_LOCAL_OPEN, Event.TRANSPORT,
                     Event.CONNECTION_REMOTE_OPEN)
@@ -570,7 +553,7 @@ class SASLEventTest(engine.CollectorTest):
         self.c1.collect(self.collector)
         self.t1.bind(self.c1)
         self.t2.bind(self.c2)
-        _testSaslMech(self, 'DIGEST-MD5', clientUser=clientUser, authenticated=False)
+        _testSaslMech(self, 'SCRAM-SHA-1', clientUser=clientUser, authenticated=False)
         self.expect(Event.CONNECTION_INIT, Event.CONNECTION_BOUND,
                     Event.CONNECTION_LOCAL_OPEN, Event.TRANSPORT,
                     Event.TRANSPORT_ERROR,
@@ -584,7 +567,7 @@ class SASLEventTest(engine.CollectorTest):
         self.c2.collect(self.collector)
         self.t1.bind(self.c1)
         self.t2.bind(self.c2)
-        _testSaslMech(self, 'DIGEST-MD5', clientUser=clientUser, authenticated=False)
+        _testSaslMech(self, 'SCRAM-SHA-1', clientUser=clientUser, authenticated=False)
         self.expect(Event.CONNECTION_INIT, Event.CONNECTION_BOUND,
                     Event.CONNECTION_LOCAL_OPEN, Event.TRANSPORT,
                     Event.TRANSPORT_ERROR,
@@ -597,7 +580,7 @@ class SASLEventTest(engine.CollectorTest):
         self.s2.allowed_mechs('IMPOSSIBLE')
         self.t1.bind(self.c1)
         self.t2.bind(self.c2)
-        _testSaslMech(self, 'DIGEST-MD5', authenticated=False)
+        _testSaslMech(self, 'SCRAM-SHA-1', authenticated=False)
         self.expect(Event.CONNECTION_INIT, Event.CONNECTION_BOUND,
                     Event.CONNECTION_LOCAL_OPEN, Event.TRANSPORT,
                     Event.TRANSPORT_ERROR,
@@ -609,7 +592,7 @@ class SASLEventTest(engine.CollectorTest):
         self.s2.allowed_mechs('IMPOSSIBLE')
         self.t1.bind(self.c1)
         self.t2.bind(self.c2)
-        _testSaslMech(self, 'DIGEST-MD5', authenticated=False)
+        _testSaslMech(self, 'SCRAM-SHA-1', authenticated=False)
         self.expect(Event.CONNECTION_INIT, Event.CONNECTION_BOUND,
                     Event.CONNECTION_LOCAL_OPEN, Event.TRANSPORT,
                     Event.TRANSPORT_TAIL_CLOSED,


### PR DESCRIPTION
MD5 based mechanisms are now considered insecure and future systems will
be configured without them available. We should stop using them to test
Proton so we can build on securely configured machines.