### PR TITLE
NO-JIRA: c/cpp: fix examples installation

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -715,7 +715,9 @@ if (BUILD_TOOLS)
   add_subdirectory(tools)
 endif (BUILD_TOOLS)
 
-install (DIRECTORY examples/
+file (COPY "${CMAKE_CURRENT_SOURCE_DIR}/examples/ssl-certs"
+      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/examples/")
+install (DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/examples/"
          DESTINATION "${PROTON_SHARE}/examples/c"
          USE_SOURCE_PERMISSIONS
          PATTERN "ProtonConfig.cmake" EXCLUDE

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -184,7 +184,9 @@ if (MSVC)
 endif (MSVC)
 
 install (DIRECTORY "include/proton" DESTINATION ${INCLUDE_INSTALL_DIR} FILES_MATCHING PATTERN "*.hpp")
-install (DIRECTORY "examples/"
+file (COPY "${CMAKE_CURRENT_SOURCE_DIR}/examples/ssl-certs"
+      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/examples/")
+install (DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/examples/"
   DESTINATION "${PROTON_SHARE}/examples/cpp"
   USE_SOURCE_PERMISSIONS
   PATTERN "ProtonCppConfig.cmake" EXCLUDE


### PR DESCRIPTION
The c/cpp examples so far installed the source files into ${PROTON_SHARE}. This is not what most users would expect, especially if we are cross-compiling and the target lacks a toolchain.

Fix this by installing the binary artifacts instead. For them to work out-of-the-box, we additionally copy the ssl-certs to the expected location as well.