### PR TITLE
Add OpenSSL 4.x compat

### DIFF
--- a/c/src/ssl/openssl.c
+++ b/c/src/ssl/openssl.c
@@ -339,7 +339,7 @@ static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
       GENERAL_NAME *name = sk_GENERAL_NAME_value( sans, i );
       if (name->type == GEN_DNS) {
         ASN1_STRING *asn1 = name->d.dNSName;
-        if (asn1 && asn1->data && asn1->length) {
+        if (asn1 && ASN1_STRING_get0_data(asn1) && ASN1_STRING_length(asn1) > 0){
           unsigned char *str;
           int len = ASN1_STRING_to_UTF8( &str, asn1 );
           if (len >= 0) {
@@ -354,11 +354,11 @@ static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
   }
 
   /* if no general names match, try the CommonName from the subject */
-  X509_NAME *name = X509_get_subject_name(cert);
+  const X509_NAME *name = X509_get_subject_name(cert);
   int i = -1;
   while (!matched && (i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0) {
-    X509_NAME_ENTRY *ne = X509_NAME_get_entry(name, i);
-    ASN1_STRING *name_asn1 = X509_NAME_ENTRY_get_data(ne);
+    const X509_NAME_ENTRY *ne = X509_NAME_get_entry(name, i);
+    const ASN1_STRING *name_asn1 = X509_NAME_ENTRY_get_data(ne);
     if (name_asn1) {
       unsigned char *str;
       int len = ASN1_STRING_to_UTF8( &str, name_asn1);
@@ -1558,7 +1558,7 @@ const char* pn_ssl_get_remote_subject(pn_ssl_t *ssl0)
   if (!ssl->subject) {
     X509 *cert = get_peer_certificate(ssl);
     if (!cert) return NULL;
-    X509_NAME *subject = X509_get_subject_name(cert);
+    const X509_NAME *subject = X509_get_subject_name(cert);
     if (!subject) return NULL;
 
     BIO *out = BIO_new(BIO_s_mem());
@@ -1677,17 +1677,17 @@ const char* pn_ssl_get_remote_subject_subfield(pn_ssl_t *ssl0, pn_ssl_cert_subje
   X509 *cert = get_peer_certificate(ssl);
   if (!cert) return NULL;
 
-  X509_NAME *subject_name = X509_get_subject_name(cert);
+  const X509_NAME *subject_name = X509_get_subject_name(cert);
 
   // TODO (gmurthy) - A server side cert subject field can have more than one common name like this - Subject: CN=www.domain1.com, CN=www.domain2.com, see https://bugzilla.mozilla.org/show_bug.cgi?id=380656
   // For now, we will only return the first common name if there is more than one common name in the cert
   int index = X509_NAME_get_index_by_NID(subject_name, openssl_field, -1);
 
   if (index > -1) {
-    X509_NAME_ENTRY *ne = X509_NAME_get_entry(subject_name, index);
+    const X509_NAME_ENTRY *ne = X509_NAME_get_entry(subject_name, index);
     if(ne) {
-      ASN1_STRING *name_asn1 = X509_NAME_ENTRY_get_data(ne);
-      return (char *) name_asn1->data;
+      const ASN1_STRING *name_asn1 = X509_NAME_ENTRY_get_data(ne);
+      return (const char *)ASN1_STRING_get0_data(name_asn1);
     }
   }
 


### PR DESCRIPTION
Hi. I maintain the qpid-proton package in Debian.
This patch fixed this Debian bug for me:
https://bugs.debian.org/1138394

while retaining compatibility with older OpenSSL 3 (I tried building with both, and it built in both cases).

I hope this helps.