### PR TITLE
Fix Qpid::Proton::DEFAULT_URI_PARSER for Ruby 3.4

### DIFF
--- a/ruby/lib/core/uri.rb
+++ b/ruby/lib/core/uri.rb
@@ -46,7 +46,12 @@ end
 module Qpid::Proton
   private
   # Make sure to allow empty hostnames, Ruby 2.0.0 does not.
-  DEFAULT_URI_PARSER = URI::RFC2396_Parser.new(:HOSTNAME => /(?:#{URI::PATTERN::HOSTNAME})|/)
+  DEFAULT_URI_PARSER =
+    if RUBY_VERSION >= '3.4'
+      URI::RFC2396_Parser.new(:HOSTNAME => /(?:#{URI::PATTERN::HOSTNAME})|/)
+    else
+      URI::Parser.new(:HOSTNAME => /(?:#{URI::PATTERN::HOSTNAME})|/)
+    end
 
   public
 

--- a/ruby/lib/core/uri.rb
+++ b/ruby/lib/core/uri.rb
@@ -45,8 +45,16 @@ end
 
 module Qpid::Proton
   private
-  # Make sure to allow empty hostnames, Ruby 2.0.0 does not.
-  DEFAULT_URI_PARSER = URI::Parser.new(:HOSTNAME => /(?:#{URI::PATTERN::HOSTNAME})|/)
+  # Make sure to allow empty hostnames
+  class CustomURIParser < URI::RFC3986_Parser
+    def parse(uri)
+      uri = super(uri)
+      uri.host = '' if uri.host.nil? || uri.host.empty?
+      uri
+    end
+  end
+
+  DEFAULT_URI_PARSER = CustomURIParser.new
 
   public
 

--- a/ruby/lib/core/uri.rb
+++ b/ruby/lib/core/uri.rb
@@ -45,16 +45,8 @@ end
 
 module Qpid::Proton
   private
-  # Make sure to allow empty hostnames
-  class CustomURIParser < URI::RFC3986_Parser
-    def parse(uri)
-      uri = super(uri)
-      uri.host = '' if uri.host.nil? || uri.host.empty?
-      uri
-    end
-  end
-
-  DEFAULT_URI_PARSER = CustomURIParser.new
+  # Make sure to allow empty hostnames, Ruby 2.0.0 does not.
+  DEFAULT_URI_PARSER = URI::RFC2396_Parser.new(:HOSTNAME => /(?:#{URI::PATTERN::HOSTNAME})|/)
 
   public
 


### PR DESCRIPTION
On Ruby 3.4 the DEFAULT_URI_PARSER is throwing an error:

```ruby
❯ DEFAULT_URI_PARSER = URI::Parser.new(:HOSTNAME => /(?:#{URI::PATTERN::HOSTNAME})|/)
'Class#new': wrong number of arguments (given 1, expected 0) (ArgumentError)
        from (irb):438:in '<main>'
```

This PR aims to replace the parser with a custom version that works well with Ruby 3.4