### PR TITLE
PROTON-2790: finer grained session flow control

### DIFF
--- a/c/docs/buffering.md
+++ b/c/docs/buffering.md
@@ -16,7 +16,7 @@ gets a @ref PN_LINK_FLOW event.
 
 The AMQP protocol allows peers to exchange session limits so they can predict
 their buffering requirements for incoming data (
-`pn_session_set_incoming_capacity()` and
+`pn_session_set_incoming_incoming_window_and_lwm()` and
 `pn_session_set_outgoing_window()`). Proton will not exceed those limits when
 sending to or receiving from the peer. However proton does *not* limit the
 amount of data buffered in local memory at the request of the application.  It

--- a/c/include/proton/transport.h
+++ b/c/include/proton/transport.h
@@ -432,10 +432,16 @@ PN_EXTERN uint32_t pn_transport_get_max_frame(pn_transport_t *transport);
 /**
  * Set the maximum frame size of a transport.
  *
+ * The negotiated frame size cannot change over the life of the transport.  After
+ * the transport has started sending AMQP frames to the peer, this function call
+ * has no effect.  Typically, the maximum frame size is set when the transport is
+ * created.
+ *
  * @param[in] transport a transport object
  * @param[in] size the maximum frame size for the transport object
  *
- * @internal XXX Deprecate when moved to connection
+ * @internal XXX Deprecate when moved to connection, note size can change on
+ * reconnect with new transport, consider status return on new API.
  */
 PN_EXTERN void pn_transport_set_max_frame(pn_transport_t *transport, uint32_t size);
 

--- a/c/include/proton/types.h
+++ b/c/include/proton/types.h
@@ -142,6 +142,13 @@ extern "C" {
 typedef uint32_t  pn_sequence_t;
 
 /**
+ * A count or limit of AMQP transfer frames.
+ *
+ * @ingroup api_types
+ */
+typedef uint32_t pn_frame_count_t;
+
+/**
  * A span of time in milliseconds.
  *
  * @ingroup api_types

--- a/c/src/core/engine-internal.h
+++ b/c/src/core/engine-internal.h
@@ -272,6 +272,11 @@ struct pn_session_t {
   pn_sequence_t incoming_deliveries;
   pn_sequence_t outgoing_deliveries;
   pn_sequence_t outgoing_window;
+  pn_frame_count_t incoming_window_lwm;
+  pn_frame_count_t max_incoming_window;
+  bool check_flow;
+  bool need_flow;
+  bool lwm_default;
 };
 
 struct pn_terminus_t {
@@ -395,6 +400,7 @@ void pn_ep_incref(pn_endpoint_t *endpoint);
 void pn_ep_decref(pn_endpoint_t *endpoint);
 
 ssize_t pni_transport_grow_capacity(pn_transport_t *transport, size_t n);
+  void pni_session_update_incoming_lwm(pn_session_t *ssn);
 
 #if __cplusplus
 }

--- a/c/tests/connection_driver_test.cpp
+++ b/c/tests/connection_driver_test.cpp
@@ -444,11 +444,11 @@ TEST_CASE("driver_session_flow_control") {
   }
 
   /* Capacity smaller than frame size is an error */
-  set_capacity_and_max_frame(1234, 12345, d, "foo");
+  set_capacity_and_max_frame(1233, 1234, d, "foo");
   CHECK_THAT(
       *client.last_condition,
       cond_matches("amqp:internal-error",
-                   "session capacity 1234 is less than frame size 12345"));
+                   "session capacity 1233 is less than frame size 1234"));
   free(buf.start);
 }
 


### PR DESCRIPTION
This patch provides an implementation of PROTON-2790 to provide finer grained management of session based flow control over input buffering.

In addition to limiting the absolute size of the inbound buffered data, this patch allows the application to choose how soon the peer is notified of new available space (the existing method waits until the capacity is fully used up which can result in needless transmission stalls).  This is particularly useful for large messages or streaming messages which are broken into multiple AMQP transfer frames.

The patch also allows the sending peer the ability to query what is the most recently communicated window size (pn_session_remote_incoming_window).

This patch also prevents anti-patterns that are possible in the current session flow model that can lead to PN_TRANSPORT_ERROR termination of the connection.  Namely the transport maximum frame size and the session incoming window will not be allowed to change at arbitrary times (which can otherwise allow the incoming window to become negative).  Session "capacity" can still be changed at any time to preserve existing usage for applications that may rely on this API (now deprecated). 

This patch strives to send the least number of additional AMQP frames on the wire to achieve the intended result.  No extra frames are sent if link credit flow frames are already pending on the session or if the incoming window is currently at or above the low water mark.

The existing session flow model based on byte capacity is marked as deprecated in favor of this alternative flow control model.  The code is structured to allow the easy removal of the "capacity" model in future.