### PR TITLE
PROTON-2792: [C++] check that scheduled tasks are active under lock

### DIFF
--- a/cpp/include/proton/work_queue.hpp
+++ b/cpp/include/proton/work_queue.hpp
@@ -280,7 +280,7 @@ class work {
     /// **Unsettled API**
     ///
     /// Execute the piece of work
-    void operator()() { item_(); }
+    void operator()() const { item_(); }
 
     ~work() = default;
 

--- a/cpp/src/container_test.cpp
+++ b/cpp/src/container_test.cpp
@@ -585,28 +585,52 @@ public:
         listener = c.listen("//:0", listen_handler);
 
         // We will cancel this scheduled task before its execution.
-        auto w1_handle = c.schedule(proton::duration(250), [this](){w1_state = 1;});
+        auto w1_handle = c.schedule(proton::duration(250),
+            [this](){
+                w1_state = 1;
+            });
 
         // We will cancel this scheduled task before its execution and will try to cancel it again.
-        auto w2_handle = c.schedule(proton::duration(260), [this](){w2_state = 1;});
+        auto w2_handle = c.schedule(proton::duration(260),
+            [this](){
+                w2_state = 1;
+            });
 
         // Attempt to make sure that we can cancel a task from a previous task even if the
         // previous task gets delayed and scheduled in the same batch as the task to be cancelled.
 
         // Set up task to cancel
-        auto w3_handle = c.schedule(proton::duration(37), [this](){w3_state = 3;});
+        auto w3_handle = c.schedule(proton::duration(37),
+            [this](){
+                w3_state = 3;
+            });
 
         // This task overruns and so forces the next 2 tasks to be scheduled together
-        c.schedule(proton::duration(35), [this](){w3_state = 1; std::this_thread::sleep_for(std::chrono::milliseconds(20)); });
+        c.schedule(proton::duration(35),
+            [this](){
+                w3_state = 1;
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            });
 
         // This should successfully cancel the first scheduled task and so leave w3_state at 2
-        c.schedule(proton::duration(36), [&, this](){ASSERT(w3_state==1); w3_state = 2; c.cancel(w3_handle);});
+        c.schedule(proton::duration(36),
+            [&c, w3_handle, this](){
+                ASSERT(w3_state==1);
+                w3_state = 2;
+                c.cancel(w3_handle);
+            });
 
         // We will try to cancel this task before its execution from different thread i.e connection thread.
-        w4_handle = c.schedule(proton::duration(270), [this](){w4_state = 1;});
+        w4_handle = c.schedule(proton::duration(270),
+            [this](){
+                w4_state = 1;
+            });
 
         // We will try to cancel this task after its execution from different thread i.e. connection thread.
-        w5_handle = c.schedule(proton::duration(0), [this](){w5_state = 1;});
+        w5_handle = c.schedule(proton::duration(0),
+            [this](){
+                w5_state = 1;
+            });
 
         // Cancel the first scheduled task.
         c.cancel(w1_handle);

--- a/cpp/src/proactor_container_impl.cpp
+++ b/cpp/src/proactor_container_impl.cpp
@@ -542,9 +542,16 @@ void container::impl::run_timer_jobs() {
     // NB. We copied the due tasks in reverse order so execute from end
 
     for (int i = tasks.size()-1; i>=0; --i) {
-        if(is_active_.count(tasks[i].w_handle)) {
-            tasks[i].task();
-            is_active_.erase(tasks[i].w_handle);
+        const auto& task = tasks[i];
+        bool active;
+
+        {
+          GUARD(deferred_lock_);
+          // NB. erase returns the number of items erased
+          active = is_active_.erase(task.w_handle);
+        }
+        if (active) {
+            task.task();
         }
     }
 }


### PR DESCRIPTION
Previously we checked whether the tasks were active without locking which was bad.

This is is an alternative fix (which has the correct semantics) to #421.

I think it probably still needs a test for the fixed behaviour and the correct semantics before merging. This would be new tests in ```container_test.cpp```