### PR TITLE
Fix build for jaeger to otlp tracing changes

### DIFF
--- a/ci/otel.sh
+++ b/ci/otel.sh
@@ -38,6 +38,6 @@ mkdir build
 cd build
 
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DWITH_OTLP=ON -DWITH_OTLP_HTTP=ON -DWITH_OTLP_GRPC=OFF
-cmake --build . --target all --config RelWithDebInfo
-sudo cmake --install . --config RelWithDebInfo
+cmake --build . --target all
+sudo cmake --install .
 cd ../..


### PR DESCRIPTION
Fix build for https://github.com/apache/qpid-proton/commit/1ad098c0703276f7a013a16b208f2af4fd86f993.

With the recent tracing changes with OT 1.9.1, the opentelemetry build succeed but the proton build failed at cmake configuration, here [build#763](https://github.com/apache/qpid-proton/actions/runs/5089577302/jobs/9147379969#step:11:60)