### PR TITLE
PROTON-2715: remove unused for-cycle counter variable

### DIFF
--- a/cpp/examples/flow_control.cpp
+++ b/cpp/examples/flow_control.cpp
@@ -62,7 +62,7 @@ class flow_sender : public proton::messaging_handler {
     flow_sender() : available(0), sequence(0) {}
 
     void send_available_messages(proton::sender &s) {
-        for (int i = sequence; available && s.credit() > 0; i++) {
+        while(available && s.credit() > 0) {
             std::ostringstream mbody;
             mbody << "flow_sender message " << sequence++;
             proton::message m(mbody.str());


### PR DESCRIPTION
Some for loops just silently scream to be let out as while

```
[ 83%] Building CXX object cpp/examples/CMakeFiles/tracing_server.dir/tracing_server.cpp.o
/home/jdanek/repos/qpid/qpid-proton/cpp/examples/flow_control.cpp:65:18: error: variable 'i' set but not used [-Werror,-Wunused-but-set-variable]
        for (int i = sequence; available && s.credit() > 0; i++) {
                 ^
1 error generated.
```