### PR TITLE
Remove 'continue' workaround for otel buiild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     - name: OTel build/install
       if: runner.os == 'Linux'
       working-directory: ${{github.workspace}}
-      run: sudo sh ./ci/otel.sh || echo "Couldn't build Opentelemetry, continuing..."
+      run: sudo sh ./ci/otel.sh
       shell: bash
     - name: cmake configure
       working-directory: ${{env.BuildDir}}


### PR DESCRIPTION
Fix deprecation warning.
```
CMake Warning at CMakeLists.txt:165 (message):
  WITH_OTLP is deprecated and will be removed in future.  Please set either
  WITH_OTLP_GRPC or WITH_OTLP_HTTP, or even both.
  ```
  
https://github.com/apache/qpid-proton/actions/runs/5121286125/jobs/9208853897#step:10:205