### PR TITLE
PROTON-2907: [ruby] Ruby Binding is broken for Ruby < 3.4 and URI gem >= 1

### DIFF
--- a/ruby/lib/core/uri.rb
+++ b/ruby/lib/core/uri.rb
@@ -47,7 +47,7 @@ module Qpid::Proton
   private
   # Make sure to allow empty hostnames, Ruby 2.0.0 does not.
   DEFAULT_URI_PARSER =
-    if RUBY_VERSION >= '3.4'
+    if defined?(URI::RFC3986_Parser) && URI::DEFAULT_PARSER.is_a?(URI::RFC3986_Parser)
       URI::RFC2396_Parser.new(:HOSTNAME => /(?:#{URI::PATTERN::HOSTNAME})|/)
     else
       URI::Parser.new(:HOSTNAME => /(?:#{URI::PATTERN::HOSTNAME})|/)


### PR DESCRIPTION
[JIRA](https://issues.apache.org/jira/browse/PROTON-2907)

Ruby binding/gem (v 0.40.0) is broken for projects using a recent URI gem version. For me it broke with ruby 3.3.6 and URI 1.0.3.

This fix replaces the ruby version check with a check on what the `URI::DEFAULT_PARSER` is. If it is `Rfc3986Parser`, we then explicitly use the other parser. Earlier ruby/URI versions do not have separate classes for parsers, it was just `Parser`. And that is why this is explicitly checking for the new one, versus checking if `URI::DEFAULT_PARSER` is `Rfc2396Parser`.

Note: The RUBY_VERSION check was added in this previous MR: https://github.com/apache/qpid-proton/pull/439