### PR TITLE
NO-JIRA: [Python] Allow configuration of container ID

### DIFF
--- a/python/proton/_reactor.py
+++ b/python/proton/_reactor.py
@@ -1192,7 +1192,11 @@ class Container(Reactor):
     for creating connections and sender- or receiver- links.
     """
 
-    def __init__(self, *handlers, **kwargs) -> None:
+    def __init__(self, *handlers, container_id: Optional[str] = None, **kwargs) -> None:
+        """Create a new Container instance
+
+        :param Optional[str] container_id: Container ID to use. If not set, a random ID is generated.
+        """
         super(Container, self).__init__(*handlers, **kwargs)
         if "impl" not in kwargs:
             try:
@@ -1201,7 +1205,7 @@ class Container(Reactor):
                 self.ssl = None
             self.global_handler = GlobalOverrides(kwargs.get('global_handler', self.global_handler))
             self.trigger = None
-            self.container_id = str(_generate_uuid())
+            self.container_id = container_id if container_id else str(_generate_uuid())
             self.allow_insecure_mechs = True
             self.allowed_mechs = None
             self.sasl_enabled = True
@@ -1361,7 +1365,7 @@ class Container(Reactor):
             **kwargs
     ) -> Connection:
         conn = self.connection(handler)
-        conn.container = self.container_id or str(_generate_uuid())
+        conn.container = self.container_id
         conn.offered_capabilities = kwargs.get('offered_capabilities')
         conn.desired_capabilities = kwargs.get('desired_capabilities')
         conn.properties = kwargs.get('properties')


### PR DESCRIPTION
This allows simple external configuration of container ID.
Without it the only way to overwrite or provide custom container ID is to inherit the class.