### PR TITLE
PROTON-2708: Introduce new proactor APIs that query batch

### DIFF
--- a/c/examples/broker.c
+++ b/c/examples/broker.c
@@ -283,9 +283,7 @@ static void check_condition(pn_event_t *e, pn_condition_t *cond) {
 
 const int WINDOW=5; /* Very small incoming credit window, to show flow control in action */
 
-static bool handle(broker_t* b, pn_event_t* e) {
-  pn_connection_t *c = pn_event_connection(e);
-
+static bool handle(broker_t* b, pn_event_t* e, pn_connection_t *c) {
   switch (pn_event_type(e)) {
 
    case PN_LISTENER_OPEN: {
@@ -433,9 +431,10 @@ static void* broker_thread(void *void_broker) {
   bool finished = false;
   do {
     pn_event_batch_t *events = pn_proactor_wait(b->proactor);
+    pn_connection_t *connection = pn_event_batch_connection(events);
     pn_event_t *e;
     while ((e = pn_event_batch_next(events))) {
-        if (!handle(b, e)) finished = true;
+        if (!handle(b, e, connection)) finished = true;
     }
     pn_proactor_done(b->proactor, events);
   } while(!finished);

--- a/c/include/proton/proactor.h
+++ b/c/include/proton/proactor.h
@@ -218,6 +218,36 @@ PNP_EXTERN pn_event_batch_t *pn_proactor_get(pn_proactor_t *proactor);
 PNP_EXTERN pn_event_t *pn_event_batch_next(pn_event_batch_t *batch);
 
 /**
+ * Query the batch for the subject of the batch. If it is a proactor then it is
+ * returned. NULL means the subject of the batch is not a proactor. The returned
+ * proactor is valid until pn_proactor_done() is called again on the same
+ * batch.
+ *
+ * @return the proactor that is subject of the batch or NULL if none.
+ */
+PNP_EXTERN pn_proactor_t *pn_event_batch_proactor(pn_event_batch_t *batch);
+
+/**
+ * Query the batch for the subject of the batch. If it is a listener then it is
+ * returned. NULL means the subject of the batch is not a listener. The returned
+ * listener is valid until pn_proactor_done() is called again on the same
+ * batch.
+ *
+ * @return the listener that is subject of the batch or NULL if none.
+ */
+PNP_EXTERN pn_listener_t *pn_event_batch_listener(pn_event_batch_t *batch);
+
+/**
+ * Query the batch for the subject of the batch. If it is a connection then it is
+ * returned. NULL means the subject of the batch is not a connection. The returned
+ * connection is valid until pn_proactor_done() is called again on the same
+ * batch.
+ *
+ * @return the connection that is subject of the batch or NULL if none.
+ */
+PNP_EXTERN pn_connection_t *pn_event_batch_connection(pn_event_batch_t *batch);
+
+/**
  * Call when finished handling a batch of events.
  *
  * Must be called exactly once to match each call to pn_proactor_wait().

--- a/c/include/proton/raw_connection.h
+++ b/c/include/proton/raw_connection.h
@@ -305,6 +305,15 @@ PNP_EXTERN pn_record_t *pn_raw_connection_attachments(pn_raw_connection_t *conne
  */
 PNP_EXTERN pn_raw_connection_t *pn_event_raw_connection(pn_event_t *event);
 
+/**
+ * Query the batch for the subject of the batch. If it is a raw connection then it is
+ * returned. NULL means the subject of the batch is not a raw connection. The returned
+ * raw connection is valid until pn_proactor_done() is called again on the same
+ * batch.
+ *
+ * @return the raw connection that is subject of the batch or NULL if none.
+ */
+PNP_EXTERN pn_raw_connection_t *pn_event_batch_raw_connection(pn_event_batch_t *batch);
 
 /**
  * @}

--- a/c/src/proactor/epoll.c
+++ b/c/src/proactor/epoll.c
@@ -650,6 +650,19 @@ static inline pconnection_t *batch_pconnection(pn_event_batch_t *batch) {
     containerof(batch, pconnection_t, batch) : NULL;
 }
 
+pn_proactor_t *pn_event_batch_proactor(pn_event_batch_t *batch) {
+  return batch_proactor(batch);
+}
+
+pn_listener_t *pn_event_batch_listener(pn_event_batch_t *batch) {
+  return batch_listener(batch);
+}
+
+pn_connection_t *pn_event_batch_connection(pn_event_batch_t *batch) {
+  pconnection_t *r = batch_pconnection(batch);
+  return r ? r->driver.connection : NULL;
+}
+
 static void psocket_error_str(psocket_t *ps, const char *msg, const char* what) {
   pconnection_t *pc = psocket_pconnection(ps);
   if (pc) {

--- a/c/src/proactor/epoll_raw_connection.c
+++ b/c/src/proactor/epoll_raw_connection.c
@@ -341,6 +341,11 @@ praw_connection_t *pni_batch_raw_connection(pn_event_batch_t *batch) {
     containerof(batch, praw_connection_t, batch) : NULL;
 }
 
+pn_raw_connection_t *pn_event_batch_raw_connection(pn_event_batch_t *batch) {
+    praw_connection_t *rc = pni_batch_raw_connection(batch);
+    return rc ? &rc->raw_connection : NULL;
+}
+
 task_t *pni_raw_connection_task(praw_connection_t *rc) {
   return &rc->task;
 }

--- a/c/src/proactor/libuv.c
+++ b/c/src/proactor/libuv.c
@@ -377,6 +377,19 @@ static inline pconnection_t *batch_pconnection(pn_event_batch_t *batch) {
     containerof(batch, pconnection_t, batch) : NULL;
 }
 
+pn_proactor_t *pn_event_batch_proactor(pn_event_batch_t *batch) {
+  return batch_proactor(batch);
+}
+
+pn_listener_t *pn_event_batch_listener(pn_event_batch_t *batch) {
+  return batch_listener(batch);
+}
+
+pn_connection_t *pn_event_batch_connection(pn_event_batch_t *batch) {
+  pconnection_t *r = batch_pconnection(batch);
+  return r ? r->driver.connection : NULL;
+}
+
 static inline work_t *batch_work(pn_event_batch_t *batch) {
   pconnection_t *pc = batch_pconnection(batch);
   if (pc) return &pc->work;
@@ -1381,3 +1394,4 @@ void pn_raw_connection_read_close(pn_raw_connection_t *conn) {}
 void pn_raw_connection_write_close(pn_raw_connection_t *conn) {}
 const struct pn_netaddr_t *pn_raw_connection_local_addr(pn_raw_connection_t *connection) { return NULL; }
 const struct pn_netaddr_t *pn_raw_connection_remote_addr(pn_raw_connection_t *connection) { return NULL; }
+pn_raw_connection_t *pn_event_batch_raw_connection(pn_event_batch_t* batch) { return NULL; }

--- a/c/src/proactor/win_iocp.cpp
+++ b/c/src/proactor/win_iocp.cpp
@@ -2007,6 +2007,19 @@ static inline pconnection_t *batch_pconnection(pn_event_batch_t *batch) {
     containerof(batch, pconnection_t, batch) : NULL;
 }
 
+pn_proactor_t *pn_event_batch_proactor(pn_event_batch_t *batch) {
+  return batch_proactor(batch);
+}
+
+pn_listener_t *pn_event_batch_listener(pn_event_batch_t *batch) {
+  return batch_listener(batch);
+}
+
+pn_connection_t *pn_event_batch_connection(pn_event_batch_t *batch) {
+  pconnection_t *r = batch_pconnection(batch);
+  return r ? r->driver.connection : NULL;
+}
+
 static inline bool pconnection_has_event(pconnection_t *pc) {
   return pn_connection_driver_has_event(&pc->driver);
 }
@@ -3434,3 +3447,4 @@ void pn_raw_connection_read_close(pn_raw_connection_t *conn) {}
 void pn_raw_connection_write_close(pn_raw_connection_t *conn) {}
 const struct pn_netaddr_t *pn_raw_connection_local_addr(pn_raw_connection_t *connection) { return NULL; }
 const struct pn_netaddr_t *pn_raw_connection_remote_addr(pn_raw_connection_t *connection) { return NULL; }
+pn_raw_connection_t *pn_event_batch_raw_connection(pn_event_batch_t* batch) { return NULL; }


### PR DESCRIPTION
These new APIs are useful for querying the proactor event batch for the object that is the subject of the batch. The proactor guarantees that the subject of the batch is never returned in any other batch until this batch is completed.