### PR TITLE
Object system speedups and simplifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /build*/
 /bld*/
 /BLD*/
+/out
+
 *.class
 *.o
 *.d

--- a/c/include/proton/event.h
+++ b/c/include/proton/event.h
@@ -526,7 +526,7 @@ PN_EXTERN void pn_collector_drain(pn_collector_t *collector);
  * this happens, this operation will return a NULL pointer.
  *
  * @param[in] collector a collector object
- * @param[in] clazz class of the context
+ * @param[in] clazz memory management class of the context
  * @param[in] context the event context
  * @param[in] type the event type
  *
@@ -537,6 +537,27 @@ PN_EXTERN void pn_collector_drain(pn_collector_t *collector);
 PN_EXTERN pn_event_t *pn_collector_put(pn_collector_t *collector,
                                        const pn_class_t *clazz, void *context,
                                        pn_event_type_t type);
+
+/**
+ * Place a new event on a collector.
+ *
+ * This operation will create a new event of the given type with a
+ * context that is managed as a pn_object and return a pointer to the
+ * newly created event. In some cases an event of the given type and
+ * context can be elided. When this happens, this operation will return
+ * a NULL pointer.
+ *
+ * @param[in] collector a collector object
+ * @param[in] object the event context object
+ * @param[in] type the event type
+ *
+ * @return a pointer to the newly created event or NULL if the event
+ *         was elided
+ */
+
+PN_EXTERN pn_event_t *pn_collector_put_object(pn_collector_t *collector,
+                                              void *object,
+                                              pn_event_type_t type);
 
 /**
  * Access the head event contained by a collector.

--- a/c/include/proton/object.h
+++ b/c/include/proton/object.h
@@ -73,63 +73,6 @@ PN_EXTERN extern const pn_class_t PN_WEAKREF[];
 
 #define PN_CLASSCLASS(PREFIX) PREFIX ## __class
 
-#define PN_CLASSDEF(PREFIX)                                               \
-static void PREFIX ## _initialize_cast(void *object) {                    \
-  PREFIX ## _initialize((PREFIX ## _t *) object);                         \
-}                                                                         \
-                                                                          \
-static void PREFIX ## _finalize_cast(void *object) {                      \
-  PREFIX ## _finalize((PREFIX ## _t *) object);                           \
-}                                                                         \
-                                                                          \
-static uintptr_t PREFIX ## _hashcode_cast(void *object) {                 \
-  uintptr_t (*fp)(PREFIX ## _t *) = PREFIX ## _hashcode;                  \
-  if (fp) {                                                               \
-    return fp((PREFIX ## _t *) object);                                   \
-  } else {                                                                \
-    return (uintptr_t) object;                                            \
-  }                                                                       \
-}                                                                         \
-                                                                          \
-static intptr_t PREFIX ## _compare_cast(void *a, void *b) {               \
-  intptr_t (*fp)(PREFIX ## _t *, PREFIX ## _t *) = PREFIX ## _compare;    \
-  if (fp) {                                                               \
-    return fp((PREFIX ## _t *) a, (PREFIX ## _t *) b);                    \
-  } else {                                                                \
-    return (intptr_t) a - (intptr_t) b;                                   \
-  }                                                                       \
-}                                                                         \
-                                                                          \
-static int PREFIX ## _inspect_cast(void *object, pn_string_t *str) {      \
-  int (*fp)(PREFIX ## _t *, pn_string_t *) = PREFIX ## _inspect;          \
-  if (fp) {                                                               \
-    return fp((PREFIX ## _t *) object, str);                              \
-  } else {                                                                \
-    return pn_string_addf(str, "%s<%p>", #PREFIX, object);                \
-  }                                                                       \
-}                                                                         \
-                                                                          \
-const pn_class_t PN_CLASSCLASS(PREFIX)[] = {{                             \
-    #PREFIX,                                                              \
-    CID_ ## PREFIX,                                                       \
-    pn_object_new,                                                        \
-    PREFIX ## _initialize_cast,                                           \
-    pn_object_incref,                                                     \
-    pn_object_decref,                                                     \
-    pn_object_refcount,                                                   \
-    PREFIX ## _finalize_cast,                                             \
-    pn_object_free,                                                       \
-    pn_object_reify,                                                      \
-    PREFIX ## _hashcode_cast,                                             \
-    PREFIX ## _compare_cast,                                              \
-    PREFIX ## _inspect_cast                                               \
-}};                                                                       \
-                                                                          \
-PREFIX ## _t *PREFIX ## _new(void) {                                      \
-  return (PREFIX ## _t *) pn_class_new(PN_CLASSCLASS(PREFIX),             \
-                                       sizeof(PREFIX ## _t));             \
-}
-
 #define PN_CLASS(PREFIX) {                      \
     #PREFIX,                                    \
     CID_ ## PREFIX,                             \

--- a/c/include/proton/object.h
+++ b/c/include/proton/object.h
@@ -70,18 +70,20 @@ PN_EXTERN extern const pn_class_t PN_OBJECT[];
 PN_EXTERN extern const pn_class_t PN_VOID[];
 PN_EXTERN extern const pn_class_t PN_WEAKREF[];
 
+PN_EXTERN void pn_object_incref(void *object);
+
 #define PN_CLASSCLASS(PREFIX) PREFIX ## __class
 
 #define PN_CLASS(PREFIX) {                      \
     #PREFIX,                                    \
     CID_ ## PREFIX,                             \
-    pn_object_new,                              \
+    NULL,                                       \
     PREFIX ## _initialize,                      \
-    pn_object_incref,                           \
-    pn_object_decref,                           \
-    pn_object_refcount,                         \
+    NULL,                                       \
+    NULL,                                       \
+    NULL,                                       \
     PREFIX ## _finalize,                        \
-    pn_object_free,                             \
+    NULL,                                       \
     PREFIX ## _hashcode,                        \
     PREFIX ## _compare,                         \
     PREFIX ## _inspect                          \
@@ -101,6 +103,11 @@ PN_EXTERN extern const pn_class_t PN_WEAKREF[];
     PREFIX ## _compare,                         \
     PREFIX ## _inspect                          \
 }
+
+PN_EXTERN void *pn_void_new(const pn_class_t *clazz, size_t size);
+PN_EXTERN void pn_void_incref(void *object);
+PN_EXTERN void pn_void_decref(void *object);
+PN_EXTERN int pn_void_refcount(void *object);
 
 /* Class to identify a plain C struct in a pn_event_t. No refcounting or memory management. */
 #define PN_STRUCT_CLASSDEF(PREFIX)                  \
@@ -123,12 +130,6 @@ PN_EXTERN pn_cid_t pn_class_id(const pn_class_t *clazz);
 PN_EXTERN const char *pn_class_name(const pn_class_t *clazz);
 PN_EXTERN void *pn_class_new(const pn_class_t *clazz, size_t size);
 
-/* pn_incref, pn_decref and pn_refcount are for internal use by the proton
-   library, the should not be called by application code. Application code
-   should use the appropriate pn_*_free function (pn_link_free, pn_session_free
-   etc.) when it is finished with a proton value. Proton values should only be
-   used when handling a pn_event_t that refers to them.
-*/
 PN_EXTERN void *pn_class_incref(const pn_class_t *clazz, void *object);
 PN_EXTERN int pn_class_refcount(const pn_class_t *clazz, void *object);
 PN_EXTERN int pn_class_decref(const pn_class_t *clazz, void *object);
@@ -139,17 +140,12 @@ PN_EXTERN intptr_t pn_class_compare(const pn_class_t *clazz, void *a, void *b);
 PN_EXTERN bool pn_class_equals(const pn_class_t *clazz, void *a, void *b);
 PN_EXTERN int pn_class_inspect(const pn_class_t *clazz, void *object, pn_string_t *dst);
 
-PN_EXTERN void *pn_void_new(const pn_class_t *clazz, size_t size);
-PN_EXTERN void pn_void_incref(void *object);
-PN_EXTERN void pn_void_decref(void *object);
-PN_EXTERN int pn_void_refcount(void *object);
-
-PN_EXTERN void *pn_object_new(const pn_class_t *clazz, size_t size);
-PN_EXTERN void pn_object_incref(void *object);
-PN_EXTERN int pn_object_refcount(void *object);
-PN_EXTERN void pn_object_decref(void *object);
-PN_EXTERN void pn_object_free(void *object);
-
+/* pn_incref, pn_decref and pn_refcount are for internal use by the proton
+ *   library, the should not be called by application code. Application code
+ *   should use the appropriate pn_*_free function (pn_link_free, pn_session_free
+ *   etc.) when it is finished with a proton value. Proton values should only be
+ *   used when handling a pn_event_t that refers to them.
+ */
 PN_EXTERN void *pn_incref(void *object);
 PN_EXTERN int pn_decref(void *object);
 PN_EXTERN int pn_refcount(void *object);

--- a/c/include/proton/object.h
+++ b/c/include/proton/object.h
@@ -114,9 +114,9 @@ const pn_class_t PN_CLASSCLASS(PREFIX)[] = {{       \
   pn_void_refcount,                                 \
   NULL, /* _finalize */                             \
   NULL, /* _free */                                 \
-  pn_void_hashcode,                                 \
-  pn_void_compare,                                  \
-  pn_void_inspect                                   \
+  NULL, /* _hashcode */                             \
+  NULL, /* _compare */                              \
+  NULL, /* _inspect */                              \
 }};                                                 \
 
 PN_EXTERN pn_cid_t pn_class_id(const pn_class_t *clazz);
@@ -143,9 +143,6 @@ PN_EXTERN void *pn_void_new(const pn_class_t *clazz, size_t size);
 PN_EXTERN void pn_void_incref(void *object);
 PN_EXTERN void pn_void_decref(void *object);
 PN_EXTERN int pn_void_refcount(void *object);
-PN_EXTERN uintptr_t pn_void_hashcode(void *object);
-PN_EXTERN intptr_t pn_void_compare(void *a, void *b);
-PN_EXTERN int pn_void_inspect(void *object, pn_string_t *dst);
 
 PN_EXTERN void *pn_object_new(const pn_class_t *clazz, size_t size);
 PN_EXTERN void pn_object_incref(void *object);

--- a/c/include/proton/object.h
+++ b/c/include/proton/object.h
@@ -66,6 +66,7 @@ struct pn_class_t {
 
 /* Hack alert: Declare these as arrays so we can treat the name of the single
    object as the address */
+PN_EXTERN extern const pn_class_t PN_DEFAULT[];
 PN_EXTERN extern const pn_class_t PN_OBJECT[];
 PN_EXTERN extern const pn_class_t PN_VOID[];
 PN_EXTERN extern const pn_class_t PN_WEAKREF[];

--- a/c/include/proton/object.h
+++ b/c/include/proton/object.h
@@ -59,7 +59,6 @@ struct pn_class_t {
   int (*refcount)(void *);
   void (*finalize)(void *);
   void (*free)(void *);
-  const pn_class_t *(*reify)(void *);
   uintptr_t (*hashcode)(void *);
   intptr_t (*compare)(void *, void *);
   int (*inspect)(void *, pn_string_t *);
@@ -83,7 +82,6 @@ PN_EXTERN extern const pn_class_t PN_WEAKREF[];
     pn_object_refcount,                         \
     PREFIX ## _finalize,                        \
     pn_object_free,                             \
-    pn_object_reify,                            \
     PREFIX ## _hashcode,                        \
     PREFIX ## _compare,                         \
     PREFIX ## _inspect                          \
@@ -99,7 +97,6 @@ PN_EXTERN extern const pn_class_t PN_WEAKREF[];
     PREFIX ## _refcount,                        \
     PREFIX ## _finalize,                        \
     PREFIX ## _free,                            \
-    PREFIX ## _reify,                           \
     PREFIX ## _hashcode,                        \
     PREFIX ## _compare,                         \
     PREFIX ## _inspect                          \
@@ -107,7 +104,6 @@ PN_EXTERN extern const pn_class_t PN_WEAKREF[];
 
 /* Class to identify a plain C struct in a pn_event_t. No refcounting or memory management. */
 #define PN_STRUCT_CLASSDEF(PREFIX)                  \
-static const pn_class_t *PREFIX ## _reify(void *p); \
 const pn_class_t PN_CLASSCLASS(PREFIX)[] = {{       \
   #PREFIX,                                          \
   CID_ ## PREFIX,                                   \
@@ -118,14 +114,10 @@ const pn_class_t PN_CLASSCLASS(PREFIX)[] = {{       \
   pn_void_refcount,                                 \
   NULL, /* _finalize */                             \
   NULL, /* _free */                                 \
-  PREFIX ## _reify,                                 \
   pn_void_hashcode,                                 \
   pn_void_compare,                                  \
   pn_void_inspect                                   \
 }};                                                 \
-const pn_class_t *PREFIX ## _reify(void *p) {       \
-  return PN_CLASSCLASS(PREFIX);                     \
-}
 
 PN_EXTERN pn_cid_t pn_class_id(const pn_class_t *clazz);
 PN_EXTERN const char *pn_class_name(const pn_class_t *clazz);
@@ -143,8 +135,6 @@ PN_EXTERN int pn_class_decref(const pn_class_t *clazz, void *object);
 
 PN_EXTERN void pn_class_free(const pn_class_t *clazz, void *object);
 
-PN_EXTERN const pn_class_t *pn_class_reify(const pn_class_t *clazz, void *object);
-PN_EXTERN uintptr_t pn_class_hashcode(const pn_class_t *clazz, void *object);
 PN_EXTERN intptr_t pn_class_compare(const pn_class_t *clazz, void *a, void *b);
 PN_EXTERN bool pn_class_equals(const pn_class_t *clazz, void *a, void *b);
 PN_EXTERN int pn_class_inspect(const pn_class_t *clazz, void *object, pn_string_t *dst);
@@ -158,7 +148,6 @@ PN_EXTERN intptr_t pn_void_compare(void *a, void *b);
 PN_EXTERN int pn_void_inspect(void *object, pn_string_t *dst);
 
 PN_EXTERN void *pn_object_new(const pn_class_t *clazz, size_t size);
-PN_EXTERN const pn_class_t *pn_object_reify(void *object);
 PN_EXTERN void pn_object_incref(void *object);
 PN_EXTERN int pn_object_refcount(void *object);
 PN_EXTERN void pn_object_decref(void *object);
@@ -174,8 +163,6 @@ PN_EXTERN intptr_t pn_compare(void *a, void *b);
 PN_EXTERN bool pn_equals(void *a, void *b);
 PN_EXTERN int pn_inspect(void *object, pn_string_t *dst);
 
-#define PN_REFCOUNT (0x1)
-
 PN_EXTERN pn_list_t *pn_list(const pn_class_t *clazz, size_t capacity);
 PN_EXTERN size_t pn_list_size(pn_list_t *list);
 PN_EXTERN void *pn_list_get(pn_list_t *list, int index);
@@ -189,9 +176,6 @@ PN_EXTERN void pn_list_clear(pn_list_t *list);
 PN_EXTERN void pn_list_iterator(pn_list_t *list, pn_iterator_t *iter);
 PN_EXTERN void pn_list_minpush(pn_list_t *list, void *value);
 PN_EXTERN void *pn_list_minpop(pn_list_t *list);
-
-#define PN_REFCOUNT_KEY (0x2)
-#define PN_REFCOUNT_VALUE (0x4)
 
 PN_EXTERN pn_map_t *pn_map(const pn_class_t *key, const pn_class_t *value,
                            size_t capacity, float load_factor);

--- a/c/src/core/engine.c
+++ b/c/src/core/engine.c
@@ -977,9 +977,9 @@ static void pn_session_finalize(void *object)
   }
 }
 
-#define pn_session_new pn_object_new
-#define pn_session_refcount pn_object_refcount
-#define pn_session_decref pn_object_decref
+#define pn_session_new NULL
+#define pn_session_refcount NULL
+#define pn_session_decref NULL
 #define pn_session_initialize NULL
 #define pn_session_hashcode NULL
 #define pn_session_compare NULL
@@ -988,7 +988,7 @@ static void pn_session_finalize(void *object)
 pn_session_t *pn_session(pn_connection_t *conn)
 {
   assert(conn);
-#define pn_session_free pn_object_free
+#define pn_session_free NULL
   static const pn_class_t clazz = PN_METACLASS(pn_session);
 #undef pn_session_free
   pn_session_t *ssn = (pn_session_t *) pn_class_new(&clazz, sizeof(pn_session_t));
@@ -1146,8 +1146,8 @@ static void pn_link_finalize(void *object)
   pn_free(link->remote_properties);
 }
 
-#define pn_link_refcount pn_object_refcount
-#define pn_link_decref pn_object_decref
+#define pn_link_refcount NULL
+#define pn_link_decref NULL
 #define pn_link_initialize NULL
 #define pn_link_hashcode NULL
 #define pn_link_compare NULL
@@ -1155,8 +1155,8 @@ static void pn_link_finalize(void *object)
 
 pn_link_t *pn_link_new(int type, pn_session_t *session, const char *name)
 {
-#define pn_link_new pn_object_new
-#define pn_link_free pn_object_free
+#define pn_link_new NULL
+#define pn_link_free NULL
   static const pn_class_t clazz = PN_METACLASS(pn_link);
 #undef pn_link_new
 #undef pn_link_free
@@ -1507,10 +1507,10 @@ static void pn_disposition_clear(pn_disposition_t *ds)
   pn_condition_clear(&ds->condition);
 }
 
-#define pn_delivery_new pn_object_new
-#define pn_delivery_refcount pn_object_refcount
-#define pn_delivery_decref pn_object_decref
-#define pn_delivery_free pn_object_free
+#define pn_delivery_new NULL
+#define pn_delivery_refcount NULL
+#define pn_delivery_decref NULL
+#define pn_delivery_free NULL
 #define pn_delivery_initialize NULL
 #define pn_delivery_hashcode NULL
 #define pn_delivery_compare NULL

--- a/c/src/core/engine.c
+++ b/c/src/core/engine.c
@@ -79,8 +79,8 @@ static void pn_endpoint_open(pn_endpoint_t *endpoint)
   if (!(endpoint->state & PN_LOCAL_ACTIVE)) {
     PN_SET_LOCAL(endpoint->state, PN_LOCAL_ACTIVE);
     pn_connection_t *conn = pni_ep_get_connection(endpoint);
-    pn_collector_put(conn->collector, PN_OBJECT, endpoint,
-                     endpoint_event((pn_endpoint_type_t) endpoint->type, true));
+    pn_collector_put_object(conn->collector, endpoint,
+                            endpoint_event((pn_endpoint_type_t) endpoint->type, true));
     pn_modified(conn, endpoint, true);
   }
 }
@@ -90,8 +90,8 @@ static void pn_endpoint_close(pn_endpoint_t *endpoint)
   if (!(endpoint->state & PN_LOCAL_CLOSED)) {
     PN_SET_LOCAL(endpoint->state, PN_LOCAL_CLOSED);
     pn_connection_t *conn = pni_ep_get_connection(endpoint);
-    pn_collector_put(conn->collector, PN_OBJECT, endpoint,
-                     endpoint_event((pn_endpoint_type_t) endpoint->type, false));
+    pn_collector_put_object(conn->collector, endpoint,
+                            endpoint_event((pn_endpoint_type_t) endpoint->type, false));
     pn_modified(conn, endpoint, true);
   }
 }
@@ -154,7 +154,7 @@ void pn_connection_free(pn_connection_t *connection) {
 
 void pn_connection_bound(pn_connection_t *connection)
 {
-  pn_collector_put(connection->collector, PN_OBJECT, connection, PN_CONNECTION_BOUND);
+  pn_collector_put_object(connection->collector, connection, PN_CONNECTION_BOUND);
   pn_ep_incref(&connection->endpoint);
 
   size_t nsessions = pn_list_size(connection->sessions);
@@ -337,7 +337,7 @@ void pn_link_detach(pn_link_t *link)
   if (link->detached) return;
 
   link->detached = true;
-  pn_collector_put(link->session->connection->collector, PN_OBJECT, link, PN_LINK_LOCAL_DETACH);
+  pn_collector_put_object(link->session->connection->collector, link, PN_LINK_LOCAL_DETACH);
   pn_modified(link->session->connection, &link->endpoint, true);
 
 }
@@ -449,7 +449,7 @@ void pn_ep_decref(pn_endpoint_t *endpoint)
   endpoint->refcount--;
   if (endpoint->refcount == 0) {
     pn_connection_t *conn = pni_ep_get_connection(endpoint);
-    pn_collector_put(conn->collector, PN_OBJECT, endpoint, pn_final_type((pn_endpoint_type_t) endpoint->type));
+    pn_collector_put_object(conn->collector, endpoint, pn_final_type((pn_endpoint_type_t) endpoint->type));
   }
 }
 
@@ -560,7 +560,7 @@ void pn_connection_collect(pn_connection_t *connection, pn_collector_t *collecto
   pn_incref(connection->collector);
   pn_endpoint_t *endpoint = connection->endpoint_head;
   while (endpoint) {
-    pn_collector_put(connection->collector, PN_OBJECT, endpoint, endpoint_init_event_map[endpoint->type]);
+    pn_collector_put_object(connection->collector, endpoint, endpoint_init_event_map[endpoint->type]);
     endpoint = endpoint->endpoint_next;
   }
 }
@@ -781,8 +781,8 @@ void pn_modified(pn_connection_t *connection, pn_endpoint_t *endpoint, bool emit
   }
 
   if (emit && connection->transport) {
-    pn_collector_put(connection->collector, PN_OBJECT, connection->transport,
-                     PN_TRANSPORT);
+    pn_collector_put_object(connection->collector, connection->transport,
+                            PN_TRANSPORT);
   }
 }
 
@@ -1018,7 +1018,7 @@ pn_session_t *pn_session(pn_connection_t *conn)
   ssn->state.remote_handles = pn_hash(PN_WEAKREF, 0, 0.75);
   // end transport state
 
-  pn_collector_put(conn->collector, PN_OBJECT, ssn, PN_SESSION_INIT);
+  pn_collector_put_object(conn->collector, ssn, PN_SESSION_INIT);
   if (conn->transport) {
     pni_session_bound(ssn);
   }
@@ -1200,7 +1200,7 @@ pn_link_t *pn_link_new(int type, pn_session_t *session, const char *name)
   link->state.link_credit = 0;
   // end transport state
 
-  pn_collector_put(session->connection->collector, PN_OBJECT, link, PN_LINK_INIT);
+  pn_collector_put_object(session->connection->collector, link, PN_LINK_INIT);
   if (session->connection->transport) {
     pni_link_bound(link);
   }

--- a/c/src/core/engine.c
+++ b/c/src/core/engine.c
@@ -980,7 +980,6 @@ static void pn_session_finalize(void *object)
 #define pn_session_new pn_object_new
 #define pn_session_refcount pn_object_refcount
 #define pn_session_decref pn_object_decref
-#define pn_session_reify pn_object_reify
 #define pn_session_initialize NULL
 #define pn_session_hashcode NULL
 #define pn_session_compare NULL
@@ -1149,7 +1148,6 @@ static void pn_link_finalize(void *object)
 
 #define pn_link_refcount pn_object_refcount
 #define pn_link_decref pn_object_decref
-#define pn_link_reify pn_object_reify
 #define pn_link_initialize NULL
 #define pn_link_hashcode NULL
 #define pn_link_compare NULL
@@ -1513,7 +1511,6 @@ static void pn_disposition_clear(pn_disposition_t *ds)
 #define pn_delivery_refcount pn_object_refcount
 #define pn_delivery_decref pn_object_decref
 #define pn_delivery_free pn_object_free
-#define pn_delivery_reify pn_object_reify
 #define pn_delivery_initialize NULL
 #define pn_delivery_hashcode NULL
 #define pn_delivery_compare NULL

--- a/c/src/core/event.c
+++ b/c/src/core/event.c
@@ -169,6 +169,12 @@ pn_event_t *pn_collector_put(pn_collector_t *collector,
   return event;
 }
 
+pn_event_t *pn_collector_put_object(pn_collector_t *collector, void *object, pn_event_type_t type)
+{
+  const pn_class_t *clazz = pn_class(object);
+  return pn_collector_put(collector, clazz, object, type);
+}
+
 pn_event_t *pn_collector_peek(pn_collector_t *collector)
 {
   return collector->head;

--- a/c/src/core/event.c
+++ b/c/src/core/event.c
@@ -142,8 +142,6 @@ pn_event_t *pn_collector_put(pn_collector_t *collector,
     return NULL;
   }
 
-  clazz = clazz->reify(context);
-
   pn_event_t *event = (pn_event_t *) pn_list_pop(collector->pool);
 
   if (!event) {
@@ -159,6 +157,10 @@ pn_event_t *pn_collector_put(pn_collector_t *collector,
   } else {
     collector->tail = event;
     collector->head = event;
+  }
+
+  if (clazz==PN_OBJECT) {
+    clazz = pn_class(context);
   }
 
   event->clazz = clazz;

--- a/c/src/core/event.c
+++ b/c/src/core/event.c
@@ -167,10 +167,6 @@ pn_event_t *pn_collector_put(pn_collector_t *collector,
     collector->head = event;
   }
 
-  if (clazz==PN_OBJECT) {
-    clazz = pn_class(context);
-  }
-
   event->clazz = clazz;
   event->context = context;
   event->type = type;

--- a/c/src/core/event.c
+++ b/c/src/core/event.c
@@ -41,8 +41,9 @@ struct pn_event_t {
   pn_event_type_t type;
 };
 
-static void pn_collector_initialize(pn_collector_t *collector)
+static void pn_collector_initialize(void* object)
 {
+  pn_collector_t *collector = (pn_collector_t *)object;
   collector->pool = pn_list(PN_OBJECT, 0);
   collector->head = NULL;
   collector->tail = NULL;
@@ -65,14 +66,16 @@ static void pn_collector_shrink(pn_collector_t *collector)
   pn_list_clear(collector->pool);
 }
 
-static void pn_collector_finalize(pn_collector_t *collector)
+static void pn_collector_finalize(void *object)
 {
+  pn_collector_t *collector = (pn_collector_t *)object;
   pn_collector_drain(collector);
   pn_decref(collector->pool);
 }
 
-static int pn_collector_inspect(pn_collector_t *collector, pn_string_t *dst)
+static int pn_collector_inspect(void *object, pn_string_t *dst)
 {
+  pn_collector_t *collector = (pn_collector_t *)object;
   assert(collector);
   int err = pn_string_addf(dst, "EVENTS[");
   if (err) return err;
@@ -95,11 +98,10 @@ static int pn_collector_inspect(pn_collector_t *collector, pn_string_t *dst)
 #define pn_collector_hashcode NULL
 #define pn_collector_compare NULL
 
-PN_CLASSDEF(pn_collector)
-
 pn_collector_t *pn_collector(void)
 {
-  return pn_collector_new();
+  static const pn_class_t clazz = PN_CLASS(pn_collector);
+  return (pn_collector_t *) pn_class_new(&clazz, sizeof(pn_collector_t));
 }
 
 void pn_collector_free(pn_collector_t *collector)
@@ -210,8 +212,9 @@ bool pn_collector_more(pn_collector_t *collector)
   return collector->head && collector->head->next;
 }
 
-static void pn_event_initialize(pn_event_t *event)
+static void pn_event_initialize(void *object)
 {
+  pn_event_t *event = (pn_event_t *)object;
   event->pool = NULL;
   event->type = PN_EVENT_NONE;
   event->clazz = NULL;
@@ -220,7 +223,8 @@ static void pn_event_initialize(pn_event_t *event)
   event->attachments = pn_record();
 }
 
-static void pn_event_finalize(pn_event_t *event) {
+static void pn_event_finalize(void *object) {
+  pn_event_t *event = (pn_event_t *)object;
   // decref before adding to the free list
   if (event->clazz && event->context) {
     pn_class_decref(event->clazz, event->context);
@@ -243,8 +247,9 @@ static void pn_event_finalize(pn_event_t *event) {
   pn_decref(pool);
 }
 
-static int pn_event_inspect(pn_event_t *event, pn_string_t *dst)
+static int pn_event_inspect(void *object, pn_string_t *dst)
 {
+  pn_event_t *event = (pn_event_t *)object;
   assert(event);
   assert(dst);
   const char *name = pn_event_type_name(event->type);
@@ -268,11 +273,10 @@ static int pn_event_inspect(pn_event_t *event, pn_string_t *dst)
 #define pn_event_hashcode NULL
 #define pn_event_compare NULL
 
-PN_CLASSDEF(pn_event)
-
 pn_event_t *pn_event(void)
 {
-  return pn_event_new();
+  static const pn_class_t clazz = PN_CLASS(pn_event);
+  return pn_class_new(&clazz, sizeof(pn_event_t));
 }
 
 pn_event_type_t pn_event_type(pn_event_t *event)

--- a/c/src/core/event.c
+++ b/c/src/core/event.c
@@ -41,10 +41,18 @@ struct pn_event_t {
   pn_event_type_t type;
 };
 
+static void pn_event_initialize(void *object);
+static void pn_event_finalize(void *object);
+static int pn_event_inspect(void *object, pn_string_t *string);
+#define pn_event_hashcode NULL
+#define pn_event_compare NULL
+
+static const pn_class_t PN_CLASSCLASS(pn_event) = PN_CLASS(pn_event);
+
 static void pn_collector_initialize(void* object)
 {
   pn_collector_t *collector = (pn_collector_t *)object;
-  collector->pool = pn_list(PN_OBJECT, 0);
+  collector->pool = pn_list(&PN_CLASSCLASS(pn_event), 0);
   collector->head = NULL;
   collector->tail = NULL;
   collector->prev = NULL;
@@ -278,13 +286,9 @@ static int pn_event_inspect(void *object, pn_string_t *dst)
   return pn_string_addf(dst, ")");
 }
 
-#define pn_event_hashcode NULL
-#define pn_event_compare NULL
-
 pn_event_t *pn_event(void)
 {
-  static const pn_class_t clazz = PN_CLASS(pn_event);
-  return pn_class_new(&clazz, sizeof(pn_event_t));
+  return pn_class_new(&PN_CLASSCLASS(pn_event), sizeof(pn_event_t));
 }
 
 pn_event_type_t pn_event_type(pn_event_t *event)

--- a/c/src/core/object/map.c
+++ b/c/src/core/object/map.c
@@ -396,7 +396,6 @@ static bool pni_identity_equals(void *a, void *b)
 }
 
 #define CID_pni_uintptr CID_pn_void
-static const pn_class_t *pni_uintptr_reify(void *object);
 #define pni_uintptr_new NULL
 #define pni_uintptr_free NULL
 #define pni_uintptr_initialize NULL
@@ -409,11 +408,6 @@ static int pni_uintptr_refcount(void *object) { return -1; }
 #define pni_uintptr_inspect NULL
 
 static const pn_class_t PN_UINTPTR[] = {PN_METACLASS(pni_uintptr)};
-
-static const pn_class_t *pni_uintptr_reify(void *object)
-{
-  return PN_UINTPTR;
-}
 
 pn_hash_t *pn_hash(const pn_class_t *clazz, size_t capacity, float load_factor)
 {

--- a/c/src/core/object/map.c
+++ b/c/src/core/object/map.c
@@ -397,12 +397,14 @@ static bool pni_identity_equals(void *a, void *b)
 
 #define CID_pni_uintptr CID_pn_void
 #define pni_uintptr_new NULL
-#define pni_uintptr_free NULL
 #define pni_uintptr_initialize NULL
-static void pni_uintptr_incref(void *object) {}
-static void pni_uintptr_decref(void *object) {}
-static int pni_uintptr_refcount(void *object) { return -1; }
 #define pni_uintptr_finalize NULL
+#define pni_uintptr_free NULL
+
+#define pni_uintptr_incref pn_void_incref
+#define pni_uintptr_decref pn_void_decref
+#define pni_uintptr_refcount pn_void_refcount
+
 #define pni_uintptr_hashcode NULL
 #define pni_uintptr_compare NULL
 #define pni_uintptr_inspect NULL

--- a/c/src/core/object/object.c
+++ b/c/src/core/object/object.c
@@ -62,7 +62,7 @@ void *pn_class_new(const pn_class_t *clazz, size_t size)
 {
   assert(clazz);
   void *object = clazz->newinst(clazz, size);
-  if (clazz->initialize) {
+  if (object && clazz->initialize) {
     clazz->initialize(object);
   }
   return object;

--- a/c/src/core/object/object.c
+++ b/c/src/core/object/object.c
@@ -162,9 +162,6 @@ void *pn_class_new(const pn_class_t *clazz, size_t size)
 void *pn_class_incref(const pn_class_t *clazz, void *object)
 {
   if (object) {
-    if (clazz==PN_OBJECT) {
-      clazz = pni_head(object)->clazz;
-    }
     pni_class_incref(clazz, object);
   }
   return object;
@@ -172,19 +169,12 @@ void *pn_class_incref(const pn_class_t *clazz, void *object)
 
 int pn_class_refcount(const pn_class_t *clazz, void *object)
 {
-  if (clazz==PN_OBJECT) {
-    clazz = pn_class(object);
-  }
-
   return pni_class_refcount(clazz, object);
 }
 
 int pn_class_decref(const pn_class_t *clazz, void *object)
 {
   if (object) {
-    if (clazz==PN_OBJECT) {
-      clazz = pni_head(object)->clazz;
-    }
     pni_class_decref(clazz, object);
     int rc = pni_class_refcount(clazz, object);
     if (rc == 0) {
@@ -209,10 +199,6 @@ int pn_class_decref(const pn_class_t *clazz, void *object)
 void pn_class_free(const pn_class_t *clazz, void *object)
 {
   if (object) {
-    if (clazz==PN_OBJECT) {
-      clazz = pni_head(object)->clazz;
-    }
-
     int rc = pni_class_refcount(clazz, object);
     assert(rc == 1 || rc == -1);
     if (rc == 1) {
@@ -232,9 +218,6 @@ intptr_t pn_class_compare(const pn_class_t *clazz, void *a, void *b)
   if (a == b) return 0;
 
   if (a && b) {
-    if (clazz==PN_OBJECT) {
-      clazz = pni_head(a)->clazz;
-    }
     if (clazz->compare) {
       return clazz->compare(a, b);
     }
@@ -249,10 +232,6 @@ bool pn_class_equals(const pn_class_t *clazz, void *a, void *b)
 
 int pn_class_inspect(const pn_class_t *clazz, void *object, pn_string_t *dst)
 {
-  if (clazz==PN_OBJECT) {
-      clazz = pni_head(object)->clazz;
-  }
-
   if (!pn_string_get(dst)) {
     pn_string_set(dst, "");
   }

--- a/c/src/core/object/object.c
+++ b/c/src/core/object/object.c
@@ -29,21 +29,23 @@
 #define pn_object_initialize NULL
 #define pn_object_finalize NULL
 #define pn_object_inspect NULL
-uintptr_t pn_object_hashcode(void *object) { return (uintptr_t) object; }
-intptr_t pn_object_compare(void *a, void *b) { return (intptr_t) a - (intptr_t) b; }
+#define pn_object_hashcode NULL
+#define pn_object_compare NULL
 
 const pn_class_t PN_OBJECT[] = {PN_CLASS(pn_object)};
 
-#define pn_void_initialize NULL
 void *pn_void_new(const pn_class_t *clazz, size_t size) { return pni_mem_allocate(clazz, size); }
+#define pn_void_initialize NULL
+#define pn_void_finalize NULL
+static void pn_void_free(void *object) { pni_mem_deallocate(PN_VOID, object); }
+
 void pn_void_incref(void* p) {}
 void pn_void_decref(void* p) {}
 int pn_void_refcount(void *object) { return -1; }
-#define pn_void_finalize NULL
-static void pn_void_free(void *object) { pni_mem_deallocate(PN_VOID, object); }
-uintptr_t pn_void_hashcode(void *object) { return (uintptr_t) object; }
-intptr_t pn_void_compare(void *a, void *b) { return (intptr_t) a - (intptr_t) b; }
-int pn_void_inspect(void *object, pn_string_t *dst) { return pn_string_addf(dst, "%p", object); }
+
+#define pn_void_hashcode NULL
+#define pn_void_compare NULL
+#define pn_void_inspect NULL
 
 const pn_class_t PN_VOID[] = {PN_METACLASS(pn_void)};
 
@@ -352,9 +354,10 @@ int pn_inspect(void *object, pn_string_t *dst)
 #define pn_weakref_finalize NULL
 #define pn_weakref_free NULL
 
-static void pn_weakref_incref(void *object) {}
-static void pn_weakref_decref(void *object) {}
-static int pn_weakref_refcount(void *object) { return -1; }
+#define pn_weakref_incref pn_void_incref
+#define pn_weakref_decref pn_void_decref
+#define pn_weakref_refcount pn_void_refcount
+
 static uintptr_t pn_weakref_hashcode(void *object) {
   return pn_hashcode(object);
 }

--- a/c/src/core/object/object.c
+++ b/c/src/core/object/object.c
@@ -67,10 +67,91 @@ pn_cid_t pn_class_id(const pn_class_t *clazz)
   return clazz->cid;
 }
 
+static inline void *pni_default_new(const pn_class_t *clazz, size_t size)
+{
+  void *object = NULL;
+  pni_head_t *head = (pni_head_t *) pni_mem_zallocate(clazz, sizeof(pni_head_t) + size);
+  if (head != NULL) {
+    object = head + 1;
+    head->clazz = clazz;
+    head->refcount = 1;
+  }
+  return object;
+}
+
+static inline void pni_default_incref(void *object) {
+  if (object) {
+    pni_head(object)->refcount++;
+  }
+}
+
+static inline int pni_default_refcount(void *object)
+{
+  assert(object);
+  return pni_head(object)->refcount;
+}
+
+static inline void pni_default_decref(void *object)
+{
+  pni_head_t *head = pni_head(object);
+  assert(head->refcount > 0);
+  head->refcount--;
+}
+
+static inline void pni_default_free(void *object)
+{
+  pni_head_t *head = pni_head(object);
+  pni_mem_deallocate(head->clazz, head);
+}
+
+void pn_object_incref(void *object) {
+  pni_default_incref(object);
+}
+
+static inline void *pni_class_new(const pn_class_t *clazz, size_t size) {
+  if (clazz->newinst) {
+    return clazz->newinst(clazz, size);
+  } else {
+    return pni_default_new(clazz, size);
+  }
+}
+
+static inline void pni_class_incref(const pn_class_t *clazz, void *object) {
+  if (clazz->incref) {
+    clazz->incref(object);
+  } else {
+    pni_default_incref(object);
+  }
+}
+
+static inline void pni_class_decref(const pn_class_t *clazz, void *object) {
+  if (clazz->decref) {
+    clazz->decref(object);
+  } else {
+    pni_default_decref(object);
+  }
+}
+
+static inline int pni_class_refcount(const pn_class_t *clazz, void *object) {
+  if (clazz->refcount) {
+    return clazz->refcount(object);
+  } else {
+    return pni_default_refcount(object);
+  }
+}
+
+static inline void pni_class_free(const pn_class_t *clazz, void *object) {
+  if (clazz->free) {
+    clazz->free(object);
+  } else {
+    pni_default_free(object);
+  }
+}
+
 void *pn_class_new(const pn_class_t *clazz, size_t size)
 {
   assert(clazz);
-  void *object = clazz->newinst(clazz, size);
+  void *object = pni_class_new(clazz, size);
   if (object && clazz->initialize) {
     clazz->initialize(object);
   }
@@ -83,8 +164,7 @@ void *pn_class_incref(const pn_class_t *clazz, void *object)
     if (clazz==PN_OBJECT) {
       clazz = pni_head(object)->clazz;
     }
-
-    clazz->incref(object);
+    pni_class_incref(clazz, object);
   }
   return object;
 }
@@ -95,7 +175,7 @@ int pn_class_refcount(const pn_class_t *clazz, void *object)
     clazz = pn_class(object);
   }
 
-  return clazz->refcount(object);
+  return pni_class_refcount(clazz, object);
 }
 
 int pn_class_decref(const pn_class_t *clazz, void *object)
@@ -104,18 +184,17 @@ int pn_class_decref(const pn_class_t *clazz, void *object)
     if (clazz==PN_OBJECT) {
       clazz = pni_head(object)->clazz;
     }
-
-    clazz->decref(object);
-    int rc = clazz->refcount(object);
+    pni_class_decref(clazz, object);
+    int rc = pni_class_refcount(clazz, object);
     if (rc == 0) {
       if (clazz->finalize) {
         clazz->finalize(object);
         // check the refcount again in case the finalizer created a
         // new reference
-        rc = clazz->refcount(object);
+        rc = pni_class_refcount(clazz, object);
       }
       if (rc == 0) {
-        clazz->free(object);
+        pni_class_free(clazz, object);
         return 0;
       }
     } else {
@@ -133,7 +212,7 @@ void pn_class_free(const pn_class_t *clazz, void *object)
       clazz = pni_head(object)->clazz;
     }
 
-    int rc = clazz->refcount(object);
+    int rc = pni_class_refcount(clazz, object);
     assert(rc == 1 || rc == -1);
     if (rc == 1) {
       rc = pn_class_decref(clazz, object);
@@ -142,7 +221,7 @@ void pn_class_free(const pn_class_t *clazz, void *object)
       if (clazz->finalize) {
         clazz->finalize(object);
       }
-      clazz->free(object);
+      pni_class_free(clazz, object);
     }
   }
 }
@@ -186,50 +265,11 @@ int pn_class_inspect(const pn_class_t *clazz, void *object, pn_string_t *dst)
   return pn_string_addf(dst, "%s<%p>", name, object);
 }
 
-void *pn_object_new(const pn_class_t *clazz, size_t size)
-{
-  void *object = NULL;
-  pni_head_t *head = (pni_head_t *) pni_mem_zallocate(clazz, sizeof(pni_head_t) + size);
-  if (head != NULL) {
-    object = head + 1;
-    head->clazz = clazz;
-    head->refcount = 1;
-  }
-  return object;
-}
-
-
-void pn_object_incref(void *object)
-{
-  if (object) {
-    pni_head(object)->refcount++;
-  }
-}
-
-int pn_object_refcount(void *object)
-{
-  assert(object);
-  return pni_head(object)->refcount;
-}
-
-void pn_object_decref(void *object)
-{
-  pni_head_t *head = pni_head(object);
-  assert(head->refcount > 0);
-  head->refcount--;
-}
-
-void pn_object_free(void *object)
-{
-  pni_head_t *head = pni_head(object);
-  pni_mem_deallocate(head->clazz, head);
-}
-
 void *pn_incref(void *object)
 {
   if (object) {
     const pn_class_t *clazz = pni_head(object)->clazz;
-    clazz->incref(object);
+    pni_class_incref(clazz, object);
   }
   return object;
 }
@@ -238,17 +278,17 @@ int pn_decref(void *object)
 {
   if (object) {
     const pn_class_t *clazz = pni_head(object)->clazz;
-    clazz->decref(object);
-    int rc = clazz->refcount(object);
+    pni_class_decref(clazz, object);
+    int rc = pni_class_refcount(clazz, object);
     if (rc == 0) {
       if (clazz->finalize) {
         clazz->finalize(object);
         // check the refcount again in case the finalizer created a
         // new reference
-        rc = clazz->refcount(object);
+        rc = pni_class_refcount(clazz, object);
       }
       if (rc == 0) {
-        clazz->free(object);
+        pni_class_free(clazz, object);
         return 0;
       }
     } else {
@@ -262,29 +302,29 @@ int pn_refcount(void *object)
 {
   assert(object);
   const pn_class_t *clazz = pni_head(object)->clazz;
-  return clazz->refcount(object);
+  return pni_class_refcount(clazz, object);
 }
 
 void pn_free(void *object)
 {
   if (object) {
     const pn_class_t *clazz = pni_head(object)->clazz;
-    int rc = clazz->refcount(object);
+    int rc = pni_class_refcount(clazz, object);
     assert(rc == 1 || rc == -1);
     if (rc == 1) {
-      clazz->decref(object);
-      assert(clazz->refcount(object) == 0);
+      pni_class_decref(clazz, object);
+      assert(pni_class_refcount(clazz, object) == 0);
       if (clazz->finalize) {
         clazz->finalize(object);
       }
-      if (clazz->refcount(object) == 0) {
-        clazz->free(object);
+      if (pni_class_refcount(clazz, object) == 0) {
+        pni_class_free(clazz, object);
       }
     } else {
       if (clazz->finalize) {
         clazz->finalize(object);
       }
-      clazz->free(object);
+      pni_class_free(clazz, object);
     }
   }
 }

--- a/c/src/core/transport.c
+++ b/c/src/core/transport.c
@@ -535,16 +535,16 @@ static void pn_transport_incref(void *object)
 }
 
 static void pn_transport_finalize(void *object);
-#define pn_transport_new pn_object_new
-#define pn_transport_refcount pn_object_refcount
-#define pn_transport_decref pn_object_decref
+#define pn_transport_new NULL
+#define pn_transport_refcount NULL
+#define pn_transport_decref NULL
 #define pn_transport_hashcode NULL
 #define pn_transport_compare NULL
 #define pn_transport_inspect NULL
 
 pn_transport_t *pn_transport(void)
 {
-#define pn_transport_free pn_object_free
+#define pn_transport_free NULL
   static const pn_class_t clazz = PN_METACLASS(pn_transport);
 #undef pn_transport_free
   pn_transport_t *transport =

--- a/c/src/core/transport.c
+++ b/c/src/core/transport.c
@@ -538,7 +538,6 @@ static void pn_transport_finalize(void *object);
 #define pn_transport_new pn_object_new
 #define pn_transport_refcount pn_object_refcount
 #define pn_transport_decref pn_object_decref
-#define pn_transport_reify pn_object_reify
 #define pn_transport_hashcode NULL
 #define pn_transport_compare NULL
 #define pn_transport_inspect NULL

--- a/c/src/handlers/iohandler.c
+++ b/c/src/handlers/iohandler.c
@@ -66,7 +66,7 @@ static void pn_iodispatch(pn_iohandler_t *handler, pn_event_t *event, pn_event_t
   pn_selector_t *selector = (pn_selector_t *) pn_record_get(record, PN_SELECTOR);
   if (!selector) {
     selector = pn_io_selector(pni_reactor_io(reactor));
-    pn_record_def(record, PN_SELECTOR, PN_OBJECT);
+    pn_record_def(record, PN_SELECTOR, pn_class(selector));
     pn_record_set(record, PN_SELECTOR, selector);
     pn_decref(selector);
   }

--- a/c/src/messenger/messenger.c
+++ b/c/src/messenger/messenger.c
@@ -389,7 +389,7 @@ static pn_listener_ctx_t *pn_listener_ctx(pn_messenger_t *messenger,
     return NULL;
   }
 
-  pn_listener_ctx_t *ctx = (pn_listener_ctx_t *) pn_class_new(PN_OBJECT, sizeof(pn_listener_ctx_t));
+  pn_listener_ctx_t *ctx = (pn_listener_ctx_t *) pn_class_new(PN_DEFAULT, sizeof(pn_listener_ctx_t));
   ctx->messenger = messenger;
   ctx->domain = pn_ssl_domain(PN_SSL_MODE_SERVER);
   if (messenger->certificate) {

--- a/c/src/messenger/messenger.c
+++ b/c/src/messenger/messenger.c
@@ -655,7 +655,7 @@ pn_messenger_t *pn_messenger(const char *name)
     m->next_tag = 0;
     m->outgoing = pni_store();
     m->incoming = pni_store();
-    m->subscriptions = pn_list(PN_OBJECT, 0);
+    m->subscriptions = pn_list(&PN_CLASSCLASS(pn_subscription), 0);
     m->incoming_subscription = NULL;
     m->error = pn_error();
     m->routes = pn_transform();

--- a/c/src/messenger/store.c
+++ b/c/src/messenger/store.c
@@ -77,6 +77,13 @@ void pni_entry_finalize(void *object)
   }
 }
 
+#define CID_pni_entry CID_pn_object
+#define pni_entry_initialize NULL
+#define pni_entry_hashcode NULL
+#define pni_entry_compare NULL
+#define pni_entry_inspect NULL
+static const pn_class_t PN_CLASSCLASS(pni_entry) = PN_CLASS(pni_entry);
+
 pni_store_t *pni_store()
 {
   pni_store_t *store = (pni_store_t *) malloc(sizeof(pni_store_t));
@@ -89,7 +96,7 @@ pni_store_t *pni_store()
   store->window = 0;
   store->lwm = 0;
   store->hwm = 0;
-  store->tracked = pn_hash(PN_OBJECT, 0, 0.75);
+  store->tracked = pn_hash(&PN_CLASSCLASS(pni_entry), 0, 0.75);
 
   return store;
 }
@@ -199,21 +206,14 @@ pni_stream_t *pni_stream_get(pni_store_t *store, const char *address)
   return pni_stream(store, address, false);
 }
 
-#define CID_pni_entry CID_pn_object
-#define pni_entry_initialize NULL
-#define pni_entry_hashcode NULL
-#define pni_entry_compare NULL
-#define pni_entry_inspect NULL
-
 pni_entry_t *pni_store_put(pni_store_t *store, const char *address)
 {
   assert(store);
-  static const pn_class_t clazz = PN_CLASS(pni_entry);
 
   if (!address) address = "";
   pni_stream_t *stream = pni_stream_put(store, address);
   if (!stream) return NULL;
-  pni_entry_t *entry = (pni_entry_t *) pn_class_new(&clazz, sizeof(pni_entry_t));
+  pni_entry_t *entry = (pni_entry_t *) pn_class_new(&PN_CLASSCLASS(pni_entry), sizeof(pni_entry_t));
   if (!entry) return NULL;
   entry->stream = stream;
   entry->free = false;

--- a/c/src/messenger/subscription.c
+++ b/c/src/messenger/subscription.c
@@ -19,6 +19,8 @@
  *
  */
 
+#include "subscription.h"
+
 #include <proton/messenger.h>
 #include <proton/object.h>
 #include <assert.h>
@@ -60,19 +62,20 @@ void pn_subscription_finalize(void *obj)
 #define pn_subscription_compare NULL
 #define pn_subscription_inspect NULL
 
+const pn_class_t PN_CLASSCLASS(pn_subscription) = PN_CLASS(pn_subscription);
+
 pn_subscription_t *pn_subscription(pn_messenger_t *messenger,
                                    const char *scheme,
                                    const char *host,
                                    const char *port)
 {
-  static const pn_class_t clazz = PN_CLASS(pn_subscription);
-  pn_subscription_t *sub = (pn_subscription_t *) pn_class_new(&clazz, sizeof(pn_subscription_t));
+  pn_subscription_t *sub = (pn_subscription_t *) pn_class_new(&PN_CLASSCLASS(pn_subscription), sizeof(pn_subscription_t));
   sub->messenger = messenger;
   pn_string_set(sub->scheme, scheme);
   pn_string_set(sub->host, host);
   pn_string_set(sub->port, port);
   pni_messenger_add_subscription(messenger, sub);
-  pn_class_decref(PN_OBJECT, sub);
+  pn_decref(sub);
   return sub;
 }
 

--- a/c/src/messenger/subscription.h
+++ b/c/src/messenger/subscription.h
@@ -24,6 +24,8 @@
 
 #include <proton/messenger.h>
 
+extern const pn_class_t PN_CLASSCLASS(pn_subscription);
+
 pn_subscription_t *pn_subscription(pn_messenger_t *messenger,
                                    const char *scheme, const char *host,
                                    const char *port);

--- a/c/src/messenger/transform.c
+++ b/c/src/messenger/transform.c
@@ -59,11 +59,11 @@ static void pn_rule_finalize(void *object)
 #define pn_rule_hashcode NULL
 #define pn_rule_compare NULL
 #define pn_rule_inspect NULL
+static const pn_class_t PN_CLASSCLASS(pn_rule) = PN_CLASS(pn_rule);
 
 pn_rule_t *pn_rule(const char *pattern, const char *substitution)
 {
-  static const pn_class_t clazz = PN_CLASS(pn_rule);
-  pn_rule_t *rule = (pn_rule_t *) pn_class_new(&clazz, sizeof(pn_rule_t));
+  pn_rule_t *rule = (pn_rule_t *) pn_class_new(&PN_CLASSCLASS(pn_rule), sizeof(pn_rule_t));
   rule->pattern = pn_string(pattern);
   rule->substitution = pn_string(substitution);
   return rule;
@@ -85,7 +85,7 @@ pn_transform_t *pn_transform()
 {
   static const pn_class_t clazz = PN_CLASS(pn_transform);
   pn_transform_t *transform = (pn_transform_t *) pn_class_new(&clazz, sizeof(pn_transform_t));
-  transform->rules = pn_list(PN_OBJECT, 0);
+  transform->rules = pn_list(&PN_CLASSCLASS(pn_rule), 0);
   transform->matched = false;
   return transform;
 }

--- a/c/src/proactor/epoll.c
+++ b/c/src/proactor/epoll.c
@@ -1197,7 +1197,7 @@ static pn_event_batch_t *pconnection_process(pconnection_t *pc, uint32_t events,
 
   if (waking) {
     pn_connection_t *c = pc->driver.connection;
-    pn_collector_put(pn_connection_collector(c), PN_OBJECT, c, PN_CONNECTION_WAKE);
+    pn_collector_put_object(pn_connection_collector(c), c, PN_CONNECTION_WAKE);
     waking = false;
   }
 

--- a/c/src/proactor/epoll_timer.c
+++ b/c/src/proactor/epoll_timer.c
@@ -83,8 +83,6 @@ typedef struct timer_deadline_t {
   bool resequenced;            // An out-of-order connection timeout caught and handled.
 } timer_deadline_t;
 
-static const pn_class_t *timer_deadline_reify(void *p);
-
 // The pn_list_t calls this to maintain its sorted heap.
 static intptr_t timer_deadline_compare(void *oa, void *ob) {
   timer_deadline_t *a = (timer_deadline_t *) oa;
@@ -104,7 +102,6 @@ static intptr_t timer_deadline_compare(void *oa, void *ob) {
 #define timer_deadline_inspect NULL
 
 static const pn_class_t timer_deadline_clazz = PN_METACLASS(timer_deadline);
-static const pn_class_t *timer_deadline_reify(void *p) { return &timer_deadline_clazz; }
 
 static timer_deadline_t* timer_deadline_t_new(void) {
   // Just the struct.  Not a Proton class based object.

--- a/c/src/proactor/libuv.c
+++ b/c/src/proactor/libuv.c
@@ -886,7 +886,7 @@ static void check_wake(pconnection_t *pc) {
   uv_mutex_lock(&pc->lock);
   if (pc->wake == W_PENDING) {
     pn_connection_t *c = pc->driver.connection;
-    pn_collector_put(pn_connection_collector(c), PN_OBJECT, c, PN_CONNECTION_WAKE);
+    pn_collector_put_object(pn_connection_collector(c), c, PN_CONNECTION_WAKE);
     pc->wake = W_NONE;
   }
   uv_mutex_unlock(&pc->lock);

--- a/c/src/proactor/win_iocp.cpp
+++ b/c/src/proactor/win_iocp.cpp
@@ -1186,13 +1186,13 @@ static uintptr_t pni_iocpdesc_hashcode(void *object)
 
 #define pni_iocpdesc_compare NULL
 #define pni_iocpdesc_inspect NULL
+#define CID_pni_iocpdesc CID_pn_void
+static pn_class_t PN_CLASSCLASS(pni_iocpdesc) = PN_CLASS(pni_iocpdesc);
 
 // Reference counted in the iocpdesc map, zombie_list, selector.
 static iocpdesc_t *pni_iocpdesc(pn_socket_t s)
 {
-  static const pn_cid_t CID_pni_iocpdesc = CID_pn_void;
-  static pn_class_t clazz = PN_CLASS(pni_iocpdesc);
-  iocpdesc_t *iocpd = (iocpdesc_t *) pn_class_new(&clazz, sizeof(iocpdesc_t));
+  iocpdesc_t *iocpd = (iocpdesc_t *) pn_class_new(&PN_CLASSCLASS(pni_iocpdesc), sizeof(iocpdesc_t));
   assert(iocpd);
   iocpd->socket = s;
   return iocpd;
@@ -1514,7 +1514,7 @@ void pni_iocp_initialize(void *obj)
   pni_shared_pool_create(iocp);
   iocp->completion_port = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
   assert(iocp->completion_port != NULL);
-  iocp->zombie_list = pn_list(PN_OBJECT, 0);
+  iocp->zombie_list = pn_list(&PN_CLASSCLASS(pni_iocpdesc), 0);
   iocp->iocp_trace = false;
 }
 

--- a/c/src/proactor/win_iocp.cpp
+++ b/c/src/proactor/win_iocp.cpp
@@ -2351,7 +2351,7 @@ static pn_event_batch_t *pconnection_process(pconnection_t *pc, iocp_result_t *r
       bool ready = pconnection_has_event(pc);
       if (waking) {
         pn_connection_t *c = pc->driver.connection;
-        pn_collector_put(pn_connection_collector(c), PN_OBJECT, c, PN_CONNECTION_WAKE);
+        pn_collector_put_object(pn_connection_collector(c), c, PN_CONNECTION_WAKE);
         waking = false;
       }
       if (ready) {

--- a/c/src/reactor/acceptor.c
+++ b/c/src/reactor/acceptor.c
@@ -60,7 +60,7 @@ void pni_acceptor_readable(pn_selectable_t *sel) {
   pn_decref(trans);
   pn_reactor_selectable_transport(reactor, sock, trans);
   record = pn_connection_attachments(conn);
-  pn_record_def(record, PNI_ACCEPTOR_CONNECTION, PN_OBJECT);
+  pn_record_def(record, PNI_ACCEPTOR_CONNECTION, pn_class(sel));
   pn_record_set(record, PNI_ACCEPTOR_CONNECTION, sel);
 
 }
@@ -83,7 +83,7 @@ pn_acceptor_t *pn_reactor_acceptor(pn_reactor_t *reactor, const char *host, cons
   pn_selectable_on_finalize(sel, pni_acceptor_finalize);
   pni_record_init_reactor(pn_selectable_attachments(sel), reactor);
   pn_record_t *record = pn_selectable_attachments(sel);
-  pn_record_def(record, PNI_ACCEPTOR_HANDLER, PN_OBJECT);
+  pn_record_def(record, PNI_ACCEPTOR_HANDLER, pn_class(handler));
   pn_record_set(record, PNI_ACCEPTOR_HANDLER, handler);
   pn_selectable_set_reading(sel, true);
   pn_reactor_update(reactor, sel);

--- a/c/src/reactor/connection.c
+++ b/c/src/reactor/connection.c
@@ -47,7 +47,7 @@ void pni_reactor_set_connection_peer_address(pn_connection_t *connection,
     pn_url_set_port(url, port);
     pn_record_t *record = pn_connection_attachments(connection);
     if (!pn_record_has(record, PNI_CONN_PEER_ADDRESS)) {
-      pn_record_def(record, PNI_CONN_PEER_ADDRESS, PN_OBJECT);
+      pn_record_def(record, PNI_CONN_PEER_ADDRESS, pn_class(url));
     }
     pn_record_set(record, PNI_CONN_PEER_ADDRESS, url);
     pn_decref(url);
@@ -311,7 +311,7 @@ pn_selectable_t *pn_reactor_selectable_transport(pn_reactor_t *reactor, pn_socke
   pn_selectable_on_expired(sel, pni_connection_expired);
   pn_selectable_on_finalize(sel, pni_connection_finalize);
   pn_record_t *record = pn_selectable_attachments(sel);
-  pn_record_def(record, PN_TRANCTX, PN_OBJECT);
+  pn_record_def(record, PN_TRANCTX, pn_class(transport));
   pn_record_set(record, PN_TRANCTX, transport);
   pn_record_t *tr = pn_transport_attachments(transport);
   pn_record_def(tr, PN_TRANCTX, PN_WEAKREF);

--- a/c/src/reactor/handler.c
+++ b/c/src/reactor/handler.c
@@ -49,14 +49,15 @@ void pn_handler_finalize(void *object) {
 #define pn_handler_compare NULL
 #define pn_handler_inspect NULL
 
+static const pn_class_t PN_CLASSCLASS(pn_handler) = PN_CLASS(pn_handler);
+
 pn_handler_t *pn_handler(void (*dispatch)(pn_handler_t *, pn_event_t *, pn_event_type_t)) {
   return pn_handler_new(dispatch, 0, NULL);
 }
 
 pn_handler_t *pn_handler_new(void (*dispatch)(pn_handler_t *, pn_event_t *, pn_event_type_t), size_t size,
                              void (*finalize)(pn_handler_t *)) {
-  static const pn_class_t clazz = PN_CLASS(pn_handler);
-  pn_handler_t *handler = (pn_handler_t *) pn_class_new(&clazz, sizeof(pn_handler_t) + size);
+  pn_handler_t *handler = (pn_handler_t *) pn_class_new(&PN_CLASSCLASS(pn_handler), sizeof(pn_handler_t) + size);
   handler->dispatch = dispatch;
   handler->finalize = finalize;
   memset(pn_handler_mem(handler), 0, size);
@@ -84,7 +85,7 @@ void *pn_handler_mem(pn_handler_t *handler) {
 void pn_handler_add(pn_handler_t *handler, pn_handler_t *child) {
   assert(handler);
   if (!handler->children) {
-    handler->children = pn_list(PN_OBJECT, 0);
+    handler->children = pn_list(&PN_CLASSCLASS(pn_handler), 0);
   }
   pn_list_add(handler->children, child);
 }

--- a/c/src/reactor/io/windows/iocp.c
+++ b/c/src/reactor/io/windows/iocp.c
@@ -751,11 +751,12 @@ static uintptr_t pni_iocpdesc_hashcode(void *object)
 #define pni_iocpdesc_compare NULL
 #define pni_iocpdesc_inspect NULL
 
+pn_class_t PN_CLASSCLASS(pni_iocpdesc) = PN_CLASS(pni_iocpdesc);
+
 // Reference counted in the iocpdesc map, zombie_list, selector.
 static iocpdesc_t *pni_iocpdesc(pn_socket_t s)
 {
-  static pn_class_t clazz = PN_CLASS(pni_iocpdesc);
-  iocpdesc_t *iocpd = (iocpdesc_t *) pn_class_new(&clazz, sizeof(iocpdesc_t));
+  iocpdesc_t *iocpd = (iocpdesc_t *) pn_class_new(&PN_CLASSCLASS(pni_iocpdesc), sizeof(iocpdesc_t));
   assert(iocpd);
   iocpd->socket = s;
   return iocpd;
@@ -1023,7 +1024,7 @@ static void drain_zombie_completions(iocp_t *iocp)
 static pn_list_t *iocp_map_close_all(iocp_t *iocp)
 {
   // Zombify stragglers, i.e. no pn_close() from the application.
-  pn_list_t *externals = pn_list(PN_OBJECT, 0);
+  pn_list_t *externals = pn_list(&PN_CLASSCLASS(pni_iocpdesc), 0);
   for (pn_handle_t entry = pn_hash_head(iocp->iocpdesc_map); entry;
        entry = pn_hash_next(iocp->iocpdesc_map, entry)) {
     iocpdesc_t *iocpd = (iocpdesc_t *) pn_hash_value(iocp->iocpdesc_map, entry);
@@ -1142,8 +1143,8 @@ void pni_iocp_initialize(void *obj)
   pni_shared_pool_create(iocp);
   iocp->completion_port = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
   assert(iocp->completion_port != NULL);
-  iocp->iocpdesc_map = pn_hash(PN_OBJECT, 0, 0.75);
-  iocp->zombie_list = pn_list(PN_OBJECT, 0);
+  iocp->iocpdesc_map = pn_hash(&PN_CLASSCLASS(pni_iocpdesc), 0, 0.75);
+  iocp->zombie_list = pn_list(&PN_CLASSCLASS(pni_iocpdesc), 0);
   iocp->iocp_trace = pn_env_bool("PN_TRACE_DRV");
   iocp->selector = NULL;
 }

--- a/c/src/reactor/io/windows/iocp.h
+++ b/c/src/reactor/io/windows/iocp.h
@@ -101,6 +101,8 @@ struct write_result_t {
   pn_bytes_t buffer;
 };
 
+extern pn_class_t PN_CLASSCLASS(pni_iocpdesc);
+
 iocpdesc_t *pni_iocpdesc_create(iocp_t *, pn_socket_t s, bool external);
 iocpdesc_t *pni_iocpdesc_map_get(iocp_t *, pn_socket_t s);
 iocpdesc_t *pni_deadline_desc(iocp_t *);

--- a/c/src/reactor/io/windows/selector.c
+++ b/c/src/reactor/io/windows/selector.c
@@ -62,7 +62,7 @@ void pn_selector_initialize(void *obj)
   pn_selector_t *selector = (pn_selector_t *) obj;
   selector->iocp = NULL;
   selector->selectables = pn_list(PN_WEAKREF, 0);
-  selector->iocp_descriptors = pn_list(PN_OBJECT, 0);
+  selector->iocp_descriptors = pn_list(&PN_CLASSCLASS(pni_iocpdesc), 0);
   selector->current = 0;
   selector->current_triggered = NULL;
   selector->awoken = 0;

--- a/c/src/reactor/reactor.c
+++ b/c/src/reactor/reactor.c
@@ -66,7 +66,8 @@ pn_timestamp_t pn_reactor_now(pn_reactor_t *reactor) {
   return reactor->now;
 }
 
-static void pn_reactor_initialize(pn_reactor_t *reactor) {
+static void pn_reactor_initialize(void *object) {
+  pn_reactor_t *reactor = (pn_reactor_t *)object;
   reactor->attachments = pn_record();
   reactor->io = pn_io();
   reactor->collector = pn_collector();
@@ -85,7 +86,8 @@ static void pn_reactor_initialize(pn_reactor_t *reactor) {
   pn_reactor_mark(reactor);
 }
 
-static void pn_reactor_finalize(pn_reactor_t *reactor) {
+static void pn_reactor_finalize(void *object) {
+  pn_reactor_t *reactor = (pn_reactor_t *)object;
   for (int i = 0; i < 2; i++) {
     if (reactor->wakeup[i] != PN_INVALID_SOCKET) {
       pn_close(reactor->io, reactor->wakeup[i]);
@@ -104,10 +106,9 @@ static void pn_reactor_finalize(pn_reactor_t *reactor) {
 #define pn_reactor_compare NULL
 #define pn_reactor_inspect NULL
 
-PN_CLASSDEF(pn_reactor)
-
 pn_reactor_t *pn_reactor() {
-  pn_reactor_t *reactor = pn_reactor_new();
+  static const pn_class_t clazz = PN_CLASS(pn_reactor);
+  pn_reactor_t *reactor = pn_class_new(&clazz, sizeof(pn_reactor_t));
   int err = pn_pipe(reactor->io, reactor->wakeup);
   if (err) {
     pn_free(reactor);

--- a/c/src/reactor/reactor.c
+++ b/c/src/reactor/reactor.c
@@ -310,7 +310,7 @@ pn_reactor_t *pn_class_reactor(const pn_class_t *clazz, void *object) {
 }
 
 pn_reactor_t *pn_object_reactor(void *object) {
-  return pn_class_reactor(pn_object_reify(object), object);
+  return pn_class_reactor(pn_class(object), object);
 }
 
 pn_reactor_t *pn_event_reactor(pn_event_t *event) {

--- a/c/src/reactor/reactor.c
+++ b/c/src/reactor/reactor.c
@@ -246,7 +246,7 @@ pn_handler_t *pn_record_get_handler(pn_record_t *record) {
 
 void pn_record_set_handler(pn_record_t *record, pn_handler_t *handler) {
   assert(record);
-  pn_record_def(record, PN_HANDLER, PN_OBJECT);
+  pn_record_def(record, PN_HANDLER, pn_class(handler));
   pn_record_set(record, PN_HANDLER, handler);
 }
 

--- a/c/src/reactor/reactor.c
+++ b/c/src/reactor/reactor.c
@@ -199,7 +199,7 @@ pn_selectable_t *pn_reactor_selectable(pn_reactor_t *reactor) {
   assert(reactor);
   pn_selectable_t *sel = pn_selectable();
   pn_selectable_collect(sel, reactor->collector);
-  pn_collector_put(reactor->collector, PN_OBJECT, sel, PN_SELECTABLE_INIT);
+  pn_collector_put_object(reactor->collector, sel, PN_SELECTABLE_INIT);
   pni_selectable_set_context(sel, reactor);
   pn_list_add(reactor->children, sel);
   pn_selectable_on_release(sel, pni_selectable_release);
@@ -216,9 +216,9 @@ void pn_reactor_update(pn_reactor_t *reactor, pn_selectable_t *selectable) {
   if (!pn_record_has(record, PNI_TERMINATED)) {
     if (pn_selectable_is_terminal(selectable)) {
       pn_record_def(record, PNI_TERMINATED, PN_VOID);
-      pn_collector_put(reactor->collector, PN_OBJECT, selectable, PN_SELECTABLE_FINAL);
+      pn_collector_put_object(reactor->collector, selectable, PN_SELECTABLE_FINAL);
     } else {
-      pn_collector_put(reactor->collector, PN_OBJECT, selectable, PN_SELECTABLE_UPDATED);
+      pn_collector_put_object(reactor->collector, selectable, PN_SELECTABLE_UPDATED);
     }
   }
 }
@@ -427,7 +427,7 @@ bool pn_reactor_process(pn_reactor_t *reactor) {
       pn_collector_pop(reactor->collector);
     } else if (!reactor->stop && pni_reactor_more(reactor)) {
       if (previous != PN_REACTOR_QUIESCED && reactor->previous != PN_REACTOR_FINAL) {
-        pn_collector_put(reactor->collector, PN_OBJECT, reactor, PN_REACTOR_QUIESCED);
+        pn_collector_put_object(reactor->collector, reactor, PN_REACTOR_QUIESCED);
       } else {
         return true;
       }
@@ -438,7 +438,7 @@ bool pn_reactor_process(pn_reactor_t *reactor) {
         reactor->selectable = NULL;
       } else {
         if (reactor->previous != PN_REACTOR_FINAL)
-          pn_collector_put(reactor->collector, PN_OBJECT, reactor, PN_REACTOR_FINAL);
+          pn_collector_put_object(reactor->collector, reactor, PN_REACTOR_FINAL);
         return false;
       }
     }
@@ -483,7 +483,7 @@ int pn_reactor_wakeup(pn_reactor_t *reactor) {
 
 void pn_reactor_start(pn_reactor_t *reactor) {
   assert(reactor);
-  pn_collector_put(reactor->collector, PN_OBJECT, reactor, PN_REACTOR_INIT);
+  pn_collector_put_object(reactor->collector, reactor, PN_REACTOR_INIT);
   reactor->selectable = pni_timer_selectable(reactor);
 }
 

--- a/c/src/reactor/selectable.c
+++ b/c/src/reactor/selectable.c
@@ -66,8 +66,9 @@ struct pn_selectable_t {
   bool terminal;
 };
 
-void pn_selectable_initialize(pn_selectable_t *sel)
+void pn_selectable_initialize(void *object)
 {
+  pn_selectable_t *sel = (pn_selectable_t *)object;
   sel->fd = PN_INVALID_SOCKET;
   sel->index = -1;
   sel->attachments = pn_record();
@@ -85,8 +86,9 @@ void pn_selectable_initialize(pn_selectable_t *sel)
   sel->terminal = false;
 }
 
-void pn_selectable_finalize(pn_selectable_t *sel)
+void pn_selectable_finalize(void *object)
 {
+  pn_selectable_t *sel = (pn_selectable_t *)object;
   if (sel->finalize) {
     sel->finalize(sel);
   }
@@ -98,11 +100,10 @@ void pn_selectable_finalize(pn_selectable_t *sel)
 #define pn_selectable_inspect NULL
 #define pn_selectable_compare NULL
 
-PN_CLASSDEF(pn_selectable)
-
 pn_selectable_t *pn_selectable(void)
 {
-  return pn_selectable_new();
+  static const pn_class_t clazz = PN_CLASS(pn_selectable);
+  return pn_class_new(&clazz, sizeof(pn_selectable_t));
 }
 
 bool pn_selectable_is_reading(pn_selectable_t *sel) {

--- a/c/src/reactor/selectable.c
+++ b/c/src/reactor/selectable.c
@@ -276,19 +276,19 @@ void pn_selectable_free(pn_selectable_t *selectable)
 }
 
 static void pni_readable(pn_selectable_t *selectable) {
-  pn_collector_put(selectable->collector, PN_OBJECT, selectable, PN_SELECTABLE_READABLE);
+  pn_collector_put_object(selectable->collector, selectable, PN_SELECTABLE_READABLE);
 }
 
 static void pni_writable(pn_selectable_t *selectable) {
-  pn_collector_put(selectable->collector, PN_OBJECT, selectable, PN_SELECTABLE_WRITABLE);
+  pn_collector_put_object(selectable->collector, selectable, PN_SELECTABLE_WRITABLE);
 }
 
 static void pni_error(pn_selectable_t *selectable) {
-  pn_collector_put(selectable->collector, PN_OBJECT, selectable, PN_SELECTABLE_ERROR);
+  pn_collector_put_object(selectable->collector, selectable, PN_SELECTABLE_ERROR);
 }
 
 static void pni_expired(pn_selectable_t *selectable) {
-  pn_collector_put(selectable->collector, PN_OBJECT, selectable, PN_SELECTABLE_EXPIRED);
+  pn_collector_put_object(selectable->collector, selectable, PN_SELECTABLE_EXPIRED);
 }
 
 void pn_selectable_collect(pn_selectable_t *selectable, pn_collector_t *collector) {

--- a/c/src/reactor/selectable.c
+++ b/c/src/reactor/selectable.c
@@ -99,11 +99,11 @@ void pn_selectable_finalize(void *object)
 #define pn_selectable_hashcode NULL
 #define pn_selectable_inspect NULL
 #define pn_selectable_compare NULL
+const pn_class_t PN_CLASSCLASS(pn_selectable) = PN_CLASS(pn_selectable);
 
 pn_selectable_t *pn_selectable(void)
 {
-  static const pn_class_t clazz = PN_CLASS(pn_selectable);
-  return pn_class_new(&clazz, sizeof(pn_selectable_t));
+  return pn_class_new(&PN_CLASSCLASS(pn_selectable), sizeof(pn_selectable_t));
 }
 
 bool pn_selectable_is_reading(pn_selectable_t *sel) {

--- a/c/src/reactor/selectable.h
+++ b/c/src/reactor/selectable.h
@@ -28,6 +28,8 @@
 
 #include <proton/selectable.h>
 
+extern const pn_class_t PN_CLASSCLASS(pn_selectable);
+
 void *pni_selectable_get_context(pn_selectable_t *selectable);
 void pni_selectable_set_context(pn_selectable_t *selectable, void *context);
 int pni_selectable_get_index(pn_selectable_t *selectable);

--- a/c/src/reactor/timer.c
+++ b/c/src/reactor/timer.c
@@ -62,9 +62,9 @@ intptr_t pn_task_compare(void *a, void *b) {
 #define pn_task_inspect NULL
 #define pn_task_hashcode NULL
 
+static const pn_class_t PN_CLASSCLASS(pn_task) = PN_CLASS(pn_task);
 pn_task_t *pn_task(void) {
-  static const pn_class_t clazz = PN_CLASS(pn_task);
-  pn_task_t *task = pn_class_new(&clazz, sizeof(pn_task_t));
+  pn_task_t *task = pn_class_new(&PN_CLASSCLASS(pn_task), sizeof(pn_task_t));
   return task;
 }
 
@@ -90,8 +90,8 @@ struct pn_timer_t {
 
 static void pn_timer_initialize(void *object) {
   pn_timer_t *timer = (pn_timer_t *)object;
-  timer->pool = pn_list(PN_OBJECT, 0);
-  timer->tasks = pn_list(PN_OBJECT, 0);
+  timer->pool = pn_list(&PN_CLASSCLASS(pn_task), 0);
+  timer->tasks = pn_list(&PN_CLASSCLASS(pn_task), 0);
 }
 
 static void pn_timer_finalize(void *object) {

--- a/c/src/reactor/timer.c
+++ b/c/src/reactor/timer.c
@@ -158,7 +158,7 @@ void pn_timer_tick(pn_timer_t *timer, pn_timestamp_t now) {
       pn_task_t *min = (pn_task_t *) pn_list_minpop(timer->tasks);
       assert(min == task);
       if (!min->cancelled)
-          pn_collector_put(timer->collector, PN_OBJECT, min, PN_TIMER_TASK);
+          pn_collector_put_object(timer->collector, min, PN_TIMER_TASK);
       pn_decref(min);
     } else {
       break;

--- a/c/src/sasl/sasl.c
+++ b/c/src/sasl/sasl.c
@@ -375,7 +375,7 @@ static void pni_emit(pn_transport_t *transport)
 {
   if (transport->connection && transport->connection->collector) {
     pn_collector_t *collector = transport->connection->collector;
-    pn_collector_put(collector, PN_OBJECT, transport, PN_TRANSPORT);
+    pn_collector_put_object(collector, transport, PN_TRANSPORT);
   }
 }
 

--- a/c/tests/event_test.cpp
+++ b/c/tests/event_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE("event_collector") {
   pn_collector_t *collector = pn_collector();                                  \
   REQUIRE(collector);                                                          \
   pn_event_t *event =                                                          \
-      pn_collector_put(collector, PN_OBJECT, obj, (pn_event_type_t)0);         \
+      pn_collector_put_object(collector, obj, (pn_event_type_t)0);             \
   pn_decref(obj);
 
 TEST_CASE("event_collector_put") {
@@ -71,7 +71,7 @@ TEST_CASE("event_collector_pool") {
   REQUIRE(!head);
   void *obj2 = pn_class_new(PN_OBJECT, 0);
   pn_event_t *event2 =
-      pn_collector_put(collector, PN_OBJECT, obj2, (pn_event_type_t)0);
+      pn_collector_put_object(collector, obj2, (pn_event_type_t)0);
   pn_decref(obj2);
   REQUIRE(event == event2);
   pn_free(collector);
@@ -87,7 +87,7 @@ void test_event_incref(bool eventfirst) {
   REQUIRE(!pn_collector_peek(collector));
   void *obj2 = pn_class_new(PN_OBJECT, 0);
   pn_event_t *event2 =
-      pn_collector_put(collector, PN_OBJECT, obj2, (pn_event_type_t)0);
+      pn_collector_put_object(collector, obj2, (pn_event_type_t)0);
   pn_decref(obj2);
   REQUIRE(head != event2);
   if (eventfirst) {

--- a/c/tests/event_test.cpp
+++ b/c/tests/event_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE("event_collector") {
 }
 
 #define SETUP_COLLECTOR                                                        \
-  void *obj = pn_class_new(PN_OBJECT, 0);                                      \
+  void *obj = pn_class_new(PN_DEFAULT, 0);                                      \
   pn_collector_t *collector = pn_collector();                                  \
   REQUIRE(collector);                                                          \
   pn_event_t *event =                                                          \
@@ -69,7 +69,7 @@ TEST_CASE("event_collector_pool") {
   pn_collector_pop(collector);
   head = pn_collector_peek(collector);
   REQUIRE(!head);
-  void *obj2 = pn_class_new(PN_OBJECT, 0);
+  void *obj2 = pn_class_new(PN_DEFAULT, 0);
   pn_event_t *event2 =
       pn_collector_put_object(collector, obj2, (pn_event_type_t)0);
   pn_decref(obj2);
@@ -85,7 +85,7 @@ void test_event_incref(bool eventfirst) {
   pn_incref(head);
   pn_collector_pop(collector);
   REQUIRE(!pn_collector_peek(collector));
-  void *obj2 = pn_class_new(PN_OBJECT, 0);
+  void *obj2 = pn_class_new(PN_DEFAULT, 0);
   pn_event_t *event2 =
       pn_collector_put_object(collector, obj2, (pn_event_type_t)0);
   pn_decref(obj2);

--- a/c/tests/object_test.cpp
+++ b/c/tests/object_test.cpp
@@ -152,7 +152,7 @@ static void test_class(const pn_class_t *clazz, size_t size) {
 }
 
 TEST_CASE("object_class") {
-  test_class(PN_OBJECT, 0);
+  test_class(PN_DEFAULT, 0);
   test_class(PN_VOID, 5);
   test_class(&noop_class, 128);
 }
@@ -172,8 +172,8 @@ static void test_new(size_t size, const pn_class_t *clazz) {
 }
 
 TEST_CASE("object_class new") {
-  test_new(0, PN_OBJECT);
-  test_new(5, PN_OBJECT);
+  test_new(0, PN_DEFAULT);
+  test_new(5, PN_DEFAULT);
   test_new(128, &noop_class);
 }
 
@@ -263,7 +263,7 @@ TEST_CASE("object_compare") {
 
 TEST_CASE("object_refcounting") {
   int refs = 3;
-  void *obj = pn_class_new(PN_OBJECT, 0);
+  void *obj = pn_class_new(PN_DEFAULT, 0);
 
   CHECK(pn_refcount(obj) == 1);
 
@@ -304,10 +304,10 @@ TEST_CASE("list") {
 }
 
 TEST_CASE("list_refcount") {
-  void *one = pn_class_new(PN_OBJECT, 0);
-  void *two = pn_class_new(PN_OBJECT, 0);
-  void *three = pn_class_new(PN_OBJECT, 0);
-  void *four = pn_class_new(PN_OBJECT, 0);
+  void *one = pn_class_new(PN_DEFAULT, 0);
+  void *two = pn_class_new(PN_DEFAULT, 0);
+  void *three = pn_class_new(PN_DEFAULT, 0);
+  void *four = pn_class_new(PN_DEFAULT, 0);
 
   pn_list_t *list = pn_list(PN_OBJECT, 0);
   CHECK(!pn_list_add(list, one));
@@ -446,16 +446,16 @@ TEST_CASE("map_build_odd") {
 }
 
 TEST_CASE("map") {
-  void *one = pn_class_new(PN_OBJECT, 0);
-  void *two = pn_class_new(PN_OBJECT, 0);
-  void *three = pn_class_new(PN_OBJECT, 0);
+  void *one = pn_class_new(PN_DEFAULT, 0);
+  void *two = pn_class_new(PN_DEFAULT, 0);
+  void *three = pn_class_new(PN_DEFAULT, 0);
 
   pn_string_t *key = pn_string("key");
   pn_string_t *dup = pn_string("key");
   pn_string_t *key1 = pn_string("key1");
   pn_string_t *key2 = pn_string("key2");
 
-  pn_map_t *map = pn_map(pn_class(key), PN_OBJECT, 4, 0.75);
+  pn_map_t *map = pn_map(PN_OBJECT, PN_OBJECT, 4, 0.75);
   CHECK(pn_map_size(map) == 0);
 
   CHECK(!pn_map_put(map, key, one));
@@ -508,9 +508,9 @@ TEST_CASE("map") {
 }
 
 TEST_CASE("hash") {
-  void *one = pn_class_new(PN_OBJECT, 0);
-  void *two = pn_class_new(PN_OBJECT, 0);
-  void *three = pn_class_new(PN_OBJECT, 0);
+  void *one = pn_class_new(PN_DEFAULT, 0);
+  void *two = pn_class_new(PN_DEFAULT, 0);
+  void *three = pn_class_new(PN_DEFAULT, 0);
 
   pn_hash_t *hash = pn_hash(PN_OBJECT, 4, 0.75);
   pn_hash_put(hash, 0, NULL);
@@ -679,8 +679,8 @@ TEST_CASE("map_iteration") {
   int n = 5;
   pn_list_t *pairs = pn_list(PN_OBJECT, 2 * n);
   for (int i = 0; i < n; i++) {
-    void *key = pn_class_new(PN_OBJECT, 0);
-    void *value = pn_class_new(PN_OBJECT, 0);
+    void *key = pn_class_new(PN_DEFAULT, 0);
+    void *value = pn_class_new(PN_DEFAULT, 0);
     pn_list_add(pairs, key);
     pn_list_add(pairs, value);
     pn_decref(key);
@@ -893,9 +893,9 @@ TEST_CASE("list_compare") {
 
   CHECK(pn_equals(a, b));
 
-  void *one = pn_class_new(PN_OBJECT, 0);
-  void *two = pn_class_new(PN_OBJECT, 0);
-  void *three = pn_class_new(PN_OBJECT, 0);
+  void *one = pn_class_new(PN_DEFAULT, 0);
+  void *two = pn_class_new(PN_DEFAULT, 0);
+  void *three = pn_class_new(PN_DEFAULT, 0);
 
   pn_list_add(a, one);
   CHECK(!pn_equals(a, b));

--- a/cpp/src/contexts.cpp
+++ b/cpp/src/contexts.cpp
@@ -64,7 +64,7 @@ T* get_context(pn_record_t* record, pn_handle_t handle) {
 
 context::~context() {}
 
-void *context::alloc(size_t n) { return pn_object_new(&cpp_context_class, n); }
+void *context::alloc(size_t n) { return pn_class_new(&cpp_context_class, n); }
 
 pn_class_t* context::pn_class() { return &cpp_context_class; }
 

--- a/cpp/src/receiver.cpp
+++ b/cpp/src/receiver.cpp
@@ -78,7 +78,7 @@ void receiver::drain() {
             // Drain is already complete.  No state to communicate over the wire.
             // Create dummy flow event where "drain finish" can be detected.
             pn_connection_t *pnc = pn_session_connection(pn_link_session(pn_object()));
-            pn_collector_put(pn_connection_collector(pnc), PN_OBJECT, pn_object(), PN_LINK_FLOW);
+            pn_collector_put_object(pn_connection_collector(pnc), pn_object(), PN_LINK_FLOW);
         }
     }
 }

--- a/python/cproton.i
+++ b/python/cproton.i
@@ -422,9 +422,9 @@ int pn_ssl_get_cert_fingerprint(pn_ssl_t *ssl, char *OUTPUT, size_t MAX_OUTPUT_S
   #define pn_pyref_initialize NULL
   #define pn_pyref_finalize NULL
   #define pn_pyref_free NULL
-  #define pn_pyref_hashcode pn_void_hashcode
-  #define pn_pyref_compare pn_void_compare
-  #define pn_pyref_inspect pn_void_inspect
+  #define pn_pyref_hashcode NULL
+  #define pn_pyref_compare NULL
+  #define pn_pyref_inspect NULL
 
   static void pn_pyref_incref(void *object) {
     PyObject* p = (PyObject*) object;
@@ -442,10 +442,6 @@ int pn_ssl_get_cert_fingerprint(pn_ssl_t *ssl, char *OUTPUT, size_t MAX_OUTPUT_S
 
   static int pn_pyref_refcount(void *object) {
     return 1;
-  }
-
-  static const pn_class_t *pn_pyref_reify(void *object) {
-    return PN_PYREF;
   }
 
   const pn_class_t PN_PYREF[] = {PN_METACLASS(pn_pyref)};

--- a/python/setup.py
+++ b/python/setup.py
@@ -155,7 +155,7 @@ class BuildExtension(build_ext):
         """Check to see if the proper version of the Proton development library
         and headers are already installed
         """
-        return misc.pkg_config_version_installed('libqpid-proton-core', atleast='0')
+        return misc.pkg_config_version_installed('libqpid-proton-core', atleast='0.38')
 
     def use_installed_proton(self):
         """The Proton development headers and library are installed, update the


### PR DESCRIPTION
This PR incorporates the work in #368 and adds some more simplification of the object system to speed up my benchmarks by 10-15% compared to the main branch commit it is based on.

The speed ups are due to:
* Removing unnecessary reify operations
* Inlining a lot of the object mechanism
* Devirtualizing most of the object function lookups.
* Something else...?