### PR TITLE
PROTON-2772: add compiler warning management macros

### DIFF
--- a/c/include/proton/annotations.h
+++ b/c/include/proton/annotations.h
@@ -109,4 +109,36 @@
     #define PN_FALLTHROUGH (void)0
 #endif
 
+// Generalize warning push/pop.
+#if defined(__GNUC__) || defined(__clang__)
+    // Clang & GCC
+    #define PN_PUSH_WARNING _Pragma("GCC diagnostic push")
+    #define PN_POP_WARNING _Pragma("GCC diagnostic pop")
+    #define PN_GNU_DISABLE_WARNING_INTERNAL2(warningName) #warningName
+    #define PN_GNU_DISABLE_WARNING(warningName) _Pragma(PN_GNU_DISABLE_WARNING_INTERNAL2(GCC diagnostic ignored warningName))
+    #ifdef __clang__
+        #define PN_CLANG_DISABLE_WARNING(warningName) PN_GNU_DISABLE_WARNING(warningName)
+        #define PN_GCC_DISABLE_WARNING(warningName)
+    #else
+        #define PN_CLANG_DISABLE_WARNING(warningName)
+        #define PN_GCC_DISABLE_WARNING(warningName) PN_GNU_DISABLE_WARNING(warningName)
+    #endif
+    #define PN_MSVC_DISABLE_WARNING(warningNumber)
+#elif defined(_MSC_VER)
+    #define PN_PUSH_WARNING __pragma(warning(push))
+    #define PN_POP_WARNING __pragma(warning(pop))
+    // Disable the GCC warnings.
+    #define PN_GNU_DISABLE_WARNING(warningName)
+    #define PN_GCC_DISABLE_WARNING(warningName)
+    #define PN_CLANG_DISABLE_WARNING(warningName)
+    #define PN_MSVC_DISABLE_WARNING(warningNumber) __pragma(warning(disable : warningNumber))
+#else
+    #define PN_PUSH_WARNING
+    #define PN_POP_WARNING
+    #define PN_GNU_DISABLE_WARNING(warningName)
+    #define PN_GCC_DISABLE_WARNING(warningName)
+    #define PN_CLANG_DISABLE_WARNING(warningName)
+    #define PN_MSVC_DISABLE_WARNING(warningNumber)
+#endif
+
 #endif /* annotations.h */

--- a/c/src/sasl/cyrus_sasl.c
+++ b/c/src/sasl/cyrus_sasl.c
@@ -24,6 +24,7 @@
 
 #include "core/logger_private.h"
 
+#include "proton/annotations.h"
 #include "proton/sasl.h"
 #include "proton/sasl_plugin.h"
 #include "proton/transport.h"
@@ -187,10 +188,13 @@ static int pni_authorize(sasl_conn_t *conn,
   return SASL_OK;
 }
 
+PN_PUSH_WARNING
+PN_GNU_DISABLE_WARNING("-Wcast-function-type")
 static const sasl_callback_t pni_server_callbacks[] = {
     {SASL_CB_PROXY_POLICY, (int(*)(void)) pni_authorize, NULL},
     {SASL_CB_LIST_END, NULL, NULL},
 };
+PN_POP_WARNING
 
 // Machinery to initialise the cyrus library only once even in a multithreaded environment
 // Relies on pthreads.


### PR DESCRIPTION
The motivation is again composite build with skupper-router, which enables a warning on this function cast.