### PR TITLE
Update Travis CI to stop using Xenial and use Focal instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,81 +17,59 @@
 # under the License
 #
 
+os: linux
+dist: focal
+language: cpp
+env:
+  global:
+    - PYTHON=python3
 jobs:
   include:
-  - os: linux
-    dist: xenial
-    language: cpp
-    compiler: gcc
-    env:
-    - OPENSSL_ia32cap='0x00000000'
-  - os: linux
-    dist: xenial
-    language: cpp
-    compiler: clang
-    env:
-    - OPENSSL_ia32cap='0x00000000'
+  - compiler: gcc
+  - compiler: clang
     # c-threaderciser test hangs on older clang
+    env:
     - QPID_PROTON_CMAKE_ARGS='-DENABLE_LINKTIME_OPTIMIZATION=OFF -DTHREADERCISER=ON'
     - QPID_PROTON_CTEST_ARGS='--exclude-regex c-threaderciser'
   - name: static libs
-    os: linux
-    dist: focal
-    language: cpp
     compiler: gcc
     env:
-    - PYTHON=python3
     - QPID_PROTON_CMAKE_ARGS='-DBUILD_STATIC_LIBS=ON -DTHREADERCISER=ON'
   - name: benchmarks
-    os: linux
-    dist: focal
-    language: cpp
     compiler: gcc
     env:
-    - PYTHON=python3
     - QPID_PROTON_CMAKE_ARGS='-DENABLE_BENCHMARKS=ON -DRUNTIME_CHECK=OFF -DTHREADERCISER=ON'
     before_install:
     - sudo apt-get install -y libbenchmark-dev
   - name: gcc asan
-    os: linux
-    dist: focal
     before_install:
     - sudo apt-get install -y gcc-10 g++-10
     env:
     - CC=gcc-10
     - CXX=g++-10
-    - PYTHON=python3
     # python-tox-test fails and ruby tests segfault
     - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DENABLE_TOX_TEST=OFF -DTHREADERCISER=ON'
     - QPID_PROTON_CTEST_ARGS='-E ^ruby.*'
   - name: clang asan
-    os: linux
-    dist: focal
     before_install:
     - sudo apt-get install -y clang-11 llvm-11-dev
     env:
     - CC=clang-11
     - CXX=clang++-11
-    - PYTHON=python3
     - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DENABLE_TOX_TEST=OFF -DTHREADERCISER=ON'
     # otherwise, on Travis ldd gives `libclang_rt.asan-x86_64.so => not found` and binaries don't work
     - LD_LIBRARY_PATH=/usr/lib/llvm-11/lib/clang/11.0.0/lib/linux/
   - name: gcc tsan
-    os: linux
-    dist: focal
     before_install:
     - sudo apt-get install -y gcc-10 g++-10
     env:
     - CC=gcc-10
     - CXX=g++-10
-    - PYTHON=python3
     - QPID_PROTON_CMAKE_ARGS='-DRUNTIME_CHECK=tsan -DTHREADERCISER=ON'
     # python-test, python-pep8-test, python-integration-test, and python-tox-test (currently all python tests) segfault
     - QPID_PROTON_CTEST_ARGS="-E 'python.*test'"
   - name: coverage
-    os: linux
     dist: bionic
-    language: cpp
     compiler: gcc
     env:
     - QPID_PROTON_CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Coverage -DTHREADERCISER=ON'
@@ -100,7 +78,6 @@ jobs:
 
   - os: osx
     osx_image: xcode12.2
-    language: cpp
     compiler: clang
     env:
     - PATH="/usr/local/opt/python/libexec/bin:/usr/local/bin:$PATH"
@@ -141,10 +118,6 @@ before_install:
   # install Valgrind only on Focal. On Xenial, we are getting `Illegal opcode at address 0x5152B15`
   - if [[ "${TRAVIS_DIST}" == "focal" ]]; then sudo -E apt-get -yq --no-install-suggests --no-install-recommends install valgrind; fi
   # install Python 3.6.8; Travis has a mechanism for this, but that would activate it in a venv, which older CMake does not deal well with
-  - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then curl -sSf --retry 5 -o python-3.6.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-3.6.8.tar.bz2; fi
-  - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then sudo tar xjf python-3.6.8.tar.bz2 --directory /; fi
-  - if [[ "${TRAVIS_DIST}" == "xenial" ]]; then PATH="/opt/python/3.6.8/bin:${PATH}"; fi
-  # same thing for bionic
   - if [[ "${TRAVIS_DIST}" == "bionic" ]]; then curl -sSf --retry 5 -o python-3.6.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/python-3.6.8.tar.bz2; fi
   - if [[ "${TRAVIS_DIST}" == "bionic" ]]; then sudo tar xjf python-3.6.8.tar.bz2 --directory /; fi
   - if [[ "${TRAVIS_DIST}" == "bionic" ]]; then PATH="/opt/python/3.6.8/bin:${PATH}"; fi


### PR DESCRIPTION
Xenial is over 5 years old now - I don't think we need to make sure we build on it any longer.