### PR TITLE
NO-JIRA: [Python] IO: Add ENETUNREACH to the list of tolerated errors

### DIFF
--- a/python/proton/_io.py
+++ b/python/proton/_io.py
@@ -65,7 +65,7 @@ class IO(object):
         try:
             s.connect(addr[4])
         except socket.error as e:
-            if e.errno not in (errno.EINPROGRESS, errno.EWOULDBLOCK, errno.EAGAIN):
+            if e.errno not in (errno.EINPROGRESS, errno.EWOULDBLOCK, errno.EAGAIN, errno.ENETUNREACH):
                 raise
         return s
 


### PR DESCRIPTION
...which will enable reconnection logic to act in this case.
`ENETUNREACH` can happen when target network is unreachable for example
when the network stack was not fully initialized yet or when a network
is not connected temporarily, etc.
This makes `ENETUNREACH` handled just like `EHOSTUNREACH`
(which is for some reason indicated with `EINPROGRESS` in this part of the code).