### PR TITLE
PROTON-2772: add format arg annotations for schannel functions

### DIFF
--- a/c/src/ssl/schannel.cpp
+++ b/c/src/ssl/schannel.cpp
@@ -374,7 +374,8 @@ static void ssl_vlog(pn_transport_t *transport, pn_log_level_t sev, const char *
   }
 }
 
-static void ssl_log(pn_transport_t *transport, pn_log_level_t sev, const char *fmt, ...)
+PN_PRINTF_FORMAT_ATTR(3, 4)
+static void ssl_log(pn_transport_t *transport, pn_log_level_t sev, PN_PRINTF_FORMAT const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -383,7 +384,8 @@ static void ssl_log(pn_transport_t *transport, pn_log_level_t sev, const char *f
 }
 
 // @todo: used to avoid littering the code with calls to printf...
-static void ssl_log_error(const char *fmt, ...)
+PN_PRINTF_FORMAT_ATTR(1, 2)
+static void ssl_log_error(PN_PRINTF_FORMAT const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -391,7 +393,8 @@ static void ssl_log_error(const char *fmt, ...)
   va_end(ap);
 }
 
-static void ssl_log_error_status(HRESULT status, const char *fmt, ...)
+PN_PRINTF_FORMAT_ATTR(2, 3)
+static void ssl_log_error_status(HRESULT status, PN_PRINTF_FORMAT const char *fmt, ...)
 {
   char buf[512];
   va_list ap;


### PR DESCRIPTION
What's missing is a compilation failure when any warnings are emitted.

MSVC needs /analyze to report the problems, there is actually lots of diagnostics printed then, and the mismatched format args are not causing compilation to fail so the warnings are easy to miss.