### PR TITLE
add links to source code and jira to ruby gem

### DIFF
--- a/ruby/qpid_proton.gemspec.in
+++ b/ruby/qpid_proton.gemspec.in
@@ -18,6 +18,12 @@ routers, bridges, proxies, and more. Proton is based on the AMQP 1.0 messaging
 standard.
 EOF
 
+  s.metadata = {
+    "homepage_uri"    => "http://qpid.apache.org/proton",
+    "source_code_uri" => "https://github.com/apache/qpid-proton/tree/main/ruby",
+    "bug_tracker_uri" => "https://issues.apache.org/jira/projects/PROTON/issues"
+  }
+
   s.extensions   = "ext/cproton/extconf.rb"
   s.files        = Dir[
                 "LICENSE.txt",


### PR DESCRIPTION
This updates the ruby gem metadata that is displayed on the repository (rubygems.org)

It will make it easier for developers to find the right location of jira and the source code.


Let me know if you want me to add a different source code repository or a changelog (via `changelog_uri`)


Also, please share the process to request a ruby bindings/gem release for v0.39.

Thank you for the great project