### PR TITLE
PROTON-xxxx: suppress deprecation warnings when using Jaeger in traci…

### DIFF
--- a/cpp/examples/tracing_client.cpp
+++ b/cpp/examples/tracing_client.cpp
@@ -150,11 +150,16 @@ int main(int argc, char **argv) {
         // 2. Set the global trace provider.
         // 3. Call proton::initOpenTelemetryTracer().
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
+
         opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
 
         // Initialize Jaeger Exporter
         std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
             new opentelemetry::exporter::jaeger::JaegerExporter(opts));
+
+#pragma GCC diagnostic pop
 
         // Set service-name
         auto resource_attributes = opentelemetry::sdk::resource::ResourceAttributes

--- a/cpp/examples/tracing_server.cpp
+++ b/cpp/examples/tracing_server.cpp
@@ -112,9 +112,14 @@ int main(int argc, char **argv) {
         // 3. Call proton::initOpenTelemetryTracer()
 
         // Initialize Jaeger Exporter
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
+
         opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
         std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
             new opentelemetry::exporter::jaeger::JaegerExporter(opts));
+
+#pragma GCC diagnostic pop
 
         // Set service-name
         auto resource_attributes = opentelemetry::sdk::resource::ResourceAttributes


### PR DESCRIPTION
…ng example

```
/home/jenkins/workspace/rh-qpid-proton-dist-el9-main/build/BUILD/qpid-proton-0.39.0/cpp/examples/tracing_client.cpp:157:50:
error: ‘JaegerExporter’ is deprecated
[-Werror=deprecated-declarations]
  157 |             new opentelemetry::exporter::jaeger::JaegerExporter(opts));
      |                                                  ^~~~~~~~~~~~~~
In file included from
```