### PR TITLE
PROTON-2772: add format arg annotations for schannel functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,8 +163,8 @@ set (COMMON_WARNING_GNU "-Wall -pedantic-errors")
 set (COMMON_WARNING_Clang "-Wall -pedantic")
 set (COMMON_WARNING_MSVC "")
 
-set (CC_WARNING_GNU "-Wno-unused-parameter -Wstrict-prototypes -Wvla -Wsign-compare -Wwrite-strings")
-set (CC_WARNING_Clang "-Wno-unused-parameter -Wstrict-prototypes -Wvla -Wsign-compare -Wwrite-strings")
+set (CC_WARNING_GNU "-Wno-unused-parameter -Wstrict-prototypes -Wvla -Wsign-compare -Wwrite-strings -Wimplicit-fallthrough=3")
+set (CC_WARNING_Clang "-Wno-unused-parameter -Wstrict-prototypes -Wvla -Wsign-compare -Wwrite-strings -Wimplicit-fallthrough")
 set (CC_WARNING_MSVC "/wd4244 /wd4267 /wd4800 /wd4996")
 
 set (CXX_WARNING_GNU "")

--- a/c/experimental/raw_plus_tls2.c
+++ b/c/experimental/raw_plus_tls2.c
@@ -19,6 +19,7 @@
 
 #include "thread.h"
 
+#include <proton/annotations.h>
 #include <proton/raw_connection.h>
 #include <proton/tls.h>
 #include <proton/listener.h>
@@ -586,7 +587,7 @@ static bool handle(jabber_t* j, pn_event_t* event) {
 
     case PN_PROACTOR_INACTIVE:
       printf("**proactor inactive: connections and listeners finalized\n");
-      // fall through
+      PN_FALLTHROUGH;
     case PN_PROACTOR_INTERRUPT: {
       pn_proactor_t *proactor = pn_event_proactor(event);
       pn_proactor_interrupt(proactor);

--- a/c/include/proton/annotations.h
+++ b/c/include/proton/annotations.h
@@ -90,4 +90,26 @@
     #endif
 #endif
 
+// fallthrough
+
+#if defined __has_cpp_attribute
+    #if __cplusplus >= __has_cpp_attribute(fallthrough)
+        #define PN_FALLTHROUGH [[fallthrough]]
+    #endif
+#endif
+
+#if !defined PN_FALLTHROUGH && defined __has_c_attribute
+    #if __STDC_VERSION__ >= __has_c_attribute(fallthrough)
+        #define PN_FALLTHROUGH [[fallthrough]]
+    #endif
+#endif
+#if !defined PN_FALLTHROUGH && defined __has_attribute
+    #if __has_attribute(__fallthrough__)
+        #define PN_FALLTHROUGH __attribute__((__fallthrough__))
+    #endif
+#endif
+#if !defined PN_FALLTHROUGH
+    #define PN_FALLTHROUGH (void)0
+#endif
+
 #endif /* annotations.h */

--- a/c/src/core/decoder.c
+++ b/c/src/core/decoder.c
@@ -354,6 +354,7 @@ static int pni_decoder_decode_value(pn_decoder_t *decoder, pn_data_t *data, uint
     {
     case PNE_ARRAY8:
       min_expected_size += 1; // Array has a constructor of at least 1 byte
+      PN_FALLTHROUGH;
     case PNE_LIST8:
     case PNE_MAP8:
       min_expected_size += 1; // All these types have a count
@@ -366,6 +367,7 @@ static int pni_decoder_decode_value(pn_decoder_t *decoder, pn_data_t *data, uint
       break;
     case PNE_ARRAY32:
       min_expected_size += 1; // Array has a constructor of at least 1 byte
+      PN_FALLTHROUGH;
     case PNE_LIST32:
     case PNE_MAP32:
       min_expected_size += 4; // All these types have a count

--- a/c/src/core/encoder.c
+++ b/c/src/core/encoder.c
@@ -362,7 +362,7 @@ static int pni_encoder_exit(void *ctx, pn_data_t *data, pni_node_t *node)
     if ((node->described && node->children == 1) || (!node->described && node->children == 0)) {
       pn_encoder_writef8(encoder, pn_type2code(encoder, node->type));
     }
-  // Fallthrough
+    PN_FALLTHROUGH;
   case PN_LIST:
   case PN_MAP:
     pos = encoder->position;

--- a/c/src/core/message.c
+++ b/c/src/core/message.c
@@ -80,9 +80,11 @@ void pni_msgid_clear(pn_atom_t* msgid) {
     case PN_BINARY:
     case PN_STRING:
       free((void*)msgid->u.as_bytes.start);
+      PN_FALLTHROUGH;
     case PN_ULONG:
     case PN_UUID:
       msgid->type = PN_NULL;
+      PN_FALLTHROUGH;
     case PN_NULL:
       return;
     default:

--- a/c/src/messenger/transform.c
+++ b/c/src/messenger/transform.c
@@ -130,7 +130,7 @@ static bool pni_match_r(pn_matcher_t *matcher, const char *pattern, const char *
         if (match) pni_sub(matcher, group, text, matched);
         return match;
       }
-    // Fallthrough
+      PN_FALLTHROUGH;
     default:
       match = pni_match_r(matcher, pattern, text + 1, group, matched + 1);
       if (!match) {


### PR DESCRIPTION
What's missing is a compilation failure when any warnings are emitted.

MSVC needs `/analyze` to report the problems, there is actually lots of diagnostics printed then, and the mismatched format args are not causing compilation to fail so the warnings are easy to miss.