### PR TITLE
PROTON-2848: [Python] Add py.typed marker to package for PEP 561

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -62,6 +62,7 @@ set(py_dist_files
     docs/index.rst
     docs/overview.rst
     docs/tutorial.rst
+    proton/py.typed
     )
 
 # Sphinx documentation

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -57,3 +57,6 @@ py-modules = ["cproton"]
 
 [tool.setuptools.dynamic]
 version = {file = "VERSION.txt"}
+
+[tool.setuptools.package-data]
+"proton" = ["py.typed"]


### PR DESCRIPTION
As far as I can tell, the python binding is properly typed. In order to allow using tools like mypy, it is required to have a py.typed file in the package (see PEP 561).