### PR TITLE
PROTON-2663 Add a constructor to ssl_client_options class

### DIFF
--- a/cpp/include/proton/ssl.hpp
+++ b/cpp/include/proton/ssl.hpp
@@ -163,6 +163,10 @@ class ssl_client_options {
                                      enum ssl::verify_mode = ssl::VERIFY_PEER_NAME);
 
     /// Create SSL client with a client certificate.
+    PN_CPP_EXTERN ssl_client_options(const ssl_certificate&,
+                                     enum ssl::verify_mode = ssl::VERIFY_PEER_NAME);
+
+    /// Create SSL client with a client certificate and a custom certificate trust database.
     PN_CPP_EXTERN ssl_client_options(const ssl_certificate&, const std::string &trust_db,
                                      enum ssl::verify_mode = ssl::VERIFY_PEER_NAME);
 

--- a/cpp/libqpid-proton-cpp.syms
+++ b/cpp/libqpid-proton-cpp.syms
@@ -475,6 +475,7 @@ proton::ssl_certificate::ssl_certificate(std::string const&, std::string const&)
 proton::ssl_certificate::ssl_certificate(std::string const&, std::string const&, std::string const&)
 
 proton::ssl_client_options::ssl_client_options()
+proton::ssl_client_options::ssl_client_options(proton::ssl_certificate&, proton::ssl::verify_mode)
 proton::ssl_client_options::ssl_client_options(proton::ssl_certificate&, std::string const&, proton::ssl::verify_mode)
 proton::ssl_client_options::ssl_client_options(std::string const&, proton::ssl::verify_mode)
 

--- a/cpp/src/ssl_options.cpp
+++ b/cpp/src/ssl_options.cpp
@@ -131,6 +131,12 @@ ssl_client_options::ssl_client_options(const std::string &trust_db, enum ssl::ve
     set_client_verify_mode(dom, mode);
 }
 
+ssl_client_options::ssl_client_options(const ssl_certificate &cert, enum ssl::verify_mode mode) : impl_(new impl) {
+    pn_ssl_domain_t* dom = impl_->pn_domain();
+    set_cred(dom, cert.certdb_main_, cert.certdb_extra_, cert.passwd_, cert.pw_set_);
+    set_client_verify_mode(dom, mode);
+}
+
 ssl_client_options::ssl_client_options(const ssl_certificate &cert, const std::string &trust_db, enum ssl::verify_mode mode) : impl_(new impl) {
     pn_ssl_domain_t* dom = impl_->pn_domain();
     set_cred(dom, cert.certdb_main_, cert.certdb_extra_, cert.passwd_, cert.pw_set_);


### PR DESCRIPTION
PROTON-2663

Please consider to incorporate this patch to Qpid Proton Cpp. Without this patch, Qpid Proton Cpp is a blocker for our project.