### PR TITLE
Fixing a leak problem.

### DIFF
--- a/c/examples/send.c
+++ b/c/examples/send.c
@@ -107,6 +107,7 @@ static bool handle(app_data_t* app, pn_event_t* event) {
      /* We received acknowledgement from the peer that a message was delivered. */
      pn_delivery_t* d = pn_event_delivery(event);
      if (pn_delivery_remote_state(d) == PN_ACCEPTED) {
+       pn_delivery_settle(d);
        if (++app->acknowledged == app->message_count) {
          printf("%d messages sent and acknowledged\n", app->acknowledged);
          pn_connection_close(pn_event_connection(event));


### PR DESCRIPTION
If the delivery object is not settled on the sender side, the delivery object does not get returned to the pool of the link. I believe that this issue was missed, because the delivery objects in this specific example are not completely lost and they get freed when the connection is closed (Valgrind happily reports that all is good). Without the proposed fix, this code will mislead people and the code written based on this example will cause memory exhaustion in the long run.