### PR TITLE
Rotate02

### DIFF
--- a/c/src/core/buffer.c
+++ b/c/src/core/buffer.c
@@ -236,7 +236,10 @@ static void pn_buffer_rotate (pn_buffer_t *buf, size_t sz) {
 
 static inline int pn_buffer_defrag(pn_buffer_t *buf)
 {
-  pn_buffer_rotate(buf, buf->start);
+  if (pni_buffer_wrapped(buf))
+    pn_buffer_rotate(buf, buf->start);
+  else
+    memmove(buf->bytes, buf->bytes + buf->start, buf->size);
   buf->start = 0;
   return 0;
 }

--- a/c/src/core/engine-internal.h
+++ b/c/src/core/engine-internal.h
@@ -361,6 +361,7 @@ struct pn_delivery_t {
   pn_delivery_state_t state;
   pn_buffer_t *bytes;
   pn_record_t *context;
+  uint32_t bytes_offset; // start of content remaining to send on transport
   bool updated;
   bool settled; // tracks whether we're in the unsettled list or not
   bool work;


### PR DESCRIPTION
the first commit does fewer buffer defrag/rotates in the case of outgoing deliveries.

the second takes advantage of code of first to promote more fairness in scheduling

third makes many calls to buffer defrag more performant.  The first commit ensures that an outgoing delivery is never wrapped, so this optimization always applies.  The special case of cj-sender runs > 10x faster, but streaming messages should in aggregate enjoy a performance boost or reduced cpu load.