### PR TITLE
PROTON-2818: Move epoll proctor connection logic to a task thread.

### DIFF
--- a/c/src/proactor/epoll-internal.h
+++ b/c/src/proactor/epoll-internal.h
@@ -238,6 +238,7 @@ typedef struct pconnection_t {
   bool server;                /* accept, not connect */
   bool tick_pending;
   bool queued_disconnect;     /* deferred from pn_proactor_disconnect() */
+  bool first_schedule;
   pn_condition_t *disconnect_condition;
   // Following values only changed by (sole) working task:
   uint32_t current_arm;  // active epoll io events

--- a/c/src/proactor/epoll_raw_connection.c
+++ b/c/src/proactor/epoll_raw_connection.c
@@ -52,6 +52,8 @@ struct praw_connection_t {
   bool disconnected;
   bool hup_detected;
   bool read_check;
+  bool first_schedule;
+  char *taddr;
 };
 
 static void psocket_error(praw_connection_t *rc, int err, const char* msg) {
@@ -145,6 +147,8 @@ static void praw_connection_init(praw_connection_t *prc, pn_proactor_t *p, pn_ra
 
   prc->connected = false;
   prc->disconnected = false;
+  prc->first_schedule = false;
+  prc->taddr = NULL;
   prc->batch.next_event = pni_raw_batch_next;
 
   pmutex_init(&prc->rearm_mutex);
@@ -163,6 +167,7 @@ static void praw_connection_cleanup(praw_connection_t *prc) {
     task_finalize(&prc->task);
     if (prc->addrinfo)
       freeaddrinfo(prc->addrinfo);
+    free(prc->taddr);
     free(prc);
   }
   // else proactor_disconnect logic owns prc and its final free
@@ -177,39 +182,43 @@ pn_raw_connection_t *pn_raw_connection(void) {
   return &conn->raw_connection;
 }
 
+// Call from pconnection_process with task lock held.
+static void praw_connection_first_connect_lh(praw_connection_t *prc) {
+  const char *host;
+  const char *port;
+
+  unlock(&prc->task.mutex);
+  size_t addrlen = strlen(prc->taddr);
+  char *addr_buf = (char*) alloca(addrlen+1);
+  pni_parse_addr(prc->taddr, addr_buf, addrlen+1, &host, &port);
+  int gai_error = pgetaddrinfo(host, port, 0, &prc->addrinfo);
+  lock(&prc->task.mutex);
+
+  if (!gai_error) {
+    prc->ai = prc->addrinfo;
+    praw_connection_maybe_connect_lh(prc); /* Start connection attempts */
+  } else {
+    psocket_gai_error(prc, gai_error, "connect to ", prc->taddr);
+  }
+}
+
 void pn_proactor_raw_connect(pn_proactor_t *p, pn_raw_connection_t *rc, const char *addr) {
+  // Called from an arbitrary thread.  Do setup prior to getaddrinfo, then switch to a worker thread.
   assert(rc);
   praw_connection_t *prc = containerof(rc, praw_connection_t, raw_connection);
   praw_connection_init(prc, p, rc);
   // TODO: check case of proactor shutting down
 
   lock(&prc->task.mutex);
-  proactor_add(&prc->task);
-
-  bool notify = false;
-
-  const char *host;
-  const char *port;
   size_t addrlen = strlen(addr);
-  char *addr_buf = (char*) alloca(addrlen+1);
-  pni_parse_addr(addr, addr_buf, addrlen+1, &host, &port);
-
-  int gai_error = pgetaddrinfo(host, port, 0, &prc->addrinfo);
-  if (!gai_error) {
-    prc->ai = prc->addrinfo;
-    praw_connection_maybe_connect_lh(prc); /* Start connection attempts */
-    if (prc->disconnected) notify = schedule(&prc->task);
-  } else {
-    psocket_gai_error(prc, gai_error, "connect to ", addr);
-    prc->disconnected = true;
-    notify = schedule(&prc->task);
-    lock(&p->task.mutex);
-    notify |= schedule_if_inactive(p);
-    unlock(&p->task.mutex);
-  }
-
-  /* We need to issue INACTIVE on immediate failure */
+  prc->taddr = (char*) malloc(addrlen+1);
+  assert(prc->taddr); // TODO: memory safety
+  memcpy(prc->taddr, addr, addrlen+1);
+  prc->first_schedule = true; // Resume connection setup when next scheduled.
+  proactor_add(&prc->task);
+  bool notify = schedule(&prc->task);
   unlock(&prc->task.mutex);
+
   if (notify) notify_poller(p);
 }
 
@@ -413,6 +422,19 @@ pn_event_batch_t *pni_raw_connection_process(task_t *t, uint32_t io_events, bool
     }
     if (events & EPOLLOUT)
       praw_connection_connected_lh(rc);
+    if (rc->first_schedule) {
+      // Normal case: resumed logic from pn_proactor_raw_connect.
+      // But possible tie: pn_raw_connection_wake()
+      // Defer wake check until getaddrinfo is done.
+      rc->first_schedule = false;
+      assert(!events); // No socket yet.
+      praw_connection_first_connect_lh(rc);  // Drops and reacquires lock.
+      if (rc->psocket.epoll_io.fd != -1 && !pni_task_wake_pending(&rc->task)) {
+        unlock(&rc->task.mutex);
+        return NULL;
+      }
+    }
+
     unlock(&rc->task.mutex);
     return &rc->batch;
   }

--- a/c/tests/raw_wake_test.cpp
+++ b/c/tests/raw_wake_test.cpp
@@ -275,7 +275,6 @@ TEST_CASE("proactor_raw_connection_wake") {
   pn_proactor_raw_connect(pn_listener_proactor(l), rc, addr.c_str());
 
 
-  REQUIRE_RUN(p, PN_LISTENER_ACCEPT);
   REQUIRE_RUN(p, PN_RAW_CONNECTION_NEED_READ_BUFFERS);
   REQUIRE_RUN(p, PN_RAW_CONNECTION_NEED_READ_BUFFERS);
   CHECK(pn_proactor_get(p) == NULL); /* idle */


### PR DESCRIPTION
This patch moves connection logic that can possibly block from the calling thread to the first actual scheduling of the task itself.  It otherwise makes no change to the existing logic.  Including in the following cases:

The trimmed "if (conn->disconnected)..." bits are code simplifications where the value of "disconnected" cannot have changed.

Similarly, the schedule_if_inactive() calls are trimmed as the inactive test is necessarily false with the newly added task in the task list.