### PR TITLE
NO-JIRA: Sort input file list

### DIFF
--- a/python/ext_build.py
+++ b/python/ext_build.py
@@ -40,7 +40,9 @@ proton_c_include = os.path.join(proton_base, 'include')
 sources = []
 extra = []
 libraries = []
-for root, _, files in os.walk(proton_core_src):
+for root, dirs, files in os.walk(proton_core_src):
+    dirs.sort() # needed for os.walk to process directories in deterministic order
+    files.sort()
     for file_ in files:
         if file_.endswith(('.c', '.cpp')):
             sources.append(os.path.join(root, file_))


### PR DESCRIPTION
Sort input file list so that `_cproton.cpython-310-x86_64-linux-gnu.so` builds in a reproducible way in spite of non-deterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE.