### PR TITLE
PROTON-2785: Fix pn_data_clear not clearing error

### DIFF
--- a/c/src/core/codec.c
+++ b/c/src/core/codec.c
@@ -431,6 +431,7 @@ void pn_data_clear(pn_data_t *data)
     data->current = 0;
     data->base_parent = 0;
     data->base_current = 0;
+    pn_error_clear(data->error);
     if (data->buf) pn_buffer_clear(data->buf);
   }
 }


### PR DESCRIPTION
We've also hit the bug of the Go library that is described in PROTON-2785. This bug happens when one large message is sent and another message with arbitrary size gets marshaled. 

Reason is that the large message does multiple calls with a too small message size to `pn_data_encode` which leads to the error `PN_OVERFLOW` to be set in `pn_encoder_encode` on the data field until a large enough buffer is provided. As the `pn_message_t` is reused the error hits the second message encoding.

Relevant Go code:
https://github.com/apache/qpid-proton/blob/9fdc19c53ea92254d9f4d5f7ff1809ed6f953503/go/pkg/amqp/message.go#L378-L393

Relevant C code:
https://github.com/apache/qpid-proton/blob/9fdc19c53ea92254d9f4d5f7ff1809ed6f953503/c/src/core/encoder.c#L395-L409

This PR adds clearing the error field when `pn_data_clear` is called. According to the docs "A cleared pn_data_t object is equivalent to a newly constructed one.", so that would match this fix.

Other possible way would be to not set those `PN_OVERFLOW` errors on `pn_data_t` at all. I don't have enough overview of the internals to know if this makes sense or not. Especially, as there are a few other errors that are set on `pn_data_t` too which might cause similar issues.