### PR TITLE
PROTON-2691: Additional fixes -Wstrict-prototypes compile warning from Clang

### DIFF
--- a/c/src/messenger/store.c
+++ b/c/src/messenger/store.c
@@ -84,7 +84,7 @@ void pni_entry_finalize(void *object)
 #define pni_entry_inspect NULL
 static const pn_class_t PN_CLASSCLASS(pni_entry) = PN_CLASS(pni_entry);
 
-pni_store_t *pni_store()
+pni_store_t *pni_store(void)
 {
   pni_store_t *store = (pni_store_t *) malloc(sizeof(pni_store_t));
   if (!store) return NULL;

--- a/c/src/messenger/transform.c
+++ b/c/src/messenger/transform.c
@@ -81,7 +81,7 @@ static void pn_transform_finalize(void *object)
 #define pn_transform_compare NULL
 #define pn_transform_inspect NULL
 
-pn_transform_t *pn_transform()
+pn_transform_t *pn_transform(void)
 {
   static const pn_class_t clazz = PN_CLASS(pn_transform);
   pn_transform_t *transform = (pn_transform_t *) pn_class_new(&clazz, sizeof(pn_transform_t));

--- a/c/src/platform/platform.c
+++ b/c/src/platform/platform.c
@@ -27,12 +27,12 @@
 
 #ifdef PN_WINAPI
 #include <windows.h>
-int pn_i_getpid() {
+int pn_i_getpid(void) {
   return (int) GetCurrentProcessId();
 }
 #else
 #include <unistd.h>
-int pn_i_getpid() {
+int pn_i_getpid(void) {
   return (int) getpid();
 }
 #endif

--- a/c/src/proactor/epoll.c
+++ b/c/src/proactor/epoll.c
@@ -1495,7 +1495,7 @@ pn_listener_t *pn_event_listener(pn_event_t *e) {
   return (pn_event_class(e) == PN_CLASSCLASS(pn_listener)) ? (pn_listener_t*)pn_event_context(e) : NULL;
 }
 
-pn_listener_t *pn_listener() {
+pn_listener_t *pn_listener(void) {
   pn_listener_t *l = (pn_listener_t*)calloc(1, sizeof(pn_listener_t));
   if (l) {
     l->batch.next_event = listener_batch_next;
@@ -1951,7 +1951,7 @@ static void grow_poller_bufs(pn_proactor_t* p) {
     ee->wanted = EPOLLIN;      // for all subsequent rearms
 }
 
-pn_proactor_t *pn_proactor() {
+pn_proactor_t *pn_proactor(void) {
   if (getenv("PNI_EPOLL_NOWARM")) pni_warm_sched = false;
   if (getenv("PNI_EPOLL_IMMEDIATE")) pni_immediate = true;
   if (getenv("PNI_EPOLL_SPINS")) pni_spins = atoi(getenv("PNI_EPOLL_SPINS"));

--- a/c/src/proactor/libuv.c
+++ b/c/src/proactor/libuv.c
@@ -1215,7 +1215,7 @@ static void work_free(work_t *w) {
   }
 }
 
-pn_proactor_t *pn_proactor() {
+pn_proactor_t *pn_proactor(void) {
   uv_once(&global_init_once, global_init_fn);
   pn_proactor_t *p = (pn_proactor_t*)calloc(1, sizeof(pn_proactor_t));
   p->collector = pn_collector();

--- a/c/src/reactor/io/windows/iocp.c
+++ b/c/src/reactor/io/windows/iocp.c
@@ -1171,7 +1171,7 @@ void pni_iocp_finalize(void *obj)
   pni_shared_pool_free(iocp);
 }
 
-iocp_t *pni_iocp()
+iocp_t *pni_iocp(void)
 {
   static const pn_class_t clazz = PN_CLASS(pni_iocp);
   iocp_t *iocp = (iocp_t *) pn_class_new(&clazz, sizeof(iocp_t));

--- a/c/src/reactor/io/windows/selector.c
+++ b/c/src/reactor/io/windows/selector.c
@@ -86,7 +86,7 @@ void pn_selector_finalize(void *obj)
 #define pn_selector_compare NULL
 #define pn_selector_inspect NULL
 
-pn_selector_t *pni_selector()
+pn_selector_t *pni_selector(void)
 {
   static const pn_class_t clazz = PN_CLASS(pn_selector);
   pn_selector_t *selector = (pn_selector_t *) pn_class_new(&clazz, sizeof(pn_selector_t));

--- a/c/src/reactor/reactor.c
+++ b/c/src/reactor/reactor.c
@@ -107,7 +107,7 @@ static void pn_reactor_finalize(void *object) {
 #define pn_reactor_compare NULL
 #define pn_reactor_inspect NULL
 
-pn_reactor_t *pn_reactor() {
+pn_reactor_t *pn_reactor(void) {
   static const pn_class_t clazz = PN_CLASS(pn_reactor);
   pn_reactor_t *reactor = pn_class_new(&clazz, sizeof(pn_reactor_t));
   int err = pn_pipe(reactor->io, reactor->wakeup);

--- a/c/tools/include/pncompat/internal/getopt.c
+++ b/c/tools/include/pncompat/internal/getopt.c
@@ -57,7 +57,7 @@ static int opt_offset = 0;             /* Index into compounded "-option" */
 static int dashdash = 0;               /* True if "--" option reached */
 static int nonopt = 0;                 /* How many nonopts we've found */
 
-static void increment_index()
+static void increment_index(void)
 {
 	/* Move onto the next option */
 	if(argv_index < argv_index2)
@@ -74,7 +74,7 @@ static void increment_index()
 * Permutes argv[] so that the argument currently being processed is moved
 * to the end.
 */
-static int permute_argv_once()
+static int permute_argv_once(void)
 {
 	/* Movability check */
 	if(argv_index + nonopt >= prev_argc) return 1;

--- a/c/tools/msgr-common.c
+++ b/c/tools/msgr-common.c
@@ -44,7 +44,7 @@ char *msgr_strdup( const char *src )
 }
 
 
-pn_timestamp_t msgr_now()
+pn_timestamp_t msgr_now(void)
 {
   // from "pncompat/misc_funcs.inc"
   return time_now();
@@ -159,7 +159,7 @@ void parse_password( const char *input, char **password )
 }
 
 static int dolog = 0;
-void enable_logging()
+void enable_logging(void)
 {
     dolog = 1;
 }


### PR DESCRIPTION
It appears I missed some functions the first time, https://github.com/jiridanek/skupper-router/actions/runs/4513086648/jobs/7947437700#step:19:90