### PR TITLE
PROTON-2529 CMakeLists.txt: fix build without a working C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,18 +78,20 @@ set (C_STANDARD_FLAGS ${C_STANDARD_${CMAKE_C_COMPILER_ID}})
 set (C_EXTENDED_FLAGS ${C_EXTENDED_${CMAKE_C_COMPILER_ID}})
 
 ## C++
-check_language (CXX)
-if (CMAKE_CXX_COMPILER)
-  enable_language(CXX)
+if (BUILD_CPP)
+  check_language (CXX)
+  if (CMAKE_CXX_COMPILER)
+    enable_language(CXX)
 
-  # This effectively checks for cmake version 3.1 or later
-  if (DEFINED CMAKE_CXX_COMPILE_FEATURES)
-    set(CMAKE_CXX_STANDARD 11)
-    set(CMAKE_CXX_EXTENSIONS OFF)
-  else ()
-    # This can only be a fairly old version of Linux in practice
-    set(CXX_STANDARD "-std=c++11")
-  endif ()
+    # This effectively checks for cmake version 3.1 or later
+    if (DEFINED CMAKE_CXX_COMPILE_FEATURES)
+      set(CMAKE_CXX_STANDARD 11)
+      set(CMAKE_CXX_EXTENSIONS OFF)
+    else ()
+      # This can only be a fairly old version of Linux in practice
+      set(CXX_STANDARD "-std=c++11")
+    endif ()
+  endif()
 endif()
 
 # Build static C and C++ libraries in addition to shared libraries.


### PR DESCRIPTION
Don't call `check_language(CXX)` if `BUILD_CPP` is not set to avoid the following if a non working C++ compiler is installed on the system:

```
CMake Error at /nvmedata/autobuild/instance-25/output-1/host/share/cmake-3.18/Modules/CMakeTestCXXCompiler.cmake:59 (message):
  The C++ compiler

    "/usr/bin/c++"

  is not able to compile a simple test program.
```

Fixes:
 - http://autobuild.buildroot.org/results/7bf05fb0208fa09543f841ec6e7adc6e4d984b0c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>