### PR TITLE
PROTON-2594: Add OpenSSL PKCS#11 PROVIDER support to enable HSM use 

### DIFF
--- a/c/examples/broker.c
+++ b/c/examples/broker.c
@@ -35,7 +35,13 @@
 /* The ssl-certs subdir must be in the current directory for an ssl-enabled broker */
 #define SSL_PW "tserverpw"
 /* Windows vs. OpenSSL certificates */
-#if defined(_WIN32)
+#if defined(PKCS11_URI)
+#  define SSL_FILE(NAME) PKCS11_URI ";object=" NAME
+#  define PRIVATEKEY(NAME) SSL_FILE(NAME ";type=private")
+#  define CERTIFICATE(NAME) SSL_FILE(NAME ";type=cert")
+#  define SET_CREDENTIALS(DOMAIN, NAME)                                 \
+  pn_ssl_domain_set_credentials(DOMAIN, CERTIFICATE(NAME), PRIVATEKEY(NAME), SSL_PW)
+#elif defined(_WIN32)
 #  define SSL_FILE(NAME) "ssl-certs/" NAME
 #  define PRIVATEKEY(NAME) SSL_FILE(NAME "-full.p12")
 #  define CERTIFICATE(NAME) SSL_FILE(NAME "-certificate.p12")

--- a/c/examples/broker.c
+++ b/c/examples/broker.c
@@ -33,17 +33,20 @@
 #include <string.h>
 
 /* The ssl-certs subdir must be in the current directory for an ssl-enabled broker */
-#define SSL_FILE(NAME) "ssl-certs/" NAME
 #define SSL_PW "tserverpw"
 /* Windows vs. OpenSSL certificates */
 #if defined(_WIN32)
+#  define SSL_FILE(NAME) "ssl-certs/" NAME
+#  define PRIVATEKEY(NAME) SSL_FILE(NAME "-full.p12")
 #  define CERTIFICATE(NAME) SSL_FILE(NAME "-certificate.p12")
 #  define SET_CREDENTIALS(DOMAIN, NAME)                                 \
-  pn_ssl_domain_set_credentials(DOMAIN, SSL_FILE(NAME "-full.p12"), "", SSL_PW)
+  pn_ssl_domain_set_credentials(DOMAIN, PRIVATEKEY(NAME), "", SSL_PW)
 #else
+#  define SSL_FILE(NAME) "ssl-certs/" NAME
+#  define PRIVATEKEY(NAME) SSL_FILE(NAME "-private-key.pem")
 #  define CERTIFICATE(NAME) SSL_FILE(NAME "-certificate.pem")
 #  define SET_CREDENTIALS(DOMAIN, NAME)                                 \
-  pn_ssl_domain_set_credentials(DOMAIN, CERTIFICATE(NAME), SSL_FILE(NAME "-private-key.pem"), SSL_PW)
+  pn_ssl_domain_set_credentials(DOMAIN, CERTIFICATE(NAME), PRIVATEKEY(NAME), SSL_PW)
 #endif
 
 /* Simple re-sizable vector that acts as a queue */
@@ -459,7 +462,7 @@ int main(int argc, char **argv) {
   b.ssl_domain = pn_ssl_domain(PN_SSL_MODE_SERVER);
   err = SET_CREDENTIALS(b.ssl_domain, "tserver");
   if (err) {
-    printf("Failed to set up server certificate: %s, private key: %s\n", CERTIFICATE("tserver"), SSL_FILE("tserver-private-key.pem"));
+    printf("Failed to set up server certificate: %s, private key: %s\n", CERTIFICATE("tserver"), PRIVATEKEY("tserver"));
   }
   {
   /* Listen on addr */


### PR DESCRIPTION
Hardware Security Modules (HSMs) are physical computing devices that
safeguard secrets and allow performing cryptographic operations like
encryption and signing without necessarily divulging the private key
material.

PKCS#11 is a platform-independent API for cryptographic tokens like
HSMs. It defines a scheme for pkcs11: URIs that describe objects on the
token as well as an API to interact with them.

This commit adds support for transparent use of PKCS#11 URIs: Whenever a
certificate or private key path is prefixed with pkcs11: it will be
interpreted as PKCS#11 URI instead of a file path and OpenSSL will do
all necessary communication with the HSM behind the scenes.

For programs like proton that use OpenSSL, this could have been
realized in two ways:

  - OpenSSL ENGINE:   Introduced in OpenSSL 0.9.6 and deprecated in 3.0
  - OpenSSL PROVIDER: Introduced in OpenSSL 3.0 to replace ENGINE

While both are supported in recent OpenSSL versions, it's more future
proof to use the PROVIDER API, even if this comes at the cost of having
to add an #ifdef to the code.

This has been tested on Linux/x86_64 with softhsm and Linux/arm32 with
OP-TEE, both with v0.5 of https://github.com/latchset/pkcs11-provider.

As everything is loaded dynamically, we do not link against any
PKCS#11-related shared libraries. It's expected that PKCS#11 provider
will already be loaded via OPENSSL_CONF if it's to be used.