### PR TITLE
PROTON-2531: Use surrogateescape when reading delivery tag

### DIFF
--- a/python/cproton.py
+++ b/python/cproton.py
@@ -200,16 +200,16 @@ def bytes2pybytes(b):
     return bytes(ffi.buffer(b.start, b.size))
 
 
-def bytes2string(b, encoding='utf8'):
-    return ffi.unpack(b.start, b.size).decode(encoding)
+def bytes2string(b, encoding='utf8', errors='strict'):
+    return ffi.unpack(b.start, b.size).decode(encoding, errors)
 
 
-def py2bytes(py, encoding='utf8'):
+def py2bytes(py):
     if isinstance(py, (bytes, bytearray, memoryview)):
         s = ffi.from_buffer(py)
         return len(s), s
     elif isinstance(py, str):
-        s = ffi.from_buffer(py.encode(encoding))
+        s = ffi.from_buffer(py.encode('utf8'))
         return len(s), s
 
 
@@ -487,7 +487,7 @@ def pn_data_get_symbol(data):
 
 
 def pn_delivery_tag(delivery):
-    return bytes2string(lib.pn_delivery_tag(delivery), 'latin-1')
+    return bytes2string(lib.pn_delivery_tag(delivery), errors='surrogateescape')
 
 
 def pn_connection_get_container(connection):
@@ -543,7 +543,7 @@ def pn_receiver(session, name):
 
 
 def pn_delivery(link, tag):
-    return lib.pn_delivery(link, py2bytes(tag, 'latin-1'))
+    return lib.pn_delivery(link, py2bytes(tag))
 
 
 def pn_link_name(link):

--- a/python/cproton.py
+++ b/python/cproton.py
@@ -204,12 +204,12 @@ def bytes2string(b, encoding='utf8'):
     return ffi.unpack(b.start, b.size).decode(encoding)
 
 
-def py2bytes(py):
+def py2bytes(py, encoding='utf8'):
     if isinstance(py, (bytes, bytearray, memoryview)):
         s = ffi.from_buffer(py)
         return len(s), s
     elif isinstance(py, str):
-        s = ffi.from_buffer(py.encode('utf8'))
+        s = ffi.from_buffer(py.encode(encoding))
         return len(s), s
 
 
@@ -487,7 +487,7 @@ def pn_data_get_symbol(data):
 
 
 def pn_delivery_tag(delivery):
-    return bytes2string(lib.pn_delivery_tag(delivery))
+    return bytes2string(lib.pn_delivery_tag(delivery), 'latin-1')
 
 
 def pn_connection_get_container(connection):
@@ -543,7 +543,7 @@ def pn_receiver(session, name):
 
 
 def pn_delivery(link, tag):
-    return lib.pn_delivery(link, py2bytes(tag))
+    return lib.pn_delivery(link, py2bytes(tag, 'latin-1'))
 
 
 def pn_link_name(link):

--- a/python/tests/proton_tests/engine.py
+++ b/python/tests/proton_tests/engine.py
@@ -980,11 +980,13 @@ class TransferTest(Test):
 
     def test_delivery_tag_bytes(self):
         test_tags = [
-            (bytes([0, 0, 0, 128]), '\x00\x00\x00\x80'),
+            (bytes([0, 0, 0, 128]), '\x00\x00\x00\udc80'),
             ('tag', 'tag'),
             (b'tag', 'tag'),
-            (bytearray([1, 2, 32, 254, 255]), '\x01\x02 \xfe\xff'),
-            (b'\xff'+(29*b' ')+b'\xff\x00', 'ÿ                             ÿ\x00')
+            (bytearray([1, 2, 32, 254, 255]), '\x01\x02 \udcfe\udcff'),
+            (b'\xff'+(29*b' ')+b'\xff\x00', '\udcff                             \udcff\x00'),
+            (chr(1024), chr(1024)),
+            (chr(1024) * 32, chr(1024) * 32)        # I think this should fail but it doesn't
         ]
 
         self.rcv.flow(len(test_tags))
@@ -1007,7 +1009,7 @@ class TransferTest(Test):
             rd.settle()
 
         try:
-            self.snd.delivery(chr(256))
+            self.snd.delivery('\udc80')
             assert False, "Expected UnicodeEncodeError"
         except UnicodeEncodeError:
             pass


### PR DESCRIPTION
Delivery tags are bytes 'on the wire' but strings in the Python interface.
Use Latin-1 codec when converting, so that all valid bytes values (0 - 255) are accepted and converted without changing the values.