### PR TITLE
PROTON-2938: WIN: Fix Heap Corruption Issue

### DIFF
--- a/c/src/proactor/win_iocp.cpp
+++ b/c/src/proactor/win_iocp.cpp
@@ -932,7 +932,8 @@ ssize_t pni_iocp_begin_write(iocpdesc_t *iocpd, const void *buf, size_t len, boo
   }
   if (iocpd->write_closed) {
     assert(pn_error_code(iocpd->error));
-    pn_error_copy(error, iocpd->error);
+    if (error != iocpd->error)
+      pn_error_copy(error, iocpd->error);
     if (iocpd->iocp->iocp_trace)
       iocp_log("write error: %s\n", pn_error_text(error));
     return SOCKET_ERROR;
@@ -1122,10 +1123,12 @@ ssize_t pni_iocp_recv(iocpdesc_t *iocpd, void *buf, size_t size, bool *would_blo
     return SOCKET_ERROR;
   }
   if (iocpd->read_closed) {
-    if (pn_error_code(iocpd->error))
-      pn_error_copy(error, iocpd->error);
-    else
+    if (pn_error_code(iocpd->error)) {
+      if (error != iocpd->error)
+        pn_error_copy(error, iocpd->error);
+    } else {
       set_iocp_error_status(error, PN_ERR, WSAENOTCONN);
+    }
     return SOCKET_ERROR;
   }
 


### PR DESCRIPTION
Found using `gflags`.  Tried a number of fixes, this seems to be the one that works.  With this fix, I am able to use `gflags` to debug on windows.

```
 	ucrtbased.dll!00007ffb465b1691()	Unknown
>	qpid-proton-cored.dll!pn_strdup(const char * src) Line 122	C
 	qpid-proton-cored.dll!pn_error_set(pn_error_t * error, int code, const char * text) Line 77	C
 	qpid-proton-cored.dll!pn_error_copy(pn_error_t * error, pn_error_t * src) Line 119	C
 	qpid-proton-proactord.dll!pn_experimental::pni_iocp_recv(pn_experimental::iocpdesc_t * iocpd, void * buf, unsigned __int64 size, bool * would_block, pn_error_t * error) Line 1126	C++
 	qpid-proton-proactord.dll!pconnection_process(pconnection_t * pc, pn_experimental::iocp_result_t * result, bool topup) Line 2380	C++
 	qpid-proton-proactord.dll!psocket_process(psocket_t * ps, pn_experimental::iocp_result_t * result, reaper * rpr) Line 2500	C++
 	qpid-proton-proactord.dll!proactor_completion_loop(pn_proactor_t * p, bool can_block) Line 2541	C++
 	qpid-proton-proactord.dll!pn_proactor_wait(pn_proactor_t * p) Line 2566	C++
 	qpid-proton-cppd.dll!proton::container::impl::thread() Line 770	C++
 	qpid-proton-cppd.dll!proton::container::impl::run(int threads) Line 821	C++
 	qpid-proton-cppd.dll!proton::container::run() Line 92	C++
 	[downstream application frame]
	
	
	-		dest	0x00000279dc2b0fa0 <Error reading characters of string.>	char *
			<Unable to read memory>	char
-		src	0x00000279dc2b0fa0 <Error reading characters of string.>	const char *
			<Unable to read memory>	const char