### PR TITLE
PROTON-2540: [cpp] Provide a way to query proton::connection for the url

### DIFF
--- a/cpp/include/proton/connection.hpp
+++ b/cpp/include/proton/connection.hpp
@@ -83,6 +83,9 @@ PN_CPP_CLASS_EXTERN connection : public internal::object<pn_connection_t>, publi
     /// Note: The value returned is not stable until the on_transport_open event is received
     PN_CPP_EXTERN std::string user() const;
 
+    /// Return the url for the connection.
+    PN_CPP_EXTERN std::string url() const;
+
     /// Open the connection.
     /// @see messaging_handler
     PN_CPP_EXTERN void open();

--- a/cpp/src/connection.cpp
+++ b/cpp/src/connection.cpp
@@ -93,6 +93,12 @@ session_range connection::sessions() const {
     return session_range(session_iterator(make_wrapper(pn_session_head(pn_object(), 0))));
 }
 
+std::string connection::url() const {
+    connection_context& cc = connection_context::get(pn_object());
+    if (!active()) throw proton::error("No active connection");
+    return cc.active_url_;
+}
+
 receiver_range connection::receivers() const {
   pn_link_t *lnk = pn_link_head(pn_object(), 0);
   while (lnk) {

--- a/cpp/src/contexts.hpp
+++ b/cpp/src/contexts.hpp
@@ -100,6 +100,7 @@ class connection_context : public context {
     std::unique_ptr<reconnect_context> reconnect_context_;
     listener_context* listener_context_;
     work_queue work_queue_;
+    std::string active_url_;
 };
 
 class reconnect_options_base;

--- a/cpp/src/proactor_container_impl.cpp
+++ b/cpp/src/proactor_container_impl.cpp
@@ -194,6 +194,7 @@ pn_connection_t* container::impl::make_connection_lh(
     cc.handler = mh;
     cc.work_queue_ = new container::impl::connection_work_queue(*container_.impl_, pnc);
     cc.reconnect_url_ = url;
+    cc.active_url_ = url;
     cc.connection_options_.reset(new connection_options(opts));
 
     make_wrapper(pnc).open(*cc.connection_options_);
@@ -258,6 +259,7 @@ void container::impl::reconnect(pn_connection_t* pnc) {
     opts.update(co);
     messaging_handler* mh = opts.handler();
     cc.handler = mh;
+    cc.active_url_ = url;
 
     make_wrapper(pnc).open(co);
     start_connection(url, pnc);


### PR DESCRIPTION
Right now, there are only two ways:

1. Save the URL where it will always guarantee to return the URL for the current connection.
2. Reconstruct the url using host, port, etc, but right now lib does not store all the URL parts.

So, either store the remaining parts of the URL for reconstructing the whole URL or save the entire URL itself.

Went with the first approach in this PR.

